### PR TITLE
feat: Update map view to display a beautiful marker

### DIFF
--- a/dev-client/App.tsx
+++ b/dev-client/App.tsx
@@ -5,34 +5,58 @@
  * @format
  */
 
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, {useEffect} from 'react';
+import {PermissionsAndroid, StyleSheet, View} from 'react-native';
 
 import Mapbox from '@rnmapbox/maps';
-import { Button, NativeBaseProvider, Text } from 'native-base';
-import { theme } from './theme';
+import {Button, NativeBaseProvider, Text} from 'native-base';
+import {theme} from './theme';
 import LoginView from './components/Login';
-
-
+import SiteMap from './components/SiteMap';
+import {DisplaySite} from './datatypes/sites';
 
 Mapbox.setAccessToken(
   'pk.eyJ1Ijoic2hyb3V4bSIsImEiOiJjbGY4bW8wbGEwbDJnM3FsN3I1ZzBqd2kzIn0.2Alc4o911ooGEtnObLpOUQ',
 );
 
-
 function App(): JSX.Element {
+  useEffect(() => {
+    const locationGranted = PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+    )
+      .then(granted => {
+        if (granted == PermissionsAndroid.RESULTS.GRANTED) {
+          console.log('You can use the camera');
+        } else {
+          // TODO: What to do if rejected?
+          console.error('You cannot use the camera');
+        }
+      })
+      .catch(err => {
+        // TODO: What to do on error?
+        console.error(err);
+      });
+  });
+
   return (
     <NativeBaseProvider theme={theme}>
-      <View style={[styles.container, {
-        justifyContent: "center"
-      }]}>
-        { /* <Mapbox.MapView style={styles.map} /> */}
-        <LoginView />
+      <View
+        style={[
+          styles.container,
+          {
+            justifyContent: 'center',
+          },
+        ]}>
+        <SiteMap
+          sites={[new DisplaySite(0.1, 0.1, 'TEST SITE 1')]}
+          center={[0, 0]}
+        />
+        {/* <LoginView /> */}
       </View>
     </NativeBaseProvider>
   );
 }
 
-const styles = StyleSheet.create({ map: { flex: 1 }, container: { flex: 1 } });
+const styles = StyleSheet.create({map: {flex: 1}, container: {flex: 1}});
 
 export default App;

--- a/dev-client/App.tsx
+++ b/dev-client/App.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, {useEffect} from 'react';
-import {PermissionsAndroid, StyleSheet, View} from 'react-native';
+import {PermissionsAndroid, Platform, StyleSheet, View} from 'react-native';
 
 import Mapbox from '@rnmapbox/maps';
 import {Button, NativeBaseProvider, Text} from 'native-base';
@@ -21,6 +21,10 @@ Mapbox.setAccessToken(
 
 function App(): JSX.Element {
   useEffect(() => {
+    if (Platform.OS !== 'android') {
+      // only need to request location permissions explicitly on Android
+      return;
+    }
     const locationGranted = PermissionsAndroid.request(
       PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
     )
@@ -48,7 +52,10 @@ function App(): JSX.Element {
           },
         ]}>
         <SiteMap
-          sites={[new DisplaySite(0.1, 0.1, 'TEST SITE 1')]}
+          sites={[
+            {lat: 0.0, lon: 0.3, name: 'TEST SITE 1'},
+            {lat: 0.1, lon: 0.5, name: 'TEST SITE 2'},
+          ]}
           center={[0, 0]}
         />
         {/* <LoginView /> */}

--- a/dev-client/__tests__/SitesMap-test.tsx
+++ b/dev-client/__tests__/SitesMap-test.tsx
@@ -1,0 +1,27 @@
+import 'react-native';
+import React from 'react';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+import SiteMap from '../components/SiteMap';
+
+const exampleSites = [
+    new DisplaySite({
+        lat: 0,
+        lon: 0,
+        name: "TEST SITE 1"
+    }),
+    new DisplaySite({
+        lat: 0.0001,
+        lon: 0.0001,
+        name: "TEST SITE 2"
+    })
+];
+
+const exampleSite = exampleSites[0];
+
+it('displays sites', () => {
+    const component = renderer.create(<SiteMap sites={exampleSites} center={[0, 0]} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/dev-client/android/app/build.gradle
+++ b/dev-client/android/app/build.gradle
@@ -170,3 +170,13 @@ dependencies {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+
+// NOTE: This is to add vector icons to our app
+// We can add more here if we ever needed to, but as we are using the Material UI, probably won't need to
+// See https://github.com/oblador/react-native-vector-icons#android
+// REVIEW: Will need to do the same process with iOS
+project.ext.vectoricons = [
+    iconFontNames: [ 'MaterialIcons.ttf' ] // Name of the font files you want to copy
+]
+
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"

--- a/dev-client/components/Login.tsx
+++ b/dev-client/components/Login.tsx
@@ -1,5 +1,4 @@
-import { Button, VStack } from "native-base";
-
+import {Button, VStack} from 'native-base';
 
 export default function LoginView(): JSX.Element {
   return (
@@ -8,5 +7,5 @@ export default function LoginView(): JSX.Element {
         Login with Google
       </Button>
     </VStack>
-  )
+  );
 }

--- a/dev-client/components/SiteMap.tsx
+++ b/dev-client/components/SiteMap.tsx
@@ -1,0 +1,47 @@
+import Mapbox, {Camera, MarkerView, UserLocation} from '@rnmapbox/maps';
+import React, {useEffect, useRef} from 'react';
+import {type DisplaySite} from '../datatypes/sites';
+import {type Position} from '@rnmapbox/maps/lib/typescript/types/Position';
+import {PermissionsAndroid} from 'react-native';
+import {IconButton, Icon} from 'native-base';
+// TODO: This vector icons module appears to be missing types
+import VIcon from 'react-native-vector-icons/MaterialIcons';
+
+type SiteMapProps = {
+  sites: DisplaySite[];
+  center: Position;
+};
+
+// REVIEW: This is a bad name, any suggestions?
+export default function SiteMap({sites, center}: SiteMapProps): JSX.Element {
+  const camera = useRef<Camera>(null);
+
+  useEffect(() => {
+    camera.current?.setCamera({
+      centerCoordinate: center,
+    });
+  }, [center]);
+
+  return (
+    <Mapbox.MapView
+      style={{
+        flex: 1,
+      }}>
+      <Camera ref={camera} />
+      <UserLocation />
+      {sites.map(site => {
+        return (
+          <MarkerView coordinate={[site.lon, site.lat]} key={site.key}>
+            <IconButton
+              icon={<Icon as={VIcon} name="location-on" />}
+              size="sm"
+              _icon={{
+                color: 'secondary.main',
+              }}
+            />
+          </MarkerView>
+        );
+      })}
+    </Mapbox.MapView>
+  );
+}

--- a/dev-client/components/SiteMap.tsx
+++ b/dev-client/components/SiteMap.tsx
@@ -1,8 +1,7 @@
 import Mapbox, {Camera, MarkerView, UserLocation} from '@rnmapbox/maps';
-import React, {useEffect, useRef} from 'react';
+import React, {memo, useEffect, useRef} from 'react';
 import {type DisplaySite} from '../datatypes/sites';
 import {type Position} from '@rnmapbox/maps/lib/typescript/types/Position';
-import {PermissionsAndroid} from 'react-native';
 import {IconButton, Icon} from 'native-base';
 // TODO: This vector icons module appears to be missing types
 import VIcon from 'react-native-vector-icons/MaterialIcons';
@@ -12,8 +11,7 @@ type SiteMapProps = {
   center: Position;
 };
 
-// REVIEW: This is a bad name, any suggestions?
-export default function SiteMap({sites, center}: SiteMapProps): JSX.Element {
+const SiteMap = memo(({sites, center}: SiteMapProps): JSX.Element => {
   const camera = useRef<Camera>(null);
 
   useEffect(() => {
@@ -22,26 +20,32 @@ export default function SiteMap({sites, center}: SiteMapProps): JSX.Element {
     });
   }, [center]);
 
+  let markers = sites.map(site => {
+    return (
+      <MarkerView
+        coordinate={[site.lon, site.lat]}
+        key={[site.lon, site.lat, site.name].join('-')}
+        allowOverlap={true}>
+        <IconButton
+          icon={<Icon as={VIcon} name="location-on" />}
+          size="sm"
+          _icon={{
+            color: 'secondary.main',
+          }}></IconButton>
+      </MarkerView>
+    );
+  });
+
   return (
     <Mapbox.MapView
       style={{
         flex: 1,
       }}>
-      <Camera ref={camera} />
+      <Camera ref={camera} centerCoordinate={[0, 0]} />
       <UserLocation />
-      {sites.map(site => {
-        return (
-          <MarkerView coordinate={[site.lon, site.lat]} key={site.key}>
-            <IconButton
-              icon={<Icon as={VIcon} name="location-on" />}
-              size="sm"
-              _icon={{
-                color: 'secondary.main',
-              }}
-            />
-          </MarkerView>
-        );
-      })}
+      {markers}
     </Mapbox.MapView>
   );
-}
+});
+
+export default SiteMap;

--- a/dev-client/datatypes/sites.ts
+++ b/dev-client/datatypes/sites.ts
@@ -1,17 +1,5 @@
-export type Point2D = [number, number];
-
-export class DisplaySite {
+export type DisplaySite = {
     lat: number;
     lon: number;
     name: string;
-
-    constructor(lat: number, lon: number, name: string) {
-        this.lat = lat;
-        this.lon = lon;
-        this.name = name;
-    }
-
-    get key() {
-        return `{this.lat},{this.lon},{this.name}`;
-    }
 }

--- a/dev-client/datatypes/sites.ts
+++ b/dev-client/datatypes/sites.ts
@@ -1,0 +1,17 @@
+export type Point2D = [number, number];
+
+export class DisplaySite {
+    lat: number;
+    lon: number;
+    name: string;
+
+    constructor(lat: number, lon: number, name: string) {
+        this.lat = lat;
+        this.lon = lon;
+        this.name = name;
+    }
+
+    get key() {
+        return `{this.lat},{this.lon},{this.name}`;
+    }
+}

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -13,7 +13,8 @@
         "react": "18.2.0",
         "react-native": "0.71.6",
         "react-native-safe-area-context": "^3.3.2",
-        "react-native-svg": "^12.1.1"
+        "react-native-svg": "^12.1.1",
+        "react-native-vector-icons": "^9.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -14650,6 +14651,54 @@
         "react-native": ">=0.50.0"
       }
     },
+    "node_modules/react-native-vector-icons": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
+      "integrity": "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-native/node_modules/@jest/types": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -27580,6 +27629,46 @@
       "requires": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3"
+      }
+    },
+    "react-native-vector-icons": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
+      "integrity": "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+        }
       }
     },
     "react-refresh": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -15,7 +15,8 @@
     "react": "18.2.0",
     "react-native": "0.71.6",
     "react-native-safe-area-context": "^3.3.2",
-    "react-native-svg": "^12.1.1"
+    "react-native-svg": "^12.1.1",
+    "react-native-vector-icons": "^9.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -35,6 +36,13 @@
     "typescript": "4.8.4"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "setupFilesAfterEnv": [
+      "@rnmapbox/maps/setup-jest"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(...|@rnmapbox))",
+      "jest-runner"
+    ]
   }
 }

--- a/dev-client/theme.ts
+++ b/dev-client/theme.ts
@@ -2,7 +2,10 @@ import { extendTheme } from "native-base";
 
 const newColorTheme = {
     primary: "#276749",
-    background: "#FFFFFF"
+    background: "#FFFFFF",
+    secondary: {
+        "main": "#C05621"
+    }
 };
 
 export const theme = extendTheme({ colors: newColorTheme});


### PR DESCRIPTION
## Description

This is a bit of a messy commit, as I was trying out a bunch of new libraries to try and get this to work. The main changes are:

- Moved the map component into it's own separate component
- Added a vector icon library to display icons that match the mockups
- Tried doing some tests, but I think we need to install some coco pods through xcode or something. I will create a chore task and try and get someone to do this.
- Ran prettier on everything, so there's a lot of noise from just styling edits
- Displayed the user location on the map, which requires asking the user for permission on newer versions of Android.

<img src="https://github.com/techmatters/terraso-mobile-client/assets/18663493/ea3614c9-9204-4328-8bda-3fa04b6bd98f" width=200px>

I started working on this issue because I realized that the login for mobile is more difficult than I anticipated (see #44 for details). It would be nice to have some mockups implemented for our demo next week so I decided to focus on building out the frontend a bit more. My idea is to mock out the backend calls to start off with. This will also give us the benefit of being able to use the work that's being done on the GraphQL client when it's ready.

### Related Issues

Related to #46 #48

## Followup issues

- [x] Issue to add information on how to find material IO vector icons to the README #56
- [x] Change MarkerView to a better solution that is automatically clustered: https://github.com/rnmapbox/maps/blob/main/docs/Annotations.md #57
- [x] Set up iOS to use react-native-vector-icons as well