### PR TITLE
chore: add buildcache to iOS build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v3
 
+      - uses: mikehardy/buildcache-action@v2
+
       - uses: actions/setup-node@v3
         with:
           node-version: '18'


### PR DESCRIPTION
## Description
Add [buildcache](https://github.com/marketplace/actions/buildcache-action) to the ios build step
```
  - uses: mikehardy/buildcache-action@v2
```