### PR TITLE
chore: move gitignore to top level of repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,8 @@ yarn-error.log
 *.jsbundle
 
 # Ruby / CocoaPods
-/ios/Pods/
-/vendor/bundle/
+dev-client/ios/Pods/
+dev-client/vendor/bundle/
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*


### PR DESCRIPTION
## Description
Move gitignore to top level of repository. Avoids .DS_Store files in root showing up in repo.