### PR TITLE
fix: Update metro config

### DIFF
--- a/dev-client/metro.config.js
+++ b/dev-client/metro.config.js
@@ -1,17 +1,11 @@
-/**
- * Metro configuration for React Native
- * https://github.com/facebook/react-native
- *
- * @format
- */
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
-module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: true,
-      },
-    }),
-  },
-};
+/**
+ * Metro configuration
+ * https://facebook.github.io/metro/docs/configuration
+ *
+ * @type {import('metro-config').MetroConfig}
+ */
+const config = {};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), config);

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "DevClient",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native/metro-config": "^0.72.6",
         "@react-navigation/material-top-tabs": "^6.6.2",
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
@@ -4586,6 +4587,17 @@
       "version": "0.72.1",
       "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.72.1.tgz",
       "integrity": "sha512-cRPZh2rBswFnGt5X5EUEPs0r+pAsXxYsifv/fgy9ZLQokuT52bPH+9xjDR+7TafRua5CttGW83wP4TntRcWNDA=="
+    },
+    "node_modules/@react-native/metro-config": {
+      "version": "0.72.6",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.72.6.tgz",
+      "integrity": "sha512-hkV0okTi/N/ui1PF4ZgxPV9zajHkxuu+arpQwk8rY+QPZgGM8SIAN5tf68DWJTbPCfAiZLFoW1TgMNbvKrSY1A==",
+      "dependencies": {
+        "@react-native/js-polyfills": "^0.72.1",
+        "metro-config": "0.76.5",
+        "metro-react-native-babel-transformer": "0.76.5",
+        "metro-runtime": "0.76.5"
+      }
     },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.72.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -11,6 +11,7 @@
     "check-ts": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-native/metro-config": "^0.72.6",
     "@react-navigation/material-top-tabs": "^6.6.2",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",

--- a/dev-client/src/screens/AppScaffold.tsx
+++ b/dev-client/src/screens/AppScaffold.tsx
@@ -17,7 +17,7 @@ type ScreenMapArgs = [ScreenRoutes, ScreenConfig<keyof RootStackParamList>];
 const previews = fetchProjects();
 const sites = SITE_DISPLAYS;
 
-function mapScreens(t: TFunction<'translation', undefined, 'translation'>) {
+function mapScreens(t: TFunction) {
   return ([name, config]: ScreenMapArgs) => {
     // TODO: initialParams are stubs, a stopgap for while we are not connected to the backend
     // This setup should be changed when we get to connecting the backend

--- a/dev-client/src/screens/index.ts
+++ b/dev-client/src/screens/index.ts
@@ -29,7 +29,7 @@ export type ScreenConfig<RouteName extends RoutePath> = {
   hideBack?: boolean;
   paramTitle?: (args: {
     route: RouteProp<RootStackParamList, RouteName>;
-    t: TFunction<'translation', null, 'translation'>;
+    t: TFunction;
   }) => string;
 };
 


### PR DESCRIPTION
I was getting the following warning when I ran `npm run start`:

warn From React Native 0.72, your metro.config.js file should extend'@react-native/metro-config'.

Metro would then crash. I obliged, and this commit is the result. Seems to fix things.