### PR TITLE
fix: automatically include React Native fonts

### DIFF
--- a/dev-client/ios/Podfile.lock
+++ b/dev-client/ios/Podfile.lock
@@ -505,6 +505,8 @@ PODS:
     - React-RCTImage
   - RNSVG (13.10.0):
     - React-Core
+  - RNVectorIcons (10.0.0):
+    - React-Core
   - SocketRocket (0.6.1)
   - Turf (2.6.1)
   - Yoga (1.14.0)
@@ -562,6 +564,7 @@ DEPENDENCIES:
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
+  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -678,6 +681,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
+  RNVectorIcons:
+    :path: "../node_modules/react-native-vector-icons"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -706,7 +711,7 @@ SPEC CHECKSUMS:
   React-Core: aaacca67f9ca54f142827e67f44bfbd815875eb6
   React-CoreModules: 32fab1d62416849a3b6dac6feff9d54e5ddc2d1e
   React-cxxreact: 37765b4975541105b2a3322a4b473417c158c869
-  React-debug: eb1dca87bbce48cb83e2e3350ec8206cd33dc4fb
+  React-debug: 06d4dc090f816a08434a81379e494e70cdc68e3e
   React-hermes: 935ae71fb3d7654e947beba8498835cd5e479707
   React-jsi: ec628dc7a15ffea969f237b0ea6d2fde212b19dd
   React-jsiexecutor: 59d1eb03af7d30b7d66589c410f13151271e8006
@@ -718,7 +723,7 @@ SPEC CHECKSUMS:
   react-native-mmkv-storage: cfb6854594cfdc5f7383a9e464bb025417d1721c
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
-  React-NativeModulesApple: 96ec8f7056d5467e696006743d40f64c2458973b
+  React-NativeModulesApple: 729f41679fd029a6de5f8ab7cd97742dc3f3e20d
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: fe7005136b58f58871cab2f70732343b6e330d30
@@ -732,14 +737,15 @@ SPEC CHECKSUMS:
   React-RCTVibration: ea3a68a49873a54ced927c90923fc6932baf344a
   React-rncore: 9672a017af4a7da7495d911f0b690cbcae9dd18d
   React-runtimeexecutor: 369ae9bb3f83b65201c0c8f7d50b72280b5a1dbc
-  React-runtimescheduler: e1a9c6406318e2cf2af49a96cfbc324a1b5b74dc
-  React-utils: fa918920e89b14bfdf260e45ee7a916de7cf8435
-  ReactCommon: e5382cf0d3a8ece592bc16f3b6818de98951087e
+  React-runtimescheduler: 4f00cf28a055b1015a66ed9c1b32d33a545235df
+  React-utils: 6bdaf17616adf4f6a6134f731dbc5b0f18fda92d
+  ReactCommon: 2acc4d3c29790c60c14db93d9370626f79d76373
   RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
   rnmapbox-maps: 6f638ec002aa6e906a6f766d69cd45f968d98e64
   RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1
   RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   RNSVG: 80584470ff1ffc7994923ea135a3e5ad825546b9
+  RNVectorIcons: 8b5bb0fa61d54cd2020af4f24a51841ce365c7e9
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce

--- a/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
+++ b/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		C61185A1D49303BBF1FC31E9 /* Pods_Terraso_LandPKS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B11C48E3D5248AFAB632513C /* Pods_Terraso_LandPKS.framework */; };
 		DA26A17B2A38EDC8003248A1 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = A77A52EE26C701884FDC0B0C /* Mapbox */; };
 		DA26A17C2A38EDC8003248A1 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = 5DA4D00C047877E1CDF04500 /* Mapbox */; };
-		DA26A1842A38F932003248A1 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DA26A1822A38F932003248A1 /* MaterialCommunityIcons.ttf */; };
-		DA26A1852A38F932003248A1 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DA26A1832A38F932003248A1 /* MaterialIcons.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -278,9 +276,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DA26A1852A38F932003248A1 /* MaterialIcons.ttf in Resources */,
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
-				DA26A1842A38F932003248A1 /* MaterialCommunityIcons.ttf in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/dev-client/react-native.config.js
+++ b/dev-client/react-native.config.js
@@ -1,11 +1,4 @@
 module.exports = {
-  dependencies: {
-    'react-native-vector-icons': {
-      platforms: {
-        ios: null,
-      },
-    },
-  },
   project: {
     ios: {
       sourceDir: './ios',


### PR DESCRIPTION
## Description
No longer manually add fonts to build phase; have React Native Vector Icons automatically include them.

Note: this ends up bundling extra `ttf` files. Normally, we would specify just the fonts we want, but since this is temporary until the icons go in the Mapbox stylesheet.