### PR TITLE
fix: dont flicker login screen on startup when logged in

### DIFF
--- a/dev-client/src/config/index.ts
+++ b/dev-client/src/config/index.ts
@@ -13,8 +13,8 @@ const apiConfig = setAPIConfig({
   terrasoAPIURL: terrasoAPIURL,
   graphQLEndpoint: terrasoAPIURL + '/graphql',
   tokenStorage: {
-    getToken: async name => {
-      const value = await MMKV.getStringAsync(name);
+    getToken: name => {
+      const value = MMKV.getString(name);
       return value === null ? undefined : value;
     },
     setToken: (name, value) => MMKV.setStringAsync(name, value),

--- a/dev-client/src/screens/AppScaffold.tsx
+++ b/dev-client/src/screens/AppScaffold.tsx
@@ -124,7 +124,7 @@ export default function AppScaffold() {
 
   return (
     <RootStack.Navigator
-      initialRouteName={currentUser === null ? 'LOGIN' : 'HOME'}
+      initialRouteName={!hasToken ? 'LOGIN' : 'HOME'}
       screenOptions={defaultScreenOptions}>
       {screens}
     </RootStack.Navigator>

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -16,6 +16,9 @@ const STARTING_ZOOM_LEVEL = 5;
 
 const HomeView = () => {
   const [mapInitialized, setMapInitialized] = useState<Location | null>(null);
+  const currentUserID = useSelector(
+    state => state.account.currentUser?.data?.id,
+  );
   const sites = useSelector(state => state.site.sites);
   const currentUserLocation = useSelector(state => state.map.userLocation);
   const dispatch = useDispatch();
@@ -25,7 +28,7 @@ const HomeView = () => {
     // load sites on mount
     dispatch(fetchSitesForUser());
     dispatch(fetchProjectsForUser());
-  }, [dispatch]);
+  }, [dispatch, currentUserID]);
 
   const moveToPoint = useCallback(
     ({longitude, latitude}: Location['coords']) => {


### PR DESCRIPTION
## Description
The app previously would always load into the login screen, and then load the home screen if the user was already logged in. Now the app will directly load the home screen if the user is already logged in, without briefly showing the login screen.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
This fixes the bug in the description, but I am hoping it will also fix #257. I am not able to reproduce #257 on my devices so we will have to wait until we can push some new releases to find out.
