### PR TITLE
fix: make entire bottom nav button pressable

### DIFF
--- a/dev-client/src/components/common/Icons.tsx
+++ b/dev-client/src/components/common/Icons.tsx
@@ -6,6 +6,7 @@ import {
   Box,
 } from 'native-base';
 import React from 'react';
+import {Pressable} from 'react-native';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 export {default as MaterialCommunityIcons} from 'react-native-vector-icons/MaterialCommunityIcons';
 
@@ -32,14 +33,16 @@ export const IconButton = React.forwardRef(
       return icon;
     }
     return (
-      <Box p="1">
-        {icon}
-        <Center>
-          <Text color="primary.contrast" fontSize="xs">
-            {label}
-          </Text>
-        </Center>
-      </Box>
+      <Pressable onPress={props.onPress}>
+        <Box p="1">
+          {icon}
+          <Center>
+            <Text color="primary.contrast" fontSize="xs">
+              {label}
+            </Text>
+          </Center>
+        </Box>
+      </Pressable>
     );
   },
 );


### PR DESCRIPTION
## Description
Previously, only the small icon portion of the bottom navigation buttons was pressable, which made it easy to miss the button and need to press it several times to effect a page navigation. With this change the entire button, including label and a 1 padding box around the button is pressable, and I am not finding I need to tap several times anymore.
