### PR TITLE
feat: toggle map styles on home screen

### DIFF
--- a/dev-client/src/components/home/MapSearch.tsx
+++ b/dev-client/src/components/home/MapSearch.tsx
@@ -11,9 +11,10 @@ const {getSuggestions, retrieveFeature} = initMapSearch();
 type Props = {
   zoomTo?: (coords: Location['coords']) => void;
   zoomToUser?: () => void;
+  toggleMapLayer?: () => void;
 };
 
-export default function MapSearch({zoomTo, zoomToUser}: Props) {
+export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
   const {t} = useTranslation();
   const [query, setQuery] = useState('');
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
@@ -91,6 +92,7 @@ export default function MapSearch({zoomTo, zoomToUser}: Props) {
             }}
             bgColor="white"
             padding={2}
+            onPress={toggleMapLayer}
           />
           <IconButton
             name="my-location"

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -17,10 +17,12 @@ import {useTranslation} from 'react-i18next';
 import {useNavigation} from '../../screens/AppScaffold';
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/components/Camera';
 import {SiteCard} from '../sites/SiteCard';
+import {StyleSheet} from 'react-native';
 
 type SiteMapProps = {
   updateUserLocation?: (location: Location) => void;
   sites: Record<string, Site>;
+  styleURL?: string;
 };
 
 const siteFeatureCollection = (
@@ -128,7 +130,7 @@ const SiteMap = (
   props: SiteMapProps,
   ref: ForwardedRef<CameraRef>,
 ): JSX.Element => {
-  const {updateUserLocation, sites} = props;
+  const {updateUserLocation, sites, styleURL} = props;
   const [temporarySite, setTemporarySite] = useState<Pick<
     Site,
     'latitude' | 'longitude'
@@ -205,12 +207,10 @@ const SiteMap = (
 
   return (
     <Mapbox.MapView
-      // eslint-disable-next-line react-native/no-inline-styles
-      style={{
-        flex: 1,
-      }}
+      style={styles.mapView}
       onLongPress={onLongPress}
-      scaleBarEnabled={false}>
+      scaleBarEnabled={false}
+      styleURL={styleURL}>
       <Camera ref={ref} />
       <Mapbox.Images
         onImageMissing={console.debug}
@@ -231,14 +231,14 @@ const SiteMap = (
         id="sitesSource"
         shape={sitesFeature}
         onPress={onSitePress}>
-        <Mapbox.SymbolLayer id="sitesLayer" style={styles.siteLayer} />
+        <Mapbox.SymbolLayer id="sitesLayer" style={mapStyles.siteLayer} />
       </Mapbox.ShapeSource>
       <Mapbox.ShapeSource
         id="temporarySitesSource"
         shape={temporarySitesFeature}>
         <Mapbox.SymbolLayer
           id="temporarySitesLayer"
-          style={styles.temporarySiteLayer}
+          style={mapStyles.temporarySiteLayer}
         />
       </Mapbox.ShapeSource>
       <UserLocation
@@ -260,7 +260,13 @@ const SiteMap = (
   );
 };
 
-const styles = {
+const styles = StyleSheet.create({
+  mapView: {
+    flex: 1,
+  },
+});
+
+const mapStyles = {
   siteLayer: {
     iconAllowOverlap: true,
     iconAnchor: 'bottom',

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import SiteMap from '../components/home/SiteMap';
 import {useCallback, useEffect, useRef, useState} from 'react';
-import {Camera, Location} from '@rnmapbox/maps';
+import Mapbox, {Camera, Location} from '@rnmapbox/maps';
 import {updateLocation} from '../model/map/mapSlice';
 import {useDispatch} from '../model/store';
 import {useSelector} from '../model/store';
@@ -17,6 +17,7 @@ const STARTING_ZOOM_LEVEL = 5;
 
 const HomeView = () => {
   const [mapInitialized, setMapInitialized] = useState<Location | null>(null);
+  const [mapStyleURL, setMapStyleURL] = useState(Mapbox.StyleURL.Street);
   const currentUserID = useSelector(
     state => state.account.currentUser?.data?.id,
   );
@@ -67,14 +68,29 @@ const HomeView = () => {
     }
   }, [currentUserLocation, moveToPoint]);
 
+  const toggleMapLayer = useCallback(
+    () =>
+      setMapStyleURL(
+        mapStyleURL === Mapbox.StyleURL.Street
+          ? Mapbox.StyleURL.Satellite
+          : Mapbox.StyleURL.Street,
+      ),
+    [mapStyleURL, setMapStyleURL],
+  );
+
   return (
     <ScreenScaffold>
       <Box flex={1} zIndex={-1}>
-        <MapSearch zoomTo={moveToPoint} zoomToUser={moveToUser} />
+        <MapSearch
+          zoomTo={moveToPoint}
+          zoomToUser={moveToUser}
+          toggleMapLayer={toggleMapLayer}
+        />
         <SiteMap
           updateUserLocation={updateUserLocation}
           sites={sites}
           ref={camera}
+          styleURL={mapStyleURL}
         />
       </Box>
       <BottomSheet sites={sites} showSiteOnMap={moveToPoint} />


### PR DESCRIPTION
## Description
Allows toggling the map style between streets and satellite on the home screen. This implementation has an annoying problem where the first time the button is toggled, the Mapbox library raises an error even though everything functions totally fine. So I'm tempted to merge as is and file a backlog issue to figure the error message out, since it won't be visible outside of dev builds. (I think?). Thoughts?

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #47
