### PR TITLE
fix: use main branch of react-native-gesture-handler + fix build workflow

### DIFF
--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -109,3 +109,9 @@ jobs:
           issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPLE_KEY_ID }}
           api-private-key: ${{ secrets.APPLE_PRIVATE_KEY }}
+
+      - name: Preserve artifacts
+        uses: actions/upload-artifact
+        with:
+          name: ios-derviced-files
+          path: "/Users/runner/Library/Developer/Xcode/DerivedData/Terraso_LandPKS-*/Build/Intermediates.noindex/ArchiveIntermediates/Terraso LandPKS/IntermediateBuildFilesPath/Terraso LandPKS.build/Release-iphoneos/Terraso LandPKS.build/DerivedSources/"

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -89,7 +89,7 @@ jobs:
           certificate-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           workspace-path: dev-client/ios/Terraso LandPKS.xcworkspace
           scheme: Terraso LandPKS
-          increment-build-number: ${{ inputs.upload == 'true' }}
+          increment-build-number: ${{ inputs.upload == 'true' && "true" || "" }}
 
       - name: Preserve artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -91,13 +91,6 @@ jobs:
           scheme: Terraso LandPKS
           increment-build-number: ${{ inputs.upload == 'true' && 'true' || '' }}
 
-      - name: Preserve artifacts
-        uses: actions/upload-artifact@v3
-        if: "!cancelled()"
-        with:
-          name: ios-derviced-files
-          path: "/Users/runner/Library/Developer/Xcode/DerivedData/Terraso_LandPKS-*/Build/Intermediates.noindex/ArchiveIntermediates/Terraso LandPKS/IntermediateBuildFilesPath/Terraso LandPKS.build/Release-iphoneos/Terraso LandPKS.build/DerivedSources/"
-
       - name: Commit iOS version bump
         if: github.ref != 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -89,7 +89,7 @@ jobs:
           certificate-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           workspace-path: dev-client/ios/Terraso LandPKS.xcworkspace
           scheme: Terraso LandPKS
-          increment-build-number: ${{ inputs.upload == true && 'true' || '' }}
+          increment-build-number: ${{ inputs.upload == 'true' && 'true' || '' }}
 
       - name: Preserve artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -91,6 +91,13 @@ jobs:
           scheme: Terraso LandPKS
           increment-build-number: ${{ inputs.upload == 'true' }}
 
+      - name: Preserve artifacts
+        uses: actions/upload-artifact@v3
+        if: "!cancelled()"
+        with:
+          name: ios-derviced-files
+          path: "/Users/runner/Library/Developer/Xcode/DerivedData/Terraso_LandPKS-*/Build/Intermediates.noindex/ArchiveIntermediates/Terraso LandPKS/IntermediateBuildFilesPath/Terraso LandPKS.build/Release-iphoneos/Terraso LandPKS.build/DerivedSources/"
+
       - name: Commit iOS version bump
         if: github.ref != 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4
@@ -109,9 +116,3 @@ jobs:
           issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPLE_KEY_ID }}
           api-private-key: ${{ secrets.APPLE_PRIVATE_KEY }}
-
-      - name: Preserve artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ios-derviced-files
-          path: "/Users/runner/Library/Developer/Xcode/DerivedData/Terraso_LandPKS-*/Build/Intermediates.noindex/ArchiveIntermediates/Terraso LandPKS/IntermediateBuildFilesPath/Terraso LandPKS.build/Release-iphoneos/Terraso LandPKS.build/DerivedSources/"

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -111,7 +111,7 @@ jobs:
           api-private-key: ${{ secrets.APPLE_PRIVATE_KEY }}
 
       - name: Preserve artifacts
-        uses: actions/upload-artifact
+        uses: actions/upload-artifact@v3
         with:
           name: ios-derviced-files
           path: "/Users/runner/Library/Developer/Xcode/DerivedData/Terraso_LandPKS-*/Build/Intermediates.noindex/ArchiveIntermediates/Terraso LandPKS/IntermediateBuildFilesPath/Terraso LandPKS.build/Release-iphoneos/Terraso LandPKS.build/DerivedSources/"

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -8,6 +8,12 @@ on:
     secrets:
       MAPBOX_DOWNLOADS_TOKEN:
         required: true
+      GOOGLE_OAUTH_IOS_CLIENT_ID:
+        required: false
+      GOOGLE_OAUTH_IOS_URI_SCHEME:
+        required: false
+      PUBLIC_MAPBOX_TOKEN:
+        required: false
       IOS_P12_BASE64:
         required: true
       IOS_MOBILE_PROVISION_BASE64:

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -89,7 +89,7 @@ jobs:
           certificate-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           workspace-path: dev-client/ios/Terraso LandPKS.xcworkspace
           scheme: Terraso LandPKS
-          increment-build-number: ${{ inputs.upload == 'true' && "true" || "" }}
+          increment-build-number: ${{ inputs.upload == true && 'true' || '' }}
 
       - name: Preserve artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Enable build cache
         uses: mikehardy/buildcache-action@v2
 
+      - name: Provide Mapbox secret key
+        run: |
+          echo "machine api.mapbox.com" >> $HOME/.netrc
+          echo "login mapbox" >> $HOME/.netrc
+          echo "password ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}" >> $HOME/.netrc
+          chmod 600 $HOME/.netrc
+
       - name: Set up config values
         if: ${{ inputs.upload == 'true' }}
         working-directory: ./dev-client
@@ -66,13 +73,6 @@ jobs:
           path: dev-client/ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-
-
-      - name: Provide Mapbox secret key
-        run: |
-          echo "machine api.mapbox.com" >> $HOME/.netrc
-          echo "login mapbox" >> $HOME/.netrc
-          echo "password ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}" >> $HOME/.netrc
-          chmod 600 $HOME/.netrc
 
       - name: CocoaPod Install
         working-directory: dev-client/ios

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -15,6 +15,9 @@ jobs:
       upload: 'true'
     secrets:
       MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
+      GOOGLE_OAUTH_IOS_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_IOS_CLIENT_ID }}
+      GOOGLE_OAUTH_IOS_URI_SCHEME: ${{ secrets.GOOGLE_OAUTH_IOS_URI_SCHEME }}
+      PUBLIC_MAPBOX_TOKEN: ${{ secrets.PUBLIC_MAPBOX_TOKEN }}
       IOS_P12_BASE64: ${{ secrets.IOS_P12_BASE64 }}
       IOS_MOBILE_PROVISION_BASE64: ${{ secrets.IOS_MOBILE_PROVISION_BASE64 }}
       IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}

--- a/dev-client/ios/Podfile.lock
+++ b/dev-client/ios/Podfile.lock
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   React-Core: 34da8c952844e21f5a69bf46438fb6bf063900d0
   React-CoreModules: 621243df8863055ff30f3bb2ff71573ffa7b16c8
   React-cxxreact: 4ad1cc861e32fb533dad6ff7a4ea25680fa1c994
-  React-debug: 8de84cd4b7de7fff5ebd53a23db3379a672dcae4
+  React-debug: e5319adf336c3f8d795aa21b99c6b9e0bc0b6e2e
   React-hermes: 37377d0a56aa0cf55c65248271866ce3268cde3f
   React-jsi: 6de8b0ccc6b765b58e4eee9ee38049dbeaf5c221
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   react-native-mmkv-storage: cfb6854594cfdc5f7383a9e464bb025417d1721c
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
-  React-NativeModulesApple: f6ed1b5ad9a3c07a5dc07721de9faf25e689425c
+  React-NativeModulesApple: fea64684c7ecbe1030b0c7cd98ec761a82f6d926
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
   React-RCTAnimation: e44fe5053708c5be762943087c78dc5a6a3c645c
@@ -737,9 +737,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 35eec7201c8ffdaccdd908a5ec874b7055f975f3
   React-rncore: 46133d523155fc84572338bd6a7c461c1d873efc
   React-runtimeexecutor: d465ba0c47ef3ed8281143f59605cacc2244d5c7
-  React-runtimescheduler: b0025e9711736ba1ac1b55f2a30e2f08a63987f0
-  React-utils: 6c7fb48fc5a0c56aba532787cb16676101fe550a
-  ReactCommon: 5cf8fbc5aa37343303ead2859aaaa562158aadd7
+  React-runtimescheduler: 3df64962a7352e48118b856f48c422e3c7dce461
+  React-utils: d428af72b6c99f7b4d6c63ad49ee6447fb540388
+  ReactCommon: 795ef2e3b65711d4098d141fd73821663357705d
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   rnmapbox-maps: 6f638ec002aa6e906a6f766d69cd45f968d98e64
   RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1

--- a/dev-client/ios/Podfile.lock
+++ b/dev-client/ios/Podfile.lock
@@ -711,7 +711,7 @@ SPEC CHECKSUMS:
   React-Core: 34da8c952844e21f5a69bf46438fb6bf063900d0
   React-CoreModules: 621243df8863055ff30f3bb2ff71573ffa7b16c8
   React-cxxreact: 4ad1cc861e32fb533dad6ff7a4ea25680fa1c994
-  React-debug: e5319adf336c3f8d795aa21b99c6b9e0bc0b6e2e
+  React-debug: 8de84cd4b7de7fff5ebd53a23db3379a672dcae4
   React-hermes: 37377d0a56aa0cf55c65248271866ce3268cde3f
   React-jsi: 6de8b0ccc6b765b58e4eee9ee38049dbeaf5c221
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   react-native-mmkv-storage: cfb6854594cfdc5f7383a9e464bb025417d1721c
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
-  React-NativeModulesApple: fea64684c7ecbe1030b0c7cd98ec761a82f6d926
+  React-NativeModulesApple: f6ed1b5ad9a3c07a5dc07721de9faf25e689425c
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
   React-RCTAnimation: e44fe5053708c5be762943087c78dc5a6a3c645c
@@ -737,9 +737,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 35eec7201c8ffdaccdd908a5ec874b7055f975f3
   React-rncore: 46133d523155fc84572338bd6a7c461c1d873efc
   React-runtimeexecutor: d465ba0c47ef3ed8281143f59605cacc2244d5c7
-  React-runtimescheduler: 3df64962a7352e48118b856f48c422e3c7dce461
-  React-utils: d428af72b6c99f7b4d6c63ad49ee6447fb540388
-  ReactCommon: 795ef2e3b65711d4098d141fd73821663357705d
+  React-runtimescheduler: b0025e9711736ba1ac1b55f2a30e2f08a63987f0
+  React-utils: 6c7fb48fc5a0c56aba532787cb16676101fe550a
+  ReactCommon: 5cf8fbc5aa37343303ead2859aaaa562158aadd7
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   rnmapbox-maps: 6f638ec002aa6e906a6f766d69cd45f968d98e64
   RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1

--- a/dev-client/ios/Podfile.lock
+++ b/dev-client/ios/Podfile.lock
@@ -458,7 +458,7 @@ PODS:
     - React-jsi (= 0.72.4)
     - React-logger (= 0.72.4)
     - React-perflogger (= 0.72.4)
-  - RNGestureHandler (2.12.1):
+  - RNGestureHandler (2.12.0):
     - React-Core
   - rnmapbox-maps (10.0.11):
     - MapboxMaps (~> 10.14.0)
@@ -740,7 +740,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 3df64962a7352e48118b856f48c422e3c7dce461
   React-utils: d428af72b6c99f7b4d6c63ad49ee6447fb540388
   ReactCommon: 795ef2e3b65711d4098d141fd73821663357705d
-  RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
+  RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   rnmapbox-maps: 6f638ec002aa6e906a6f766d69cd45f968d98e64
   RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1
   RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7

--- a/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
+++ b/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
@@ -469,6 +469,9 @@
 			baseConfigurationReference = 9B636DA2BF577EB074AE1958 /* Pods-Terraso LandPKS-Terraso LandPKSTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 2A8W5MT5NL;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -487,6 +490,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.terraso.landpks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "021da57f-2b02-4efd-9bc5-a3fb2a5057ab";
+				PROVISIONING_PROFILE_SPECIFIER = "Terraso LandPKS Beta Profile";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TerrasoLandPKS.app/TerrasoLandPKS";
 			};
 			name = Debug;
@@ -496,7 +501,10 @@
 			baseConfigurationReference = FE1CE62AEB19A25D32A26A47 /* Pods-Terraso LandPKS-Terraso LandPKSTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = 2A8W5MT5NL;
 				INFOPLIST_FILE = DevClientTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -511,6 +519,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.terraso.landpks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "021da57f-2b02-4efd-9bc5-a3fb2a5057ab";
+				PROVISIONING_PROFILE_SPECIFIER = "Terraso LandPKS Beta Profile";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TerrasoLandPKS.app/TerrasoLandPKS";
 			};
 			name = Release;
@@ -521,10 +531,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 20;
-				DEVELOPMENT_TEAM = "";
+				CURRENT_PROJECT_VERSION = 21;
+				DEVELOPMENT_TEAM = 2A8W5MT5NL;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2A8W5MT5NL;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Terraso LandPKS/Info.plist";
@@ -542,7 +553,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.terraso.test.Terraso-LandPKS";
 				PRODUCT_NAME = TerrasoLandPKS;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE = "021da57f-2b02-4efd-9bc5-a3fb2a5057ab";
+				PROVISIONING_PROFILE_SPECIFIER = "Terraso LandPKS Beta Profile";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Terraso LandPKS Beta Profile";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -560,10 +572,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 20;
-				DEVELOPMENT_TEAM = "";
+				CURRENT_PROJECT_VERSION = 21;
+				DEVELOPMENT_TEAM = 2A8W5MT5NL;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2A8W5MT5NL;
 				INFOPLIST_FILE = "Terraso LandPKS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Terraso LandPKS";
@@ -580,7 +593,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.terraso.test.Terraso-LandPKS";
 				PRODUCT_NAME = TerrasoLandPKS;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE = "021da57f-2b02-4efd-9bc5-a3fb2a5057ab";
+				PROVISIONING_PROFILE_SPECIFIER = "Terraso LandPKS Beta Profile";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Terraso LandPKS Beta Profile";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
+++ b/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2A8W5MT5NL;
 				ENABLE_BITCODE = NO;
@@ -562,7 +562,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2A8W5MT5NL;
 				INFOPLIST_FILE = "Terraso LandPKS/Info.plist";

--- a/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
+++ b/dev-client/ios/Terraso LandPKS.xcodeproj/project.pbxproj
@@ -534,7 +534,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 2A8W5MT5NL;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2A8W5MT5NL;
 				ENABLE_BITCODE = NO;
@@ -575,7 +575,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 2A8W5MT5NL;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2A8W5MT5NL;
 				INFOPLIST_FILE = "Terraso LandPKS/Info.plist";

--- a/dev-client/ios/Terraso LandPKS/Info.plist
+++ b/dev-client/ios/Terraso LandPKS/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>22</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -24,7 +24,7 @@
         "react-native-app-auth": "^6.4.3",
         "react-native-autocomplete-input": "^5.3.2",
         "react-native-config": "^1.5.1",
-        "react-native-gesture-handler": "^2.12.1",
+        "react-native-gesture-handler": "software-mansion/react-native-gesture-handler#main",
         "react-native-get-random-values": "^1.9.0",
         "react-native-gradle-plugin": "^0.71.19",
         "react-native-mmkv-storage": "^0.9.1",
@@ -15456,9 +15456,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.12.1.tgz",
-      "integrity": "sha512-deqh36bw82CFUV9EC4tTo2PP1i9HfCOORGS3Zmv71UYhEZEHkzZv18IZNPB+2Awzj45vLIidZxGYGFxHlDSQ5A==",
+      "version": "2.12.0",
+      "resolved": "git+ssh://git@github.com/software-mansion/react-native-gesture-handler.git#17bbcde27a10ee0259f7f4501b71e129ad6e584f",
+      "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -24,7 +24,7 @@
         "react-native-app-auth": "^6.4.3",
         "react-native-autocomplete-input": "^5.3.2",
         "react-native-config": "^1.5.1",
-        "react-native-gesture-handler": "software-mansion/react-native-gesture-handler#main",
+        "react-native-gesture-handler": "software-mansion/react-native-gesture-handler#17bbcde",
         "react-native-get-random-values": "^1.9.0",
         "react-native-gradle-plugin": "^0.71.19",
         "react-native-mmkv-storage": "^0.9.1",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -29,7 +29,7 @@
     "react-native-app-auth": "^6.4.3",
     "react-native-autocomplete-input": "^5.3.2",
     "react-native-config": "^1.5.1",
-    "react-native-gesture-handler": "^2.12.1",
+    "react-native-gesture-handler": "software-mansion/react-native-gesture-handler#main",
     "react-native-get-random-values": "^1.9.0",
     "react-native-gradle-plugin": "^0.71.19",
     "react-native-mmkv-storage": "^0.9.1",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -29,7 +29,7 @@
     "react-native-app-auth": "^6.4.3",
     "react-native-autocomplete-input": "^5.3.2",
     "react-native-config": "^1.5.1",
-    "react-native-gesture-handler": "software-mansion/react-native-gesture-handler#main",
+    "react-native-gesture-handler": "software-mansion/react-native-gesture-handler#17bbcde",
     "react-native-get-random-values": "^1.9.0",
     "react-native-gradle-plugin": "^0.71.19",
     "react-native-mmkv-storage": "^0.9.1",


### PR DESCRIPTION
## Description
Use main branch of react-native-gesture-handler. Allows site popover to be closed.

See:
https://github.com/techmatters/terraso-mobile-client/issues/305 https://github.com/rnmapbox/maps/issues/2880#issuecomment-1630091579


### Related Issues
Fixes #305.