### PR TITLE
feat: navigate to project on creation

### DIFF
--- a/dev-client/src/components/projects/CreateProjectView/index.tsx
+++ b/dev-client/src/components/projects/CreateProjectView/index.tsx
@@ -6,10 +6,12 @@ import {useNavigation} from '../../../screens/AppScaffold';
 
 export default function CreateProjectView() {
   const dispatch = useDispatch();
-  const navigate = useNavigation();
+  const navigation = useNavigation();
   const onSubmit = async (values: FormValues) => {
-    await dispatch(addProject(values));
-    navigate.goBack();
+    const {payload} = await dispatch(addProject(values));
+    if (payload !== undefined && 'id' in payload) {
+      navigation.replace('PROJECT_VIEW', {project: payload});
+    }
   };
   return (
     <ScrollView bg="background.default">


### PR DESCRIPTION
## Description
When creating a project, users are now taken to the new project's screen rather than back to the project list view.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #307

