### PR TITLE
feat: bottom sheet site create uses dropped pin's coordinates

### DIFF
--- a/dev-client/src/components/home/BottomSheet.tsx
+++ b/dev-client/src/components/home/BottomSheet.tsx
@@ -2,7 +2,6 @@ import BottomSheet, {
   BottomSheetFlatList,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet';
-import {useNavigation} from '../../screens/AppScaffold';
 import {
   Box,
   Button,
@@ -85,10 +84,10 @@ const LandPKSInfo = () => {
 type Props = {
   sites: Record<string, Site>;
   showSiteOnMap: (site: Site) => void;
+  onCreateSite: () => void;
 };
-const SiteListBottomSheet = ({sites, showSiteOnMap}: Props) => {
+const SiteListBottomSheet = ({sites, showSiteOnMap, onCreateSite}: Props) => {
   const {t} = useTranslation();
-  const navigation = useNavigation();
 
   const siteList = useMemo(() => Object.values(sites), [sites]);
 
@@ -103,10 +102,6 @@ const SiteListBottomSheet = ({sites, showSiteOnMap}: Props) => {
     () => ['15%', siteList.length === 0 ? '50%' : '75%', '100%'],
     [siteList.length],
   );
-
-  const addSiteCallback = useCallback(() => {
-    navigation.navigate('CREATE_SITE');
-  }, [navigation]);
 
   const {colors} = useTheme();
   const listStyle = useMemo(() => ({paddingHorizontal: 16}), []);
@@ -128,7 +123,7 @@ const SiteListBottomSheet = ({sites, showSiteOnMap}: Props) => {
         <Heading variant="h6">{t('site.list_title')}</Heading>
         <Button
           size="sm"
-          onPress={addSiteCallback}
+          onPress={onCreateSite}
           startIcon={<Icon name="add" />}>
           {t('site.create')}
         </Button>

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -21,6 +21,7 @@ type SiteMapProps = {
   calloutState: CalloutState;
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
+  onCreateSite: () => void;
 };
 
 const siteFeatureCollection = (
@@ -119,8 +120,14 @@ const SiteMap = (
   props: SiteMapProps,
   ref: ForwardedRef<CameraRef>,
 ): JSX.Element => {
-  const {updateUserLocation, sites, setCalloutState, calloutState, styleURL} =
-    props;
+  const {
+    updateUserLocation,
+    sites,
+    setCalloutState,
+    calloutState,
+    onCreateSite,
+    styleURL,
+  } = props;
   const selectedSite =
     calloutState.kind === 'site' ? sites[calloutState.siteId] : null;
   const {navigate} = useNavigation();
@@ -143,15 +150,6 @@ const SiteMap = (
       ),
     [calloutState],
   );
-
-  const temporaryCreateCallback = useCallback(() => {
-    const siteToCreate: Coords | undefined =
-      calloutState.kind === 'location' ? calloutState.coords : undefined;
-    setCalloutState({kind: 'none'});
-    navigate('CREATE_SITE', {
-      mapCoords: siteToCreate,
-    });
-  }, [navigate, calloutState, setCalloutState]);
 
   const temporaryLearnMoreCallback = useCallback(() => {
     setCalloutState({kind: 'none'});
@@ -249,7 +247,7 @@ const SiteMap = (
         <TemporarySiteCallout
           site={calloutState.coords}
           closeCallout={closeCallout}
-          onCreate={temporaryCreateCallback}
+          onCreate={onCreateSite}
           onLearnMore={temporaryLearnMoreCallback}
         />
       )}

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -20,20 +20,21 @@ import {ValidationError} from 'yup';
 import {Icon} from '../common/Icons';
 import {useTranslation} from 'react-i18next';
 import {useSelector} from '../../model/store';
+import {Coords} from '../../model/map/mapSlice';
 
 type LatLongString = {latitude: string; longitude: string};
 
-function fromLocation(location: Location): LatLongString {
+function fromLocation(coords: Coords): LatLongString {
   return {
-    longitude: String(location.coords.longitude),
-    latitude: String(location.coords.latitude),
+    longitude: String(coords.longitude),
+    latitude: String(coords.latitude),
   };
 }
 
 type Props = {
   defaultProject?: string;
   userLocation?: Location;
-  sitePin?: Location;
+  sitePin?: Coords;
   createSiteCallback?: (input: SiteAddMutationInput) => void;
 };
 
@@ -62,7 +63,7 @@ export default function CreateSiteView({
 
   const {latitude: defaultLat, longitude: defaultLon} = useMemo(() => {
     if (sitePin) {
-      return {...sitePin.coords};
+      return sitePin;
     }
     if (userLocation) {
       return {...userLocation.coords};
@@ -119,7 +120,7 @@ export default function CreateSiteView({
   const locationOptions = useMemo(() => {
     const options: Record<LocationInputOptions, LatLongString | undefined> = {
       coords: {latitude: '', longitude: ''},
-      gps: userLocation && fromLocation(userLocation),
+      gps: userLocation && fromLocation(userLocation.coords),
       pin: sitePin && fromLocation(sitePin),
     };
     return options;

--- a/dev-client/src/components/sites/LocationDashboardScreen.tsx
+++ b/dev-client/src/components/sites/LocationDashboardScreen.tsx
@@ -186,7 +186,7 @@ export const LocationDashboardScreen: ScreenDefinition<Props> = {
         <IconButton
           name="add"
           _icon={{color: tintColor}}
-          onPress={() => navigate('CREATE_SITE', {mapCoords: coords})}
+          onPress={() => navigate('CREATE_SITE', {coords})}
         />
       );
     },

--- a/dev-client/src/screens/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen.tsx
@@ -2,21 +2,22 @@ import {useCallback} from 'react';
 import CreateSiteView from '../components/sites/CreateSiteView';
 import {useDispatch, useSelector} from '../model/store';
 import {
-  Site,
   addSite,
   fetchSitesForProject,
 } from 'terraso-client-shared/site/siteSlice';
 import {SiteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 import {ScreenDefinition} from './AppScaffold';
 import CloseButton from '../components/common/CloseButton';
+import {Coords} from '../model/map/mapSlice';
 
 type Props =
   | {
-      mapCoords?: Pick<Site, 'latitude' | 'longitude'>;
+      coords: Coords;
     }
   | {
       projectId: string;
     }
+  | {}
   | undefined;
 
 const CreateSiteScaffold = (props: Props = {}) => {
@@ -37,12 +38,8 @@ const CreateSiteScaffold = (props: Props = {}) => {
     <CreateSiteView
       userLocation={userLocation}
       createSiteCallback={createSiteCallback}
-      defaultProject={('projectId' in props && props.projectId) || undefined}
-      sitePin={
-        'mapCoords' in props && props.mapCoords
-          ? {coords: props.mapCoords}
-          : undefined
-      }
+      defaultProject={'projectId' in props ? props.projectId : undefined}
+      sitePin={'coords' in props ? props.coords : undefined}
     />
   );
 };

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -6,7 +6,7 @@ import {useDispatch} from '../model/store';
 import {useSelector} from '../model/store';
 import {Site, fetchSitesForUser} from 'terraso-client-shared/site/siteSlice';
 import BottomSheet from '../components/home/BottomSheet';
-import {ScreenDefinition} from './AppScaffold';
+import {ScreenDefinition, useNavigation} from './AppScaffold';
 import {MainMenuBar, MapInfoIcon} from './HeaderIcons';
 import {ScreenScaffold} from './ScreenScaffold';
 import {fetchProjectsForUser} from 'terraso-client-shared/project/projectSlice';
@@ -29,6 +29,7 @@ export type CalloutState =
 const STARTING_ZOOM_LEVEL = 12;
 
 const HomeView = () => {
+  const navigation = useNavigation();
   const [mapInitialized, setMapInitialized] = useState<Location | null>(null);
   const [mapStyleURL, setMapStyleURL] = useState(Mapbox.StyleURL.Street);
   const [calloutState, setCalloutState] = useState<CalloutState>({
@@ -110,6 +111,16 @@ const HomeView = () => {
     [moveToPoint, setCalloutState],
   );
 
+  const onCreateSite = useCallback(() => {
+    navigation.navigate(
+      'CREATE_SITE',
+      calloutState.kind === 'location'
+        ? {coords: calloutState.coords}
+        : undefined,
+    );
+    setCalloutState({kind: 'none'});
+  }, [navigation, calloutState]);
+
   return (
     <ScreenScaffold>
       <Box flex={1} zIndex={-1}>
@@ -125,9 +136,14 @@ const HomeView = () => {
           calloutState={calloutState}
           setCalloutState={setCalloutState}
           styleURL={mapStyleURL}
+          onCreateSite={onCreateSite}
         />
       </Box>
-      <BottomSheet sites={sites} showSiteOnMap={showSiteOnMap} />
+      <BottomSheet
+        sites={sites}
+        showSiteOnMap={showSiteOnMap}
+        onCreateSite={onCreateSite}
+      />
     </ScreenScaffold>
   );
 };


### PR DESCRIPTION
## Description
**NOTE: THIS PR IS BASED ON https://github.com/techmatters/terraso-mobile-client/pull/318 TO AVOID MERGE CONFLICTS. MAKE SURE THAT PR GETS MERGED AND BASE BRANCH IS UPDATED TO MAIN BEFORE MERGING THIS PR.**

Creating a site from the bottom sheet's button now also uses the dropped location pin's coords if available.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #315 
