### PR TITLE
feat: use updated site card design/component for project sites list

### DIFF
--- a/dev-client/src/components/common/ProgressCircle.tsx
+++ b/dev-client/src/components/common/ProgressCircle.tsx
@@ -1,9 +1,0 @@
-import {Text} from 'native-base';
-
-type Props = {
-  done: number;
-};
-
-export default function ProgressCirle({done}: Props) {
-  return <Text>{done} %</Text>;
-}


### PR DESCRIPTION
## Description
Updates the site card in the project sites list to use the same component as on the home screen.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes (once QA'd) #323 
