### PR TITLE
fix: dont rerun build action on PR title/body edit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - edited
-      - synchronize
 
 jobs:
   ios-build:


### PR DESCRIPTION
## Description
Updates the `build.yml` file to use the default values for what types of pull request events trigger a build. We had specified the `edited` event which would cause a rebuild if the PR's title or body changed.

### Verification steps
This PR should still trigger a build run. But if the title is edited a new build run should not be triggered.

### References
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request