### PR TITLE
feat: collapse bottom sheet when showing site

### DIFF
--- a/dev-client/src/components/home/BottomSheet.tsx
+++ b/dev-client/src/components/home/BottomSheet.tsx
@@ -13,11 +13,12 @@ import {
   Image,
   useTheme,
 } from 'native-base';
-import {useCallback, useMemo} from 'react';
+import {forwardRef, useCallback, useMemo} from 'react';
 import {Site} from 'terraso-client-shared/site/siteSlice';
 import {Trans, useTranslation} from 'react-i18next';
 import {Icon} from '../common/Icons';
 import {SiteCard} from '../sites/SiteCard';
+import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 
 const LandPKSInfo = () => {
   const {t} = useTranslation();
@@ -86,62 +87,63 @@ type Props = {
   showSiteOnMap: (site: Site) => void;
   onCreateSite: () => void;
 };
-const SiteListBottomSheet = ({sites, showSiteOnMap, onCreateSite}: Props) => {
-  const {t} = useTranslation();
+export const SiteListBottomSheet = forwardRef<BottomSheetMethods, Props>(
+  ({sites, showSiteOnMap, onCreateSite}, ref) => {
+    const {t} = useTranslation();
 
-  const siteList = useMemo(() => Object.values(sites), [sites]);
+    const siteList = useMemo(() => Object.values(sites), [sites]);
 
-  const renderSite = useCallback(
-    ({item}: {item: Site}) => (
-      <SiteCard site={item} onShowSiteOnMap={showSiteOnMap} />
-    ),
-    [showSiteOnMap],
-  );
+    const renderSite = useCallback(
+      ({item}: {item: Site}) => (
+        <SiteCard site={item} onShowSiteOnMap={showSiteOnMap} />
+      ),
+      [showSiteOnMap],
+    );
 
-  const snapPoints = useMemo(
-    () => ['15%', siteList.length === 0 ? '50%' : '75%', '100%'],
-    [siteList.length],
-  );
+    const snapPoints = useMemo(
+      () => ['15%', siteList.length === 0 ? '50%' : '75%', '100%'],
+      [siteList.length],
+    );
 
-  const {colors} = useTheme();
-  const listStyle = useMemo(() => ({paddingHorizontal: 16}), []);
-  const backgroundStyle = useMemo(
-    () => ({backgroundColor: colors.grey[300]}),
-    [colors],
-  );
+    const {colors} = useTheme();
+    const listStyle = useMemo(() => ({paddingHorizontal: 16}), []);
+    const backgroundStyle = useMemo(
+      () => ({backgroundColor: colors.grey[300]}),
+      [colors],
+    );
 
-  return (
-    <BottomSheet
-      snapPoints={snapPoints}
-      backgroundStyle={backgroundStyle}
-      handleIndicatorStyle={{backgroundColor: colors.grey[800]}}>
-      <Row
-        justifyContent="space-between"
-        alignItems="center"
-        paddingBottom="4"
-        paddingX="16px">
-        <Heading variant="h6">{t('site.list_title')}</Heading>
-        <Button
-          size="sm"
-          onPress={onCreateSite}
-          startIcon={<Icon name="add" />}>
-          {t('site.create')}
-        </Button>
-      </Row>
-      {siteList.length === 0 ? (
-        <LandPKSInfo />
-      ) : (
-        <BottomSheetFlatList
-          style={listStyle}
-          data={siteList}
-          keyExtractor={site => site.id}
-          renderItem={renderSite}
-          ItemSeparatorComponent={() => <Box height="8px" />}
-          ListFooterComponent={<Box height="10px" />}
-        />
-      )}
-    </BottomSheet>
-  );
-};
-
-export default SiteListBottomSheet;
+    return (
+      <BottomSheet
+        ref={ref}
+        snapPoints={snapPoints}
+        backgroundStyle={backgroundStyle}
+        handleIndicatorStyle={{backgroundColor: colors.grey[800]}}>
+        <Row
+          justifyContent="space-between"
+          alignItems="center"
+          paddingBottom="4"
+          paddingX="16px">
+          <Heading variant="h6">{t('site.list_title')}</Heading>
+          <Button
+            size="sm"
+            onPress={onCreateSite}
+            startIcon={<Icon name="add" />}>
+            {t('site.create')}
+          </Button>
+        </Row>
+        {siteList.length === 0 ? (
+          <LandPKSInfo />
+        ) : (
+          <BottomSheetFlatList
+            style={listStyle}
+            data={siteList}
+            keyExtractor={site => site.id}
+            renderItem={renderSite}
+            ItemSeparatorComponent={() => <Box height="8px" />}
+            ListFooterComponent={<Box height="10px" />}
+          />
+        )}
+      </BottomSheet>
+    );
+  },
+);

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -5,7 +5,7 @@ import {Coords, updateLocation} from '../model/map/mapSlice';
 import {useDispatch} from '../model/store';
 import {useSelector} from '../model/store';
 import {Site, fetchSitesForUser} from 'terraso-client-shared/site/siteSlice';
-import BottomSheet from '../components/home/BottomSheet';
+import {SiteListBottomSheet} from '../components/home/BottomSheet';
 import {ScreenDefinition, useNavigation} from './AppScaffold';
 import {MainMenuBar, MapInfoIcon} from './HeaderIcons';
 import {ScreenScaffold} from './ScreenScaffold';
@@ -13,6 +13,7 @@ import {fetchProjectsForUser} from 'terraso-client-shared/project/projectSlice';
 import MapSearch from '../components/home/MapSearch';
 import {Box} from 'native-base';
 import {coordsToPosition} from '../components/common/Map';
+import BottomSheet from '@gorhom/bottom-sheet';
 
 export type CalloutState =
   | {
@@ -29,6 +30,7 @@ export type CalloutState =
 const STARTING_ZOOM_LEVEL = 12;
 
 const HomeView = () => {
+  const bottomSheetRef = useRef<BottomSheet>(null);
   const navigation = useNavigation();
   const [mapInitialized, setMapInitialized] = useState<Location | null>(null);
   const [mapStyleURL, setMapStyleURL] = useState(Mapbox.StyleURL.Street);
@@ -107,6 +109,7 @@ const HomeView = () => {
     (site: Site) => {
       moveToPoint(site);
       setCalloutState({kind: 'site', siteId: site.id});
+      bottomSheetRef.current?.collapse();
     },
     [moveToPoint, setCalloutState],
   );
@@ -139,7 +142,8 @@ const HomeView = () => {
           onCreateSite={onCreateSite}
         />
       </Box>
-      <BottomSheet
+      <SiteListBottomSheet
+        ref={bottomSheetRef}
         sites={sites}
         showSiteOnMap={showSiteOnMap}
         onCreateSite={onCreateSite}


### PR DESCRIPTION
## Description
When clicking a site card's map icon, the bottom sheet will  collapse as we're panning the map to the site.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes (once QA'd) #306
