### PR TITLE
fix: hide back button titles on iOS

### DIFF
--- a/dev-client/src/screens/AppScaffold.tsx
+++ b/dev-client/src/screens/AppScaffold.tsx
@@ -104,6 +104,7 @@ export default function AppScaffold() {
 
   const defaultScreenOptions = useMemo<NativeStackNavigationOptions>(
     () => ({
+      headerBackTitleVisible: false,
       headerStyle: {backgroundColor: colors.primary.main},
       headerTintColor: colors.primary.contrast,
       headerTitle: ({children: name, ...props}) => (


### PR DESCRIPTION
## Description
Hide back button titles on iOS. Matches Android behaviour.

### Related Issues
Fixes #339.