### PR TITLE
fix: use numeric keyboard for lat/long fields

### DIFF
--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -197,6 +197,7 @@ export default function CreateSiteView({
           <FormControl.Label>Latitude</FormControl.Label>
           <Input
             variant="underlined"
+            keyboardType="numeric"
             size="sm"
             onChangeText={latitude =>
               setMutationInput({...mutationInput, latitude})
@@ -210,6 +211,7 @@ export default function CreateSiteView({
           <Input
             size="sm"
             variant="underlined"
+            keyboardType="numeric"
             value={mutationInput.longitude}
             onChangeText={longitude =>
               setMutationInput({...mutationInput, longitude})


### PR DESCRIPTION
## Description
Use numeric keyboard for lat/long fields

### Related Issues
Fixes #328.