### PR TITLE
fix: use location pin icon for 'home' in bottom toolbar

### DIFF
--- a/dev-client/src/screens/ScreenScaffold.tsx
+++ b/dev-client/src/screens/ScreenScaffold.tsx
@@ -26,7 +26,7 @@ export const BottomNavigation = () => {
   return (
     <HStack bg="primary.main" justifyContent="center" space={10} pb={2}>
       <BottomNavIconButton
-        name="map"
+        name="location-pin"
         label={t('bottom_navigation.home')}
         onPress={onHome}
       />


### PR DESCRIPTION
## Description
Use location pin icon for 'home' in bottom toolbar

### Related Issues
Fixes #353.