### PR TITLE
feat: Disable save button on create site on submit

### DIFF
--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -63,6 +63,7 @@ export default function CreateSiteView({
 
   const projectMap = useSelector(state => state.project.projects);
   const projects = useMemo(() => Object.values(projectMap), [projectMap]);
+  const [submitting, setSubmitting] = useState(false);
 
   const {latitude: defaultLat, longitude: defaultLon} = useMemo(() => {
     if (sitePin) {
@@ -90,6 +91,7 @@ export default function CreateSiteView({
    * Checks the form status with the yup library, and posts to backend
    */
   const onSave = useCallback(async () => {
+    setSubmitting(true);
     if (createSiteCallback === undefined) {
       return;
     }
@@ -99,6 +101,7 @@ export default function CreateSiteView({
     try {
       validationResults = await siteValidationSchema.validate(mutationInput);
     } catch (validationError) {
+      setSubmitting(false);
       if (validationError instanceof ValidationError) {
         setErrors({
           [validationError.path as keyof SiteAddMutationInput]:
@@ -119,6 +122,7 @@ export default function CreateSiteView({
     if (createdSite !== undefined) {
       navigation.replace('LOCATION_DASHBOARD', {siteId: createdSite.id});
     }
+    setSubmitting(false);
   }, [mutationInput, createSiteCallback, navigation]);
 
   /* calculates the associated location for a given location input option
@@ -253,7 +257,11 @@ export default function CreateSiteView({
               }),
           }}
         />
-        <Fab label={t('general.save_fab')} onPress={onSave} />
+        <Fab
+          label={t('general.save_fab')}
+          onPress={onSave}
+          disabled={submitting}
+        />
       </VStack>
     </ScrollView>
   );


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This PR simply disables the submit button when the user clicks on "Submit" on the create site page.

I will refactor this  component to use [Formik](https://formik.org/) at a later date, which will simplify the logic here a lot. But I'd like to get some unit tests set up first and wait until after usability testing is wrapped up to work on this to avoid the risk of a regression.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
