### PR TITLE
fix: hide SSRProvider warning

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -23,8 +23,10 @@ import './config';
 import {createStore} from './model/store';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {APP_CONFIG} from './config';
+import { LogBox } from 'react-native';
 
 Mapbox.setAccessToken(APP_CONFIG.mapboxAccessToken);
+LogBox.ignoreLogs(['In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.']);
 
 function App(): JSX.Element {
   const store = useMemo(createStore, []);

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -23,10 +23,12 @@ import './config';
 import {createStore} from './model/store';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {APP_CONFIG} from './config';
-import { LogBox } from 'react-native';
+import {LogBox} from 'react-native';
 
 Mapbox.setAccessToken(APP_CONFIG.mapboxAccessToken);
-LogBox.ignoreLogs(['In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.']);
+LogBox.ignoreLogs([
+  'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
+]);
 
 function App(): JSX.Element {
   const store = useMemo(createStore, []);


### PR DESCRIPTION
## Description
Hide SSRProvider warning:
```
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
```

NativeBase is no longer being updated so this warning won't be fixed.
