### PR TITLE
fix: Don't reset site name on privacy change

### DIFF
--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -171,7 +171,9 @@ export default function CreateSiteView({
           <Input
             placeholder="Site name"
             value={mutationInput.name}
-            onChangeText={name => setMutationInput({...mutationInput, name})}
+            onChangeText={name =>
+              setMutationInput(current => ({...current, name}))
+            }
           />
           {/* TODO: FormControl.ErrorMessage does not seem to work :( */}
           {errors.name &&
@@ -204,7 +206,7 @@ export default function CreateSiteView({
             keyboardType="numeric"
             size="sm"
             onChangeText={latitude =>
-              setMutationInput({...mutationInput, latitude})
+              setMutationInput(current => ({...current, latitude}))
             }
             value={mutationInput.latitude}
             leftElement={<Icon mr={2} name="edit" />}
@@ -218,7 +220,7 @@ export default function CreateSiteView({
             keyboardType="numeric"
             value={mutationInput.longitude}
             onChangeText={longitude =>
-              setMutationInput({...mutationInput, longitude})
+              setMutationInput(current => ({...current, longitude}))
             }
             leftElement={<Icon mr={2} name="edit" />}
           />
@@ -228,7 +230,7 @@ export default function CreateSiteView({
           <Select
             selectedValue={mutationInput.projectId}
             onValueChange={projectId =>
-              setMutationInput({...mutationInput, projectId})
+              setMutationInput(current => ({...current, projectId}))
             }>
             {projects.map(project => (
               <Select.Item
@@ -251,10 +253,10 @@ export default function CreateSiteView({
             name: 'data-privacy',
             value: mutationInput.privacy,
             onChange: (privacy: ProjectPrivacy) =>
-              setMutationInput({
-                ...mutationInput,
+              setMutationInput(current => ({
+                ...current,
                 privacy,
-              }),
+              })),
           }}
         />
         <Fab


### PR DESCRIPTION
Changes the CreateSiteView to pass a function to the setMutationInput function. This ensures that the most current state is being used and we don't get stale state, which caused this bug.

The ultimate goal is to replace this custom form updating with Formik after we've set up a few unit tests, but as we are getting ready for usability testing I've opted for the simplest solution.

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
