### PR TITLE
fix: Clear search box when search query empty

### DIFF
--- a/dev-client/src/components/home/MapSearch.tsx
+++ b/dev-client/src/components/home/MapSearch.tsx
@@ -42,9 +42,7 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
   const {t} = useTranslation();
   const [query, setQuery] = useState('');
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
-  const [_abortController, setAbortController] =
-    useState<AbortController | null>(null);
-  //const [isLoading, setIsLoading] = useState(false);
+  const [, setAbortController] = useState<AbortController | null>(null);
   const [hideResults, setHideResults] = useState(false);
 
   async function makeSuggestionsApiCall(queryText: string) {

--- a/dev-client/src/components/home/mapSearch.ts
+++ b/dev-client/src/components/home/mapSearch.ts
@@ -63,11 +63,12 @@ export function initMapSearch() {
    *       would this be more reliable than relying on IP
    * TODO: For US version we can restrict queries to country
    */
-  const getSuggestions = async (query: string) => {
+  const getSuggestions = async (query: string, signal: AbortSignal) => {
     try {
       const resp = await fetch(
         `${BASE_URI}/suggest?` +
           `q=${query}&access_token=${ACCESS_TOKEN}&session_token=${session.token}&types=place,address,street,block,poi`,
+        {signal},
       );
       const payload = (await checkResponse(resp)) as SuggestionResponse;
       return payload;


### PR DESCRIPTION
## Description

Uses the Web API [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/AbortController) to cancel requests that are still pending when a previous request is triggered. Previously this would often happen with short strings, where the search request for a shorter string takes longer than a longer string.

- Request 1 triggered.
- Request 2 triggered.
- Request 2 completes.
- Request 1 completes.

The results of Request 1 would overwrite Request 2.

This was particularly a problem when trying to reset the search results, because setting the react state takes much less time than making a HTTP request. So it would be something like:

- Request triggered for query of length 2
- Suggestions cleared when user continues deleting
- Request completes, and suggestions set with this result.

Which is why this needed to completed to fix this bug.
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
