### PR TITLE
fix: map icon size and resolution

### DIFF
--- a/dev-client/src/components/common/Map.tsx
+++ b/dev-client/src/components/common/Map.tsx
@@ -1,5 +1,5 @@
 import Mapbox from '@rnmapbox/maps';
-import {PixelRatio, StyleProp, ViewStyle} from 'react-native';
+import {PixelRatio, Platform, StyleProp, ViewStyle} from 'react-native';
 import {Icon} from './Icons';
 import {Coords} from '../../model/map/mapSlice';
 import {Position} from '@rnmapbox/maps/lib/typescript/types/Position';
@@ -24,7 +24,7 @@ export const positionToCoords = ([longitude, latitude]: Position): Coords => ({
 });
 
 export const mapIconSizeForPlatform = (size: number) =>
-  Math.round(size * PixelRatio.get());
+  Math.round(size * Platform.select({android: PixelRatio.get(), default: 1}));
 
 export const StaticMapView = ({
   coords,

--- a/dev-client/src/components/common/Map.tsx
+++ b/dev-client/src/components/common/Map.tsx
@@ -1,5 +1,5 @@
 import Mapbox from '@rnmapbox/maps';
-import {StyleProp, ViewStyle} from 'react-native';
+import {PixelRatio, StyleProp, ViewStyle} from 'react-native';
 import {Icon} from './Icons';
 import {Coords} from '../../model/map/mapSlice';
 import {Position} from '@rnmapbox/maps/lib/typescript/types/Position';
@@ -22,6 +22,9 @@ export const positionToCoords = ([longitude, latitude]: Position): Coords => ({
   latitude,
   longitude,
 });
+
+export const mapIconSizeForPlatform = (size: number) =>
+  Math.round(size * PixelRatio.get());
 
 export const StaticMapView = ({
   coords,

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -2,7 +2,7 @@ import Mapbox, {Camera, Location, UserLocation} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/src/types/OnPressEvent';
 import {memo, useMemo, useCallback, forwardRef, ForwardedRef} from 'react';
 import {Card, CardCloseButton} from '../common/Card';
-import MapIcon from 'react-native-vector-icons/MaterialIcons';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 import {Site} from 'terraso-client-shared/site/siteSlice';
 import {Box, Row, Text, Divider, Button, useTheme, Column} from 'native-base';
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from '../../constants';
@@ -12,7 +12,7 @@ import {CameraRef} from '@rnmapbox/maps/lib/typescript/components/Camera';
 import {SiteCard} from '../sites/SiteCard';
 import {Keyboard, StyleSheet} from 'react-native';
 import {CalloutState} from '../../screens/HomeScreen';
-import {positionToCoords} from '../common/Map';
+import {mapIconSizeForPlatform, positionToCoords} from '../common/Map';
 import {Coords} from '../../model/map/mapSlice';
 
 type SiteMapProps = {
@@ -199,6 +199,22 @@ const SiteMap = (
     [setCalloutState],
   );
 
+  const mapImages = useMemo(
+    () => ({
+      sitePin: Icon.getImageSourceSync(
+        'location-on',
+        mapIconSizeForPlatform(35),
+        colors.secondary.main,
+      ),
+      temporarySitePin: Icon.getImageSourceSync(
+        'location-on',
+        mapIconSizeForPlatform(35),
+        colors.action.active,
+      ),
+    }),
+    [colors],
+  );
+
   return (
     <Mapbox.MapView
       style={styles.mapView}
@@ -207,21 +223,7 @@ const SiteMap = (
       scaleBarEnabled={false}
       styleURL={styleURL}>
       <Camera ref={ref} />
-      <Mapbox.Images
-        onImageMissing={console.debug}
-        images={{
-          sitePin: MapIcon.getImageSourceSync(
-            'location-on',
-            undefined,
-            colors.secondary.main,
-          ),
-          temporarySitePin: MapIcon.getImageSourceSync(
-            'location-on',
-            undefined,
-            colors.action.active,
-          ),
-        }}
-      />
+      <Mapbox.Images onImageMissing={console.debug} images={mapImages} />
       <Mapbox.ShapeSource
         id="sitesSource"
         shape={sitesFeature}
@@ -266,13 +268,11 @@ const mapStyles = {
   siteLayer: {
     iconAllowOverlap: true,
     iconAnchor: 'bottom',
-    iconSize: 4.0,
     iconImage: 'sitePin',
   } satisfies Mapbox.SymbolLayerStyle,
   temporarySiteLayer: {
     iconAllowOverlap: true,
     iconAnchor: 'bottom',
-    iconSize: 4.0,
     iconImage: 'temporarySitePin',
   } satisfies Mapbox.SymbolLayerStyle,
 };

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -26,11 +26,11 @@ export const theme = extendTheme({
       800: '#424242',
     },
     action: {
-      active: '#1A202CB2',
+      active: '#1A202C',
     },
     text: {
-      primary: '#1A202CCC',
-      secondary: '#1A202CCC',
+      primary: '#1A202C',
+      secondary: '#1A202C',
     },
   },
   radii: {


### PR DESCRIPTION
## Description
I think what is happening here is we're working around a bug in rnmapbox where they ignore the `scale` attribute of RN `ImageSource`s passed into the `Mapbox.Images` component on Android only. We do this by selectively multiplying the icon size by the pixel ratio on Android only. I'd like paul to confirm it looks good on his iOS dev setup before merging, but i think we still won't know until we push a release with this fix.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes (hopefully, once QA'd) #192, #367, #316, and #365

### Verification steps
Map icons should be the correct size and not pixelated on all platforms.