### PR TITLE
fix: remove empty left marrgin

### DIFF
--- a/dev-client/src/components/sites/LocationDashboardScreen.tsx
+++ b/dev-client/src/components/sites/LocationDashboardScreen.tsx
@@ -153,7 +153,6 @@ export const LocationDashboardScreen = ({siteId, coords}: Props) => {
                 name: 'site-privacy',
                 onChange: onSitePrivacyChanged,
                 value: site.privacy,
-                ml: '',
               }}
             />
           )}


### PR DESCRIPTION
## Description
Remove empty (`''`) left margin on site page. Removes warning message.

### Related Issues
Fixes #397.