### PR TITLE
feat: home screen site pin clustering

### DIFF
--- a/dev-client/src/components/common/Card.tsx
+++ b/dev-client/src/components/common/Card.tsx
@@ -34,11 +34,13 @@ type CardProps = {
   buttons?: React.ReactNode;
   children?: React.ReactNode;
   onPress?: () => void;
-};
-export const Card = ({buttons, onPress, children}: CardProps) => {
+} & React.ComponentProps<typeof Box>;
+export const Card = ({buttons, onPress, children, ...boxProps}: CardProps) => {
   return (
     <Pressable onPress={onPress}>
-      <Box variant="card">{children}</Box>
+      <Box variant="card" {...boxProps}>
+        {children}
+      </Box>
       {buttons}
     </Pressable>
   );

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -44,8 +44,13 @@ export type CalloutState =
     }
   | {
       kind: 'location';
-      coords: Coords;
       showCallout: boolean;
+      coords: Coords;
+    }
+  | {
+      kind: 'site_cluster';
+      siteIds: string[];
+      coords: Coords;
     }
   | {kind: 'none'};
 
@@ -67,7 +72,7 @@ export const HomeScreen = () => {
   const siteList = useMemo(() => Object.values(sites), [sites]);
   const currentUserLocation = useSelector(state => state.map.userLocation);
   const dispatch = useDispatch();
-  const camera = useRef<Camera | null>(null);
+  const camera = useRef<Camera>(null);
   const {
     results: searchedSites,
     query: sitesQuery,
@@ -190,7 +195,6 @@ export const HomeScreen = () => {
               calloutState={calloutState}
               setCalloutState={setCalloutState}
               styleURL={mapStyleURL}
-              onCreateSite={onCreateSite}
             />
           </Box>
           <SiteListBottomSheet


### PR DESCRIPTION
## Description
Site pins on the home screen are now clustered when they are close together. Clicking a cluster will zoom in on it enough to split up the cluster when zoomed out, or show a list if already zoomed in a lot. Clicking a list item will close the list and open the callout for that site. Also resolved some of the things from #333 and #405 while I was monkeying around in the map code.

Limitations: 
- uses a circle for clusters instead of the chip from design. using the chip would require pre-loading images of the chip without text and manually positioning text on the chip using the janky mapbox style API while accounting for platform differences in resolution etc, which is possible but too much effort for a first PR or maybe for MVP
- i couldn't figure out how to make the list scrollable because the map intercepts the gesture and i'm not sure how to prevent that behaviour. so if someone has a large number of sites in the same place it will open a comically large list that can be scrolled by panning the map

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #210 
