### PR TITLE
fix: update lat/lon of create site form as user's location changes

### DIFF
--- a/dev-client/src/model/map/mapSlice.ts
+++ b/dev-client/src/model/map/mapSlice.ts
@@ -1,22 +1,19 @@
 import {PayloadAction, createSlice} from '@reduxjs/toolkit';
-import {Location} from '@rnmapbox/maps';
 
 export type Coords = {
   latitude: number;
   longitude: number;
 };
 
-type MapState = {
-  userLocation?: Location;
+const initialState = {
+  userLocation: null as Coords | null,
 };
-
-const initialState: MapState = {};
 
 const mapSlice = createSlice({
   name: 'map',
   initialState,
   reducers: {
-    updateLocation(state, action: PayloadAction<Location>) {
+    updateLocation(state, action: PayloadAction<Coords>) {
       state.userLocation = action.payload;
     },
   },

--- a/dev-client/src/screens/AppScaffold.tsx
+++ b/dev-client/src/screens/AppScaffold.tsx
@@ -21,6 +21,9 @@ import {useNavigation as useNavigationNative} from '@react-navigation/native';
 import {LocationDashboardScreen} from '../components/sites/LocationDashboardScreen';
 import {SiteSettingsScreen} from '../components/sites/SiteSettingsScreen';
 import {SiteTeamSettingsScreen} from '../components/sites/SiteTeamSettings';
+import {Location, locationManager} from '@rnmapbox/maps';
+import {updateLocation} from '../model/map/mapSlice';
+import {USER_DISPLACEMENT_MIN_DISTANCE_M} from '../constants';
 
 const screenDefinitions = {
   LOGIN: LoginScreen,
@@ -76,6 +79,13 @@ export default function AppScaffold() {
       dispatch(fetchUser());
     }
   }, [hasToken, currentUser, dispatch]);
+
+  useEffect(() => {
+    const listener = ({coords}: Location) => dispatch(updateLocation(coords));
+    locationManager.setMinDisplacement(USER_DISPLACEMENT_MIN_DISTANCE_M);
+    locationManager.addListener(listener);
+    return () => locationManager.removeListener(listener);
+  }, [dispatch]);
 
   return (
     <RootStack.Navigator

--- a/dev-client/src/screens/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen.tsx
@@ -1,6 +1,6 @@
 import {useCallback} from 'react';
 import CreateSiteView from '../components/sites/CreateSiteView';
-import {useDispatch, useSelector} from '../model/store';
+import {useDispatch} from '../model/store';
 import {
   addSite,
   fetchSitesForProject,
@@ -20,7 +20,6 @@ type Props =
   | undefined;
 
 export const CreateSiteScreen = (props: Props = {}) => {
-  const userLocation = useSelector(state => state.map.userLocation);
   const dispatch = useDispatch();
 
   const createSiteCallback = useCallback(
@@ -44,7 +43,6 @@ export const CreateSiteScreen = (props: Props = {}) => {
       BottomNavigation={null}
       AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
       <CreateSiteView
-        userLocation={userLocation}
         createSiteCallback={createSiteCallback}
         defaultProject={'projectId' in props ? props.projectId : undefined}
         sitePin={'coords' in props ? props.coords : undefined}


### PR DESCRIPTION
## Description
Moves the logic that updates user's location to the root of the app, and modifies the create site form to keep the lat/lon fields updated as the user moves.

### Checklist
- [x] Corresponding issue has been opened


### Related Issues
Fixes #256

### Verification steps
Latitude/longitude field of create site form should update as user moves around.