### PR TITLE
feat: site dashboard scaffolding!

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-svg": "^13.13.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-vector-icons": "^10.0.0",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#25aef81",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#696a506",
         "uuid": "^9.0.1",
         "yup": "^1.3.2"
       },
@@ -18672,18 +18672,18 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#83c09df779d035413847a2ef8d6af6246ef0c40b"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#9898e6b52ba47a6e4454153ab24bfe5d66df10c9"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#25aef81483fc7e3d014de70b89619e7178738253",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#696a506e3e878ec685bde63ac2fb9b5a181d3325",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#83c09df",
+        "terraso-backend": "github:techmatters/terraso-backend#9898e6b",
         "uuid": "^9.0.1"
       }
     },

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-svg": "^13.13.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-vector-icons": "^10.0.0",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#9dc6d41",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#fbdcacd",
         "uuid": "^9.0.1",
         "yup": "^1.3.2"
       },
@@ -18672,18 +18672,18 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#a0281eeb0739da3caebe5068864d1a0afb26bc5f"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#5476cb6b79d3a269a4f6ed5d934c3fc68c555244"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#9dc6d41ef4afdb1dbfcd83388ab67a389a558e8c",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#fbdcacd5b73be4950e67b8cafe5a7e5f20bf2295",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#a0281ee",
+        "terraso-backend": "github:techmatters/terraso-backend#5476cb6",
         "uuid": "^9.0.1"
       }
     },

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-svg": "^13.13.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-vector-icons": "^10.0.0",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#d96a909",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#25aef81",
         "uuid": "^9.0.1",
         "yup": "^1.3.2"
       },
@@ -18672,18 +18672,18 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#4170565525a1b85462685d4e2c861a3cfeec7fba"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#83c09df779d035413847a2ef8d6af6246ef0c40b"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#d96a909820857e1f7ea66935979db38b7fe2f3eb",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#25aef81483fc7e3d014de70b89619e7178738253",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#4929e5f",
+        "terraso-backend": "github:techmatters/terraso-backend#83c09df",
         "uuid": "^9.0.1"
       }
     },

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-svg": "^13.13.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-vector-icons": "^10.0.0",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#696a506",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#9dc6d41",
         "uuid": "^9.0.1",
         "yup": "^1.3.2"
       },
@@ -18672,18 +18672,18 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#9898e6b52ba47a6e4454153ab24bfe5d66df10c9"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#a0281eeb0739da3caebe5068864d1a0afb26bc5f"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#696a506e3e878ec685bde63ac2fb9b5a181d3325",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#9dc6d41ef4afdb1dbfcd83388ab67a389a558e8c",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#9898e6b",
+        "terraso-backend": "github:techmatters/terraso-backend#a0281ee",
         "uuid": "^9.0.1"
       }
     },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -39,7 +39,7 @@
     "react-native-svg": "^13.13.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.0.0",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#9dc6d41",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#fbdcacd",
     "uuid": "^9.0.1",
     "yup": "^1.3.2"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -39,7 +39,7 @@
     "react-native-svg": "^13.13.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.0.0",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#696a506",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#9dc6d41",
     "uuid": "^9.0.1",
     "yup": "^1.3.2"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -39,7 +39,7 @@
     "react-native-svg": "^13.13.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.0.0",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#25aef81",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#696a506",
     "uuid": "^9.0.1",
     "yup": "^1.3.2"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -39,7 +39,7 @@
     "react-native-svg": "^13.13.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.0.0",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#d96a909",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#25aef81",
     "uuid": "^9.0.1",
     "yup": "^1.3.2"
   },

--- a/dev-client/src/components/common/Modal.tsx
+++ b/dev-client/src/components/common/Modal.tsx
@@ -14,7 +14,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import {useHeaderHeight} from '../../screens/ScreenScaffold';
 import {CardCloseButton} from './Card';
-import {Pressable} from 'react-native';
+import {Pressable, StyleSheet} from 'react-native';
 import {useDisclose, Modal as NativeBaseModal} from 'native-base';
 import {KeyboardAvoidingView} from 'react-native';
 
@@ -44,7 +44,7 @@ export const Modal = forwardRef<ModalMethods, Props>(
         )}
         <NativeBaseModal isOpen={isOpen} onClose={onClose}>
           <KeyboardAvoidingView
-            style={{width: '100%', alignItems: 'center'}}
+            style={styles.nativeBaseModalChild}
             behavior="padding"
             keyboardVerticalOffset={100}>
             <NativeBaseModal.Content padding="18px">
@@ -101,3 +101,10 @@ export const BottomSheetModal = forwardRef<ModalMethods, Props>(
 const BackdropComponent = (props: BottomSheetBackdropProps) => (
   <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} />
 );
+
+const styles = StyleSheet.create({
+  nativeBaseModalChild: {
+    width: '100%',
+    alignItems: 'center',
+  },
+});

--- a/dev-client/src/components/common/Modal.tsx
+++ b/dev-client/src/components/common/Modal.tsx
@@ -1,0 +1,103 @@
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
+import {
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetScrollView,
+  BottomSheetModal as GorhomBottomSheetModal,
+} from '@gorhom/bottom-sheet';
+import {useHeaderHeight} from '../../screens/ScreenScaffold';
+import {CardCloseButton} from './Card';
+import {Pressable} from 'react-native';
+import {useDisclose, Modal as NativeBaseModal} from 'native-base';
+import {KeyboardAvoidingView} from 'react-native';
+
+type ModalMethods = {
+  onClose: () => void;
+  onOpen: () => void;
+};
+
+const ModalContext = createContext<ModalMethods | undefined>(undefined);
+export const useModal = () => useContext(ModalContext);
+
+type Props = React.PropsWithChildren<{
+  trigger?: (onOpen: () => void) => React.ReactNode;
+}>;
+
+export const Modal = forwardRef<ModalMethods, Props>(
+  ({children, trigger}, forwardedRef) => {
+    const {isOpen, onOpen, onClose} = useDisclose();
+    const methods = useMemo(() => ({onClose, onOpen}), [onOpen, onClose]);
+    useImperativeHandle(forwardedRef, () => methods, [methods]);
+    return (
+      <>
+        {trigger && (
+          <Pressable onPress={methods.onOpen}>
+            {trigger(methods.onOpen)}
+          </Pressable>
+        )}
+        <NativeBaseModal isOpen={isOpen} onClose={onClose}>
+          <KeyboardAvoidingView
+            style={{width: '100%', alignItems: 'center'}}
+            behavior="padding"
+            keyboardVerticalOffset={100}>
+            <NativeBaseModal.Content padding="18px">
+              <CardCloseButton onPress={onClose} />
+              <ModalContext.Provider value={methods}>
+                {children}
+              </ModalContext.Provider>
+            </NativeBaseModal.Content>
+          </KeyboardAvoidingView>
+        </NativeBaseModal>
+      </>
+    );
+  },
+);
+
+export const BottomSheetModal = forwardRef<ModalMethods, Props>(
+  ({children, trigger}, forwardedRef) => {
+    const headerHeight = useHeaderHeight();
+    const ref = useRef<GorhomBottomSheetModal>(null);
+    const methods = useMemo(
+      () => ({
+        onClose: () => ref.current?.dismiss(),
+        onOpen: () => ref.current?.present(),
+      }),
+      [ref],
+    );
+    useImperativeHandle(forwardedRef, () => methods, [methods]);
+
+    return (
+      <>
+        {trigger && (
+          <Pressable onPress={methods.onOpen}>
+            {trigger(methods.onOpen)}
+          </Pressable>
+        )}
+        <GorhomBottomSheetModal
+          ref={ref}
+          handleComponent={null}
+          topInset={headerHeight}
+          backdropComponent={BackdropComponent}
+          enableDynamicSizing>
+          <ModalContext.Provider value={methods}>
+            <BottomSheetScrollView>
+              {children}
+              <CardCloseButton onPress={methods.onClose} />
+            </BottomSheetScrollView>
+          </ModalContext.Provider>
+        </GorhomBottomSheetModal>
+      </>
+    );
+  },
+);
+
+const BackdropComponent = (props: BottomSheetBackdropProps) => (
+  <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} />
+);

--- a/dev-client/src/components/common/SpeedDial.tsx
+++ b/dev-client/src/components/common/SpeedDial.tsx
@@ -1,0 +1,28 @@
+import {useState, useCallback} from 'react';
+import {Column} from 'native-base';
+import {IconButton} from './Icons';
+
+export const SpeedDialButton = (
+  props: React.ComponentProps<typeof IconButton>,
+) => <IconButton variant="FAB" {...props} />;
+
+export const SpeedDial = ({children}: React.PropsWithChildren<{}>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleIsOpen = useCallback(() => setIsOpen(value => !value), []);
+
+  return (
+    <Column
+      alignItems="flex-end"
+      position="absolute"
+      right="16px"
+      bottom="16px"
+      space="16px">
+      {isOpen && children}
+      <IconButton
+        variant="FAB"
+        name={isOpen ? 'close' : 'add'}
+        onPress={toggleIsOpen}
+      />
+    </Column>
+  );
+};

--- a/dev-client/src/components/common/SpeedDial.tsx
+++ b/dev-client/src/components/common/SpeedDial.tsx
@@ -2,10 +2,6 @@ import {useState, useCallback} from 'react';
 import {Column} from 'native-base';
 import {IconButton} from './Icons';
 
-export const SpeedDialButton = (
-  props: React.ComponentProps<typeof IconButton>,
-) => <IconButton variant="FAB" {...props} />;
-
 export const SpeedDial = ({children}: React.PropsWithChildren<{}>) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleIsOpen = useCallback(() => setIsOpen(value => !value), []);
@@ -20,6 +16,7 @@ export const SpeedDial = ({children}: React.PropsWithChildren<{}>) => {
       {isOpen && children}
       <IconButton
         variant="FAB"
+        size="lg"
         name={isOpen ? 'close' : 'add'}
         onPress={toggleIsOpen}
       />

--- a/dev-client/src/components/dataInputs/AddIntervalModal.tsx
+++ b/dev-client/src/components/dataInputs/AddIntervalModal.tsx
@@ -1,0 +1,134 @@
+import {Button, Modal, Row} from 'native-base';
+import {CardCloseButton} from '../common/Card';
+import {Formik} from 'formik';
+import * as yup from 'yup';
+import {FORM_LABEL_MAX} from '../../constants';
+import {useMemo} from 'react';
+import {useSelector} from '../../model/store';
+import {
+  DepthInterval,
+  updateSoilData,
+} from 'terraso-client-shared/soilId/soilIdSlice';
+import {FormInput} from '../common/Form';
+import {useTranslation} from 'react-i18next';
+
+type Props = {
+  siteId: string;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const AddIntervalModal = ({siteId, isOpen, onClose}: Props) => {
+  const {t} = useTranslation();
+  const existingIntervals = useSelector(
+    state => state.soilId.soilData[siteId].depthIntervals,
+  );
+
+  const schema = useMemo(
+    () =>
+      yup.object({
+        name: yup
+          .string()
+          .max(
+            FORM_LABEL_MAX,
+            t('site.depth_interval.label_help', {max: FORM_LABEL_MAX}),
+          ),
+        start: yup
+          .number()
+          .min(0)
+          .required()
+          .test((start, {createError}) => {
+            if (
+              existingIntervals.some(
+                interval => start >= interval.start && start < interval.end,
+              )
+            ) {
+              return createError({message: 'overlap'});
+            }
+            return true;
+          }),
+        end: yup
+          .number()
+          .max(200)
+          .required()
+          .test((end, {createError, parent}) => {
+            if (
+              existingIntervals.some(
+                interval => end > interval.start && end <= interval.end,
+              )
+            ) {
+              return createError({message: 'overlap'});
+            } else if (parent.start >= end) {
+              return createError({message: 'ordering'});
+            }
+            return true;
+          }),
+      }),
+    [t, existingIntervals],
+  );
+
+  const onSubmit = (values: DepthInterval) => {
+    const index = existingIntervals.findIndex(
+      existing => existing.end <= values.start,
+    );
+    const newIntervals =
+      index === -1
+        ? [values, ...existingIntervals]
+        : [
+            ...existingIntervals.slice(0, index + 1),
+            values,
+            ...existingIntervals.slice(index + 2),
+          ];
+    updateSoilData({siteId, depthIntervals: newIntervals});
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal.Content>
+        <CardCloseButton onPress={onClose} />
+        <Formik
+          validationSchema={schema}
+          initialValues={{
+            name: '',
+            start: '',
+            end: '',
+          }}
+          onSubmit={values => onSubmit(schema.validateSync(values))}>
+          {({handleSubmit, isValid, isSubmitting}) => (
+            <>
+              <FormInput
+                name="name"
+                helpText={t('site.depth_interval.label_help')}
+                placeholder={t('site.depth_interval.label_placeholder')}
+                variant="underlined"
+              />
+              <Row justifyContent="space-between" space="40px">
+                <FormInput
+                  name="start"
+                  variant="underlined"
+                  label={t('site.depth_interval.start_label', {
+                    unit: 'cm',
+                  })}
+                />
+                <FormInput
+                  name="end"
+                  variant="underlined"
+                  label={t('site.depth_interval.end_label', {
+                    unit: 'cm',
+                  })}
+                />
+              </Row>
+              <Button
+                size="lg"
+                mx="auto"
+                onPress={() => handleSubmit()}
+                isDisabled={!isValid || isSubmitting}>
+                {t('general.add')}
+              </Button>
+            </>
+          )}
+        </Formik>
+      </Modal.Content>
+    </Modal>
+  );
+};

--- a/dev-client/src/components/dataInputs/AddIntervalModal.tsx
+++ b/dev-client/src/components/dataInputs/AddIntervalModal.tsx
@@ -5,20 +5,13 @@ import {
   DepthInterval,
   LabelledDepthInterval,
 } from 'terraso-client-shared/soilId/soilIdSlice';
-import {FormInput} from '../common/Form';
 import {useTranslation} from 'react-i18next';
-import {intervalSchema, IntervalForm} from './IntervalForm';
+import {intervalSchema, IntervalForm, IntervalFormInput} from './IntervalForm';
 import {useModal} from '../common/Modal';
 
 type Props = {
   onSubmit: (_: LabelledDepthInterval) => Promise<void>;
   existingIntervals: DepthInterval[];
-};
-
-type FormInput = {
-  label: string;
-  start: string;
-  end: string;
 };
 
 export const AddIntervalModal = ({
@@ -33,14 +26,14 @@ export const AddIntervalModal = ({
     [t, existingIntervals],
   );
 
-  const onSubmit = async (values: FormInput) => {
+  const onSubmit = async (values: IntervalFormInput) => {
     const {label, ...depthInterval} = schema.cast(values);
     await parentOnSubmit({label: label ?? '', depthInterval});
     onClose();
   };
 
   return (
-    <Formik<FormInput>
+    <Formik<IntervalFormInput>
       validationSchema={schema}
       initialValues={{
         label: '',

--- a/dev-client/src/components/dataInputs/AddIntervalModal.tsx
+++ b/dev-client/src/components/dataInputs/AddIntervalModal.tsx
@@ -1,134 +1,68 @@
-import {Button, Modal, Row} from 'native-base';
-import {CardCloseButton} from '../common/Card';
+import {Box, Button, Heading} from 'native-base';
 import {Formik} from 'formik';
-import * as yup from 'yup';
-import {FORM_LABEL_MAX} from '../../constants';
 import {useMemo} from 'react';
-import {useSelector} from '../../model/store';
 import {
   DepthInterval,
-  updateSoilData,
+  LabelledDepthInterval,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 import {FormInput} from '../common/Form';
 import {useTranslation} from 'react-i18next';
+import {intervalSchema, IntervalForm} from './IntervalForm';
+import {useModal} from '../common/Modal';
 
 type Props = {
-  siteId: string;
-  isOpen: boolean;
-  onClose: () => void;
+  onSubmit: (_: LabelledDepthInterval) => Promise<void>;
+  existingIntervals: DepthInterval[];
 };
 
-export const AddIntervalModal = ({siteId, isOpen, onClose}: Props) => {
+type FormInput = {
+  label: string;
+  start: string;
+  end: string;
+};
+
+export const AddIntervalModal = ({
+  onSubmit: parentOnSubmit,
+  existingIntervals,
+}: Props) => {
   const {t} = useTranslation();
-  const existingIntervals = useSelector(
-    state => state.soilId.soilData[siteId].depthIntervals,
-  );
+  const onClose = useModal()!.onClose;
 
   const schema = useMemo(
-    () =>
-      yup.object({
-        name: yup
-          .string()
-          .max(
-            FORM_LABEL_MAX,
-            t('site.depth_interval.label_help', {max: FORM_LABEL_MAX}),
-          ),
-        start: yup
-          .number()
-          .min(0)
-          .required()
-          .test((start, {createError}) => {
-            if (
-              existingIntervals.some(
-                interval => start >= interval.start && start < interval.end,
-              )
-            ) {
-              return createError({message: 'overlap'});
-            }
-            return true;
-          }),
-        end: yup
-          .number()
-          .max(200)
-          .required()
-          .test((end, {createError, parent}) => {
-            if (
-              existingIntervals.some(
-                interval => end > interval.start && end <= interval.end,
-              )
-            ) {
-              return createError({message: 'overlap'});
-            } else if (parent.start >= end) {
-              return createError({message: 'ordering'});
-            }
-            return true;
-          }),
-      }),
+    () => intervalSchema({t, existingIntervals}),
     [t, existingIntervals],
   );
 
-  const onSubmit = (values: DepthInterval) => {
-    const index = existingIntervals.findIndex(
-      existing => existing.end <= values.start,
-    );
-    const newIntervals =
-      index === -1
-        ? [values, ...existingIntervals]
-        : [
-            ...existingIntervals.slice(0, index + 1),
-            values,
-            ...existingIntervals.slice(index + 2),
-          ];
-    updateSoilData({siteId, depthIntervals: newIntervals});
+  const onSubmit = async (values: FormInput) => {
+    const {label, ...depthInterval} = schema.cast(values);
+    await parentOnSubmit({label: label ?? '', depthInterval});
+    onClose();
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
-      <Modal.Content>
-        <CardCloseButton onPress={onClose} />
-        <Formik
-          validationSchema={schema}
-          initialValues={{
-            name: '',
-            start: '',
-            end: '',
-          }}
-          onSubmit={values => onSubmit(schema.validateSync(values))}>
-          {({handleSubmit, isValid, isSubmitting}) => (
-            <>
-              <FormInput
-                name="name"
-                helpText={t('site.depth_interval.label_help')}
-                placeholder={t('site.depth_interval.label_placeholder')}
-                variant="underlined"
-              />
-              <Row justifyContent="space-between" space="40px">
-                <FormInput
-                  name="start"
-                  variant="underlined"
-                  label={t('site.depth_interval.start_label', {
-                    unit: 'cm',
-                  })}
-                />
-                <FormInput
-                  name="end"
-                  variant="underlined"
-                  label={t('site.depth_interval.end_label', {
-                    unit: 'cm',
-                  })}
-                />
-              </Row>
-              <Button
-                size="lg"
-                mx="auto"
-                onPress={() => handleSubmit()}
-                isDisabled={!isValid || isSubmitting}>
-                {t('general.add')}
-              </Button>
-            </>
-          )}
-        </Formik>
-      </Modal.Content>
-    </Modal>
+    <Formik<FormInput>
+      validationSchema={schema}
+      initialValues={{
+        label: '',
+        start: '',
+        end: '',
+      }}
+      onSubmit={onSubmit}>
+      {({handleSubmit, isValid, isSubmitting}) => (
+        <>
+          <Heading variant="h6">{t('soil.depth_interval.add_title')}</Heading>
+          <Box height="20px" />
+          <IntervalForm />
+          <Box height="50px" />
+          <Button
+            size="lg"
+            mx="auto"
+            onPress={() => handleSubmit()}
+            isDisabled={!isValid || isSubmitting}>
+            {t('general.add')}
+          </Button>
+        </>
+      )}
+    </Formik>
   );
 };

--- a/dev-client/src/components/dataInputs/EditIntervalModal.tsx
+++ b/dev-client/src/components/dataInputs/EditIntervalModal.tsx
@@ -5,16 +5,22 @@ import {
   updateSoilDataDepthInterval,
   soilPitMethods,
   methodEnabled,
+  SoilDataDepthInterval,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 import {fromEntries} from 'terraso-client-shared/utils';
 import {useMemo, useCallback} from 'react';
-import {intervalSchema, IntervalForm} from './IntervalForm';
+import {intervalSchema, IntervalForm, IntervalFormInput} from './IntervalForm';
 import * as yup from 'yup';
 import {useTranslation} from 'react-i18next';
 import {Heading, Row, Box, Button} from 'native-base';
 import {Formik} from 'formik';
 import {FormCheckbox, FormSwitch} from '../common/Form';
 import {useModal} from '../common/Modal';
+
+type EditIntervalFormInput = IntervalFormInput &
+  Omit<SoilDataDepthInterval, 'label' | 'depthInterval'> & {
+    applyToAll: boolean;
+  };
 
 type Props = {
   siteId: string;
@@ -49,7 +55,9 @@ export const EditIntervalModal = ({siteId, depthInterval}: Props) => {
   );
 
   const onSubmit = useCallback(
-    async values => {
+    async (values: EditIntervalFormInput) => {
+      // TODO: actually use the applyToAll variable
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {start, end, applyToAll, ...newInterval} = schema.cast(values);
       await dispatch(
         updateSoilDataDepthInterval({

--- a/dev-client/src/components/dataInputs/EditIntervalModal.tsx
+++ b/dev-client/src/components/dataInputs/EditIntervalModal.tsx
@@ -1,0 +1,118 @@
+import {useDispatch, useSelector} from '../../model/store';
+import {
+  DepthInterval,
+  sameDepth,
+  updateSoilDataDepthInterval,
+  soilPitMethods,
+  methodEnabled,
+} from 'terraso-client-shared/soilId/soilIdSlice';
+import {fromEntries} from 'terraso-client-shared/utils';
+import {useMemo, useCallback} from 'react';
+import {intervalSchema, IntervalForm} from './IntervalForm';
+import * as yup from 'yup';
+import {useTranslation} from 'react-i18next';
+import {Heading, Row, Box, Button} from 'native-base';
+import {Formik} from 'formik';
+import {FormCheckbox, FormSwitch} from '../common/Form';
+import {useModal} from '../common/Modal';
+
+type Props = {
+  siteId: string;
+  depthInterval: DepthInterval;
+};
+export const EditIntervalModal = ({siteId, depthInterval}: Props) => {
+  const {t} = useTranslation();
+  const soilData = useSelector(state => state.soilId.soilData[siteId]);
+  const dispatch = useDispatch();
+  const onClose = useModal()!.onClose;
+
+  const existingIntervals = useMemo(
+    () => soilData.depthIntervals.map(interval => interval.depthInterval),
+    [soilData.depthIntervals],
+  );
+  const interval = useMemo(
+    () => soilData.depthIntervals.find(sameDepth({depthInterval}))!,
+    [soilData.depthIntervals, depthInterval],
+  );
+
+  const schema = useMemo(
+    () =>
+      intervalSchema({t, existingIntervals}).shape({
+        applyToAll: yup.boolean().required(),
+        ...fromEntries(
+          soilPitMethods
+            .map(methodEnabled)
+            .map(method => [method, yup.boolean().required()]),
+        ),
+      }),
+    [t, existingIntervals],
+  );
+
+  const onSubmit = useCallback(
+    async values => {
+      const {start, end, applyToAll, ...newInterval} = schema.cast(values);
+      await dispatch(
+        updateSoilDataDepthInterval({
+          siteId,
+          ...newInterval,
+          depthInterval: {start, end},
+        }),
+      );
+      onClose();
+    },
+    [schema, dispatch, onClose, siteId],
+  );
+
+  return (
+    <Formik
+      validationSchema={schema}
+      initialValues={{
+        ...interval,
+        start: '',
+        end: '',
+        applyToAll: false,
+      }}
+      onSubmit={onSubmit}>
+      {({handleSubmit, isValid, isSubmitting}) => (
+        <>
+          <Heading variant="h6">{t('soil.depth_interval.edit_title')}</Heading>
+          <Box height="20px" />
+          <IntervalForm />
+          <Box height="50px" />
+          <Heading variant="h6">
+            {t('soil.depth_interval.data_inputs_title')}
+          </Heading>
+          {soilPitMethods.map(method => (
+            <FormSwitch
+              name={methodEnabled(method)}
+              value={interval[methodEnabled(method)]}
+              onChange={value =>
+                dispatch(
+                  updateSoilDataDepthInterval({
+                    siteId,
+                    depthInterval,
+                    [methodEnabled(method)]: value,
+                  }),
+                )
+              }
+              label={t(`soil.collection_method.${method}`)}
+            />
+          ))}
+          <FormCheckbox
+            name="applyToAll"
+            label={t('soil.depth_interval.apply_to_all_label')}
+          />
+          <Row>
+            <Button
+              size="lg"
+              mx="auto"
+              onPress={() => handleSubmit()}
+              isDisabled={!isValid || isSubmitting}>
+              {t('general.add')}
+            </Button>
+          </Row>
+        </>
+      )}
+    </Formik>
+  );
+};

--- a/dev-client/src/components/dataInputs/IntervalForm.tsx
+++ b/dev-client/src/components/dataInputs/IntervalForm.tsx
@@ -50,6 +50,12 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       }),
   });
 
+export type IntervalFormInput = {
+  label: string;
+  start: string;
+  end: string;
+};
+
 export const IntervalForm = () => {
   const {t} = useTranslation();
   return (

--- a/dev-client/src/components/dataInputs/IntervalForm.tsx
+++ b/dev-client/src/components/dataInputs/IntervalForm.tsx
@@ -1,0 +1,88 @@
+import * as yup from 'yup';
+import {FORM_LABEL_MAX} from '../../constants';
+import {DepthInterval} from 'terraso-client-shared/soilId/soilIdSlice';
+import {TFunction} from 'i18next';
+import {useTranslation} from 'react-i18next';
+import {FormInput} from '../common/Form';
+import {Box, Row} from 'native-base';
+
+type Args = {
+  t: TFunction;
+  existingIntervals: DepthInterval[];
+};
+export const intervalSchema = ({t, existingIntervals}: Args) =>
+  yup.object({
+    label: yup
+      .string()
+      .max(
+        FORM_LABEL_MAX,
+        t('soil.depth_interval.label_help', {max: FORM_LABEL_MAX}),
+      ),
+    start: yup
+      .number()
+      .min(0)
+      .required()
+      .test((start, {createError}) => {
+        if (
+          existingIntervals.some(
+            interval => start >= interval.start && start < interval.end,
+          )
+        ) {
+          return createError({message: 'overlap'});
+        }
+        return true;
+      }),
+    end: yup
+      .number()
+      .max(200)
+      .required()
+      .test((end, {createError, parent}) => {
+        if (
+          existingIntervals.some(
+            interval => end > interval.start && end <= interval.end,
+          )
+        ) {
+          return createError({message: 'overlap'});
+        } else if (parent.start >= end) {
+          return createError({message: 'ordering'});
+        }
+        return true;
+      }),
+  });
+
+export const IntervalForm = () => {
+  const {t} = useTranslation();
+  return (
+    <>
+      <FormInput
+        name="label"
+        helpText={t('soil.depth_interval.label_help', {
+          max: FORM_LABEL_MAX,
+        })}
+        placeholder={t('soil.depth_interval.label_placeholder')}
+        variant="underlined"
+      />
+      <Box height="20px" />
+      <Row justifyContent="space-between" space="40px">
+        <Box flex={1}>
+          <FormInput
+            name="start"
+            variant="underlined"
+            placeholder={t('soil.depth_interval.start_label', {
+              unit: 'cm',
+            })}
+          />
+        </Box>
+        <Box flex={1}>
+          <FormInput
+            name="end"
+            variant="underlined"
+            placeholder={t('soil.depth_interval.end_label', {
+              unit: 'cm',
+            })}
+          />
+        </Box>
+      </Row>
+    </>
+  );
+};

--- a/dev-client/src/components/dataInputs/SlopeScreen.tsx
+++ b/dev-client/src/components/dataInputs/SlopeScreen.tsx
@@ -1,0 +1,5 @@
+import {Text} from 'native-base';
+
+export const SlopeScreen = (_: {siteId: string}) => {
+  return <Text margin="auto">Unimplemented slope screen</Text>;
+};

--- a/dev-client/src/components/dataInputs/SoilScreen.tsx
+++ b/dev-client/src/components/dataInputs/SoilScreen.tsx
@@ -9,12 +9,15 @@ import {EditIntervalModal} from './EditIntervalModal';
 import {useMemo, useCallback} from 'react';
 import {
   LabelledDepthInterval,
+  SoilData,
   updateSoilDataDepthInterval,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 
 export const SoilScreen = ({siteId}: {siteId: string}) => {
   const {t} = useTranslation();
-  const soilData = useSelector(state => state.soilId.soilData[siteId]);
+  const soilData = useSelector(state => state.soilId.soilData[siteId]) as
+    | SoilData
+    | undefined;
   const project = useSelector(state => {
     const projectId = state.site.sites[siteId].projectId;
     return projectId ? state.soilId.projectSettings[projectId] : undefined;
@@ -23,15 +26,15 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
     () =>
       (project?.depthIntervals ?? [])
         .concat(
-          soilData.depthIntervals.filter(
+          soilData?.depthIntervals?.filter(
             ({depthInterval: a}) =>
               project?.depthIntervals?.every(
                 ({depthInterval: b}) => a.end <= b.start || a.start >= b.end,
               ),
-          ),
+          ) ?? [],
         )
         .sort((a, b) => a.depthInterval.start - b.depthInterval.start),
-    [project?.depthIntervals, soilData.depthIntervals],
+    [project?.depthIntervals, soilData?.depthIntervals],
   );
   const existingIntervals = useMemo(
     () => allIntervals.map(interval => interval.depthInterval),

--- a/dev-client/src/components/dataInputs/SoilScreen.tsx
+++ b/dev-client/src/components/dataInputs/SoilScreen.tsx
@@ -1,0 +1,49 @@
+import {Box, Button, Column, Heading, Row, useDisclose} from 'native-base';
+import {useSelector} from '../../model/store';
+import {useTranslation} from 'react-i18next';
+import {Icon, IconButton} from '../common/Icons';
+import {AddIntervalModal} from './AddIntervalModal';
+
+export const SoilScreen = ({siteId}: {siteId: string}) => {
+  const {t} = useTranslation();
+  const {
+    isOpen: addIntervalIsOpen,
+    onOpen: addIntervalOnOpen,
+    onClose: addIntervalOnClose,
+  } = useDisclose();
+  const soilData = useSelector(state => state.soilId.soilData[siteId]);
+
+  return (
+    <>
+      <AddIntervalModal
+        siteId={siteId}
+        isOpen={addIntervalIsOpen}
+        onClose={addIntervalOnClose}
+      />
+      <Column backgroundColor="grey.300">
+        <Row backgroundColor="background.default">
+          <Heading variant="h6">{t('soil.profile')}</Heading>
+        </Row>
+        <Box height="16px" />
+        {soilData.depthIntervals.map(interval => (
+          <Row
+            backgroundColor="primary.dark"
+            justifyContent="space-between"
+            px="12px"
+            py="8px">
+            <Heading variant="h6">{`${interval.start}-${interval.end} cm`}</Heading>
+            <IconButton name="more-vert" />
+          </Row>
+        ))}
+        <Button
+          variant="large"
+          color="primary.dark"
+          width="full"
+          leftIcon={<Icon name="add" />}
+          onPress={addIntervalOnOpen}>
+          {t('soil.add_depth_label')}
+        </Button>
+      </Column>
+    </>
+  );
+};

--- a/dev-client/src/components/dataInputs/SoilScreen.tsx
+++ b/dev-client/src/components/dataInputs/SoilScreen.tsx
@@ -1,49 +1,125 @@
-import {Box, Button, Column, Heading, Row, useDisclose} from 'native-base';
-import {useSelector} from '../../model/store';
+import {Box, Button, Column, Heading, Row} from 'native-base';
+import {useDispatch, useSelector} from '../../model/store';
 import {useTranslation} from 'react-i18next';
 import {Icon, IconButton} from '../common/Icons';
 import {AddIntervalModal} from './AddIntervalModal';
+import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {BottomSheetModal, Modal} from '../common/Modal';
+import {EditIntervalModal} from './EditIntervalModal';
+import {useMemo, useCallback} from 'react';
+import {
+  LabelledDepthInterval,
+  updateSoilDataDepthInterval,
+} from 'terraso-client-shared/soilId/soilIdSlice';
 
 export const SoilScreen = ({siteId}: {siteId: string}) => {
   const {t} = useTranslation();
-  const {
-    isOpen: addIntervalIsOpen,
-    onOpen: addIntervalOnOpen,
-    onClose: addIntervalOnClose,
-  } = useDisclose();
   const soilData = useSelector(state => state.soilId.soilData[siteId]);
+  const project = useSelector(state => {
+    const projectId = state.site.sites[siteId].projectId;
+    return projectId ? state.soilId.projectSettings[projectId] : undefined;
+  });
+  const allIntervals = useMemo(
+    () =>
+      (project?.depthIntervals ?? [])
+        .concat(
+          soilData.depthIntervals.filter(
+            ({depthInterval: a}) =>
+              project?.depthIntervals?.every(
+                ({depthInterval: b}) => a.end <= b.start || a.start >= b.end,
+              ),
+          ),
+        )
+        .sort((a, b) => a.depthInterval.start - b.depthInterval.start),
+    [project?.depthIntervals, soilData.depthIntervals],
+  );
+  const existingIntervals = useMemo(
+    () => allIntervals.map(interval => interval.depthInterval),
+    [allIntervals],
+  );
+  const dispatch = useDispatch();
+
+  const onAddDepthInterval = useCallback(
+    async (interval: LabelledDepthInterval) => {
+      await dispatch(updateSoilDataDepthInterval({siteId, ...interval}));
+    },
+    [siteId, dispatch],
+  );
 
   return (
-    <>
-      <AddIntervalModal
-        siteId={siteId}
-        isOpen={addIntervalIsOpen}
-        onClose={addIntervalOnClose}
-      />
+    <BottomSheetModalProvider>
       <Column backgroundColor="grey.300">
-        <Row backgroundColor="background.default">
-          <Heading variant="h6">{t('soil.profile')}</Heading>
+        <Row backgroundColor="background.default" px="16px" py="12px">
+          <Heading variant="h6">{t('soil.surface')}</Heading>
         </Row>
         <Box height="16px" />
-        {soilData.depthIntervals.map(interval => (
-          <Row
-            backgroundColor="primary.dark"
-            justifyContent="space-between"
-            px="12px"
-            py="8px">
-            <Heading variant="h6">{`${interval.start}-${interval.end} cm`}</Heading>
-            <IconButton name="more-vert" />
-          </Row>
+        <Row backgroundColor="background.default" px="16px" py="12px">
+          <Heading variant="h6">{t('soil.pit')}</Heading>
+        </Row>
+        {allIntervals.map(interval => (
+          <DepthIntervalEditor
+            key={`${interval.depthInterval.start}:${interval.depthInterval.end}`}
+            siteId={siteId}
+            interval={interval}
+          />
         ))}
-        <Button
-          variant="large"
-          color="primary.dark"
-          width="full"
-          leftIcon={<Icon name="add" />}
-          onPress={addIntervalOnOpen}>
-          {t('soil.add_depth_label')}
-        </Button>
+        <Modal
+          trigger={onOpen => (
+            <Button
+              size="lg"
+              variant="fullWidth"
+              backgroundColor="primary.dark"
+              justifyContent="start"
+              _text={{
+                color: 'primary.contrast',
+              }}
+              _icon={{
+                color: 'primary.contrast',
+              }}
+              width="full"
+              borderRadius="0px"
+              leftIcon={<Icon name="add" />}
+              onPress={onOpen}>
+              {t('soil.add_depth_label')}
+            </Button>
+          )}>
+          <AddIntervalModal
+            onSubmit={onAddDepthInterval}
+            existingIntervals={existingIntervals}
+          />
+        </Modal>
       </Column>
-    </>
+    </BottomSheetModalProvider>
+  );
+};
+
+const DepthIntervalEditor = ({
+  siteId,
+  interval: {label, depthInterval},
+}: {
+  siteId: string;
+  interval: LabelledDepthInterval;
+}) => {
+  return (
+    <Row
+      backgroundColor="primary.dark"
+      justifyContent="space-between"
+      px="12px"
+      py="8px">
+      <Heading variant="h6" color="primary.contrast">
+        {label && `${label}: `}
+        {`${depthInterval.start}-${depthInterval.end} cm`}
+      </Heading>
+      <BottomSheetModal
+        trigger={onOpen => (
+          <IconButton
+            name="more-vert"
+            _icon={{color: 'primary.contrast'}}
+            onPress={onOpen}
+          />
+        )}>
+        <EditIntervalModal siteId={siteId} depthInterval={depthInterval} />
+      </BottomSheetModal>
+    </Row>
   );
 };

--- a/dev-client/src/components/projects/CreateProjectView/index.tsx
+++ b/dev-client/src/components/projects/CreateProjectView/index.tsx
@@ -13,8 +13,8 @@ export default function CreateProjectView() {
   const navigation = useNavigation();
   const onSubmit = async (values: ProjectFormValues) => {
     const {payload} = await dispatch(addProject(values));
-    if (payload !== undefined && 'id' in payload) {
-      navigation.replace('PROJECT_VIEW', {projectId: payload.id});
+    if (payload !== undefined && 'project' in payload) {
+      navigation.replace('PROJECT_VIEW', {projectId: payload.project.id});
     }
   };
   const validationSchema = useMemo(() => projectValidationSchema(t), [t]);

--- a/dev-client/src/components/projects/ProjectInputTab.tsx
+++ b/dev-client/src/components/projects/ProjectInputTab.tsx
@@ -1,12 +1,35 @@
-import {Text, VStack} from 'native-base';
+import {Button, Row, Text} from 'native-base';
 import {useTranslation} from 'react-i18next';
 import RadioBlock from '../common/RadioBlock';
+import {Accordion} from '../common/Accordion';
+import {FormSwitch} from '../common/Form';
+import {useDispatch, useSelector} from '../../model/store';
+import {TabRoutes, TabStackParamList} from './constants';
+import {
+  LabelledDepthInterval,
+  collectionMethods,
+  deleteProjectDepthInterval,
+  methodRequired,
+  updateProjectDepthInterval,
+  updateProjectSoilSettings,
+} from 'terraso-client-shared/soilId/soilIdSlice';
+import {Icon, IconButton} from '../common/Icons';
+import {Modal} from '../common/Modal';
+import {AddIntervalModal} from '../dataInputs/AddIntervalModal';
+import {useMemo, useCallback} from 'react';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {ScrollView} from 'react-native';
 
-export default function ProjectInputTab() {
+type Props = NativeStackScreenProps<TabStackParamList, TabRoutes.INPUTS>;
+export const ProjectInputTab = ({
+  route: {
+    params: {projectId},
+  },
+}: Props) => {
   const {t} = useTranslation();
 
   return (
-    <VStack space={3} p={4}>
+    <ScrollView>
       <RadioBlock<'imperial' | 'metric'>
         label={t('projects.inputs.units.heading')}
         options={{
@@ -33,7 +56,96 @@ export default function ProjectInputTab() {
           defaultValue: 'soil-survey',
         }}
       />
-      <Text>Input methods TBD</Text>
-    </VStack>
+      <Accordion Head={<Text>{t('soil.pit')}</Text>}>
+        <SoilPitSettings projectId={projectId} />
+      </Accordion>
+      <Accordion
+        Head={<Text>{t('soil.project_settings.required_data_title')}</Text>}>
+        <RequiredDataSettings projectId={projectId} />
+      </Accordion>
+    </ScrollView>
   );
-}
+};
+
+const SoilPitSettings = ({projectId}: {projectId: string}) => {
+  const {t} = useTranslation();
+  const settings = useSelector(
+    state => state.soilId.projectSettings[projectId],
+  );
+  const allSettings = useSelector(state => state.soilId.projectSettings);
+  console.log(allSettings);
+  console.log(projectId);
+  const dispatch = useDispatch();
+  const existingIntervals = useMemo(
+    () => settings.depthIntervals.map(interval => interval.depthInterval),
+    [settings.depthIntervals],
+  );
+
+  const onAddDepthInterval = useCallback(
+    async (interval: LabelledDepthInterval) => {
+      await dispatch(updateProjectDepthInterval({projectId, ...interval}));
+    },
+    [projectId, dispatch],
+  );
+
+  return (
+    <>
+      {settings.depthIntervals.map(({label, depthInterval}) => (
+        <Row key={`${depthInterval.start}:${depthInterval.end}`}>
+          <Text flex={1}>{label}</Text>
+          <Text flex={1}>{`${depthInterval.start}-${depthInterval.end}`}</Text>
+          <Row flex={1} justifyContent="flex-end">
+            <IconButton
+              name="close"
+              onPress={() =>
+                dispatch(deleteProjectDepthInterval({projectId, depthInterval}))
+              }
+            />
+          </Row>
+        </Row>
+      ))}
+      <Modal
+        trigger={onOpen => (
+          <Button
+            onPress={onOpen}
+            alignSelf="flex-start"
+            leftIcon={<Icon name="add" />}>
+            {t('soil.add_depth_label')}
+          </Button>
+        )}>
+        <AddIntervalModal
+          onSubmit={onAddDepthInterval}
+          existingIntervals={existingIntervals}
+        />
+      </Modal>
+    </>
+  );
+};
+
+const RequiredDataSettings = ({projectId}: {projectId: string}) => {
+  const {t} = useTranslation();
+  const settings = useSelector(
+    state => state.soilId.projectSettings[projectId],
+  );
+  const dispatch = useDispatch();
+
+  return (
+    <>
+      {collectionMethods.map(method => (
+        <FormSwitch
+          name={methodRequired(method)}
+          value={settings[methodRequired(method)]}
+          onChange={value =>
+            dispatch(
+              updateProjectSoilSettings({
+                projectId,
+                [methodRequired(method)]: value,
+              }),
+            )
+          }
+          label={t(`soil.collection_method.${method}`)}
+        />
+      ))}
+    </>
+  );
+};

--- a/dev-client/src/components/projects/ProjectInputTab.tsx
+++ b/dev-client/src/components/projects/ProjectInputTab.tsx
@@ -72,9 +72,6 @@ const SoilPitSettings = ({projectId}: {projectId: string}) => {
   const settings = useSelector(
     state => state.soilId.projectSettings[projectId],
   );
-  const allSettings = useSelector(state => state.soilId.projectSettings);
-  console.log(allSettings);
-  console.log(projectId);
   const dispatch = useDispatch();
   const existingIntervals = useMemo(
     () => settings.depthIntervals.map(interval => interval.depthInterval),

--- a/dev-client/src/components/projects/ProjectPreviewCard.tsx
+++ b/dev-client/src/components/projects/ProjectPreviewCard.tsx
@@ -42,7 +42,7 @@ export default function ProjectPreviewCard({project}: Props) {
           variant="chip"
           backgroundColor="primary.lightest"
           startIcon={<Icon name="location-on" />}>
-          {Object.keys(project.siteIds).length}
+          {Object.keys(project.sites).length}
         </Badge>
         <Badge
           variant="chip"

--- a/dev-client/src/components/projects/ProjectSitesTab.tsx
+++ b/dev-client/src/components/projects/ProjectSitesTab.tsx
@@ -94,7 +94,7 @@ const selectProjectSites = createSelector(
     projectId: string,
   ) => {
     let project = projects[projectId];
-    return Object.keys(project.siteIds)
+    return Object.keys(project.sites)
       .map(id => sites[id])
       .filter(site => site);
   },

--- a/dev-client/src/components/projects/ProjectTabs.tsx
+++ b/dev-client/src/components/projects/ProjectTabs.tsx
@@ -1,5 +1,5 @@
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
-import ProjectInputTab from './ProjectInputTab';
+import {ProjectInputTab} from './ProjectInputTab';
 import ProjectTeamTab from './ProjectTeamTab';
 import {TabRoutes, TabStackParamList} from './constants';
 import ProjectSettingsTab from './ProjectSettingsTab';
@@ -67,7 +67,11 @@ export default function ProjectTabs({project}: Props) {
           downloadLink: TEMP_DOWNLOAD_LINK,
         }}
       />
-      <Tab.Screen name={TabRoutes.INPUTS} component={ProjectInputTab} />
+      <Tab.Screen
+        name={TabRoutes.INPUTS}
+        component={ProjectInputTab}
+        initialParams={{projectId: project.id}}
+      />
       <Tab.Screen
         name={TabRoutes.TEAM}
         component={ProjectTeamTab}

--- a/dev-client/src/components/projects/ProjectTabs.tsx
+++ b/dev-client/src/components/projects/ProjectTabs.tsx
@@ -1,6 +1,5 @@
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import ProjectInputTab from './ProjectInputTab';
-import {useTheme} from 'native-base';
 import ProjectTeamTab from './ProjectTeamTab';
 import {TabRoutes, TabStackParamList} from './constants';
 import ProjectSettingsTab from './ProjectSettingsTab';
@@ -13,6 +12,7 @@ import {
 import {useSelector} from '../../model/store';
 import {useMemo} from 'react';
 import {User} from 'terraso-client-shared/account/accountSlice';
+import {useDefaultTabOptions} from '../../screens/TabBar';
 
 const TEMP_DOWNLOAD_LINK = 'https://s3.amazon.com/mydownload';
 
@@ -24,7 +24,7 @@ type ScreenOptions = React.ComponentProps<
 type Props = {project: Project};
 
 export default function ProjectTabs({project}: Props) {
-  const {colors} = useTheme();
+  const defaultTabOptions = useDefaultTabOptions();
 
   const tabIconNames: Record<keyof TabStackParamList, string> = {
     Inputs: 'tune',
@@ -37,19 +37,9 @@ export default function ProjectTabs({project}: Props) {
     let iconName = tabIconNames[route.name];
 
     return {
-      tabBarScrollEnabled: true,
+      ...defaultTabOptions,
       tabBarIcon: ({color}) => {
         return <Icon name={iconName} color={color} />;
-      },
-      tabBarActiveTintColor: colors.primary.contrast,
-      tabBarInactiveTintColor: colors.secondary.main,
-      tabBarItemStyle: {width: 100, flexDirection: 'row'},
-      tabBarStyle: {
-        backgroundColor: colors.grey[200],
-      },
-      tabBarIndicatorStyle: {
-        backgroundColor: colors.secondary.main,
-        height: '100%',
       },
     };
   };

--- a/dev-client/src/components/projects/constants.ts
+++ b/dev-client/src/components/projects/constants.ts
@@ -10,7 +10,7 @@ export const enum TabRoutes {
 }
 
 export type TabStackParamList = {
-  [TabRoutes.INPUTS]: undefined;
+  [TabRoutes.INPUTS]: {projectId: string};
   [TabRoutes.TEAM]: {
     memberships: [ProjectMembership, User][];
     projectId: string;

--- a/dev-client/src/components/sites/LocationDashboardScreen.tsx
+++ b/dev-client/src/components/sites/LocationDashboardScreen.tsx
@@ -1,78 +1,78 @@
-import {useNavigation} from '../../screens/AppScaffold';
-import {useDispatch, useSelector} from '../../model/store';
-import {useTranslation} from 'react-i18next';
-import RadioBlock from '../common/RadioBlock';
 import {
-  Site,
-  SitePrivacy,
-  updateSite,
-} from 'terraso-client-shared/site/siteSlice';
-import {useCallback, useMemo} from 'react';
-import {Box, Divider, Text, Column} from 'native-base';
+  useNavigation,
+  ParamList,
+  ScreenDefinitions,
+} from '../../screens/AppScaffold';
+import {useSelector} from '../../model/store';
+import {useTranslation} from 'react-i18next';
+import {useMemo} from 'react';
 import {
   AppBar,
   AppBarIconButton,
   ScreenCloseButton,
   ScreenScaffold,
 } from '../../screens/ScreenScaffold';
-import {Accordion} from '../common/Accordion';
-import {StaticMapView} from '../common/Map';
-import {StyleSheet} from 'react-native';
+import {LocationDashboardView} from './LocationDashboardView';
+import {Coords} from '../../model/map/mapSlice';
+import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
+import {SlopeScreen} from '../dataInputs/SlopeScreen';
+import {SoilScreen} from '../dataInputs/SoilScreen';
+import {useDefaultTabOptions} from '../../screens/TabBar';
+import {SpeedDial, SpeedDialButton} from '../common/SpeedDial';
 
-const TEMP_ELEVATION = '1900 ft';
-const TEMP_ACCURACY = '20 ft';
-const TEMP_MODIFIED_DATE = '8/15/23';
-const TEMP_MODIFIED_NAME = 'Sample Sam';
-const TEMP_NOT_FOUND = 'not found';
-const TEMP_SOIL_ID_VALUE = 'Clifton';
-const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
-const TEMP_LCC_PREDICTION = 'Class 1';
-const TEMP_SOIL_ID_CONFIDENCE = '80%';
-const TEMP_ECO_SITE_ID_CONFIDENCE = '80%';
-const TEMP_LCC_CONFIDENCE = '80%';
+type Props = {siteId?: string; coords?: Coords};
 
-type Props = {siteId?: string; coords?: Pick<Site, 'latitude' | 'longitude'>};
+const tabDefinitions = {
+  SITE: LocationDashboardView,
+  SLOPE: SlopeScreen,
+  SOIL: SoilScreen,
+} satisfies ScreenDefinitions;
+type TabsParamList = ParamList<typeof tabDefinitions>;
+type ScreenName = keyof TabsParamList;
 
-const LocationDetail = ({label, value}: {label: string; value: string}) => (
-  <Text variant="body1">
-    <Text bold>{label}: </Text>
-    <Text>{value}</Text>
-  </Text>
-);
+const Tab = createMaterialTopTabNavigator<TabsParamList>();
 
-type LocationPredictionProps = {
-  label: string;
-  prediction: string;
-  confidence: string;
-};
-const LocationPrediction = ({
-  label,
-  prediction,
-  confidence,
-}: LocationPredictionProps) => {
+const LocationDashboardTabs = (params: {siteId: string}) => {
   const {t} = useTranslation();
+  const defaultOptions = useDefaultTabOptions();
+
+  const tabs = useMemo(
+    () =>
+      Object.entries(tabDefinitions).map(([name, View]) => (
+        <Tab.Screen
+          name={name as ScreenName}
+          key={name}
+          initialParams={params}
+          options={{...defaultOptions, tabBarLabel: t(`site.tabs.${name}`)}}
+          children={props => <View {...((props.route.params ?? {}) as any)} />}
+        />
+      )),
+    [params, t, defaultOptions],
+  );
 
   return (
-    <Column backgroundColor="primary.main" alignItems="center" py="18px">
-      <Text variant="body1" color="primary.contrast" bold>
-        {label}
-      </Text>
-      <Box h="5px" />
-      <Text variant="body2" color="primary.contrast">
-        <Text bold>{t('soil.prediction')}: </Text>
-        <Text>{prediction}</Text>
-      </Text>
-      <Text variant="body2" color="primary.contrast">
-        <Text bold>{t('soil.confidence')}: </Text>
-        <Text>{confidence}</Text>
-      </Text>
-    </Column>
+    <>
+      <Tab.Navigator initialRouteName="SITE">{tabs}</Tab.Navigator>
+      <SpeedDial>
+        <SpeedDialButton
+          name="description"
+          label={t('site.dashboard.speed_dial.note_label')}
+        />
+        <SpeedDialButton
+          name="image"
+          label={t('site.dashboard.speed_dial.photo_label')}
+        />
+        <SpeedDialButton
+          name="check"
+          label={t('site.dashboard.speed_dial.bedrock_label')}
+        />
+      </SpeedDial>
+    </>
   );
 };
 
 export const LocationDashboardScreen = ({siteId, coords}: Props) => {
   const {t} = useTranslation();
-  const dispatch = useDispatch();
   const navigation = useNavigation();
   const site = useSelector(state =>
     siteId === undefined ? undefined : state.site.sites[siteId],
@@ -80,16 +80,6 @@ export const LocationDashboardScreen = ({siteId, coords}: Props) => {
   if (coords === undefined) {
     coords = site!;
   }
-  const project = useSelector(state =>
-    site?.projectId === undefined
-      ? undefined
-      : state.project.projects[site.projectId],
-  );
-
-  const onSitePrivacyChanged = useCallback(
-    (privacy: SitePrivacy) => dispatch(updateSite({id: site!.id, privacy})),
-    [site, dispatch],
-  );
 
   const appBarRightButton = useMemo(
     () =>
@@ -116,100 +106,11 @@ export const LocationDashboardScreen = ({siteId, coords}: Props) => {
           title={site?.name ?? t('site.dashboard.default_title')}
         />
       }>
-      <StaticMapView
-        coords={coords}
-        style={styles.mapView}
-        displayCenterMarker={true}
-      />
-      <Accordion
-        initiallyOpen
-        Head={
-          <Text variant="body1" color="primary.contrast">
-            {t('general.details')}
-          </Text>
-        }>
-        <Box px="16px" py="8px">
-          {project && (
-            <LocationDetail label={t('projects.label')} value={project.name} />
-          )}
-          {project && (
-            <LocationDetail
-              label={t('site.dashboard.privacy')}
-              value={t(`privacy.${project.privacy}.title`)}
-            />
-          )}
-          {site && !project && (
-            <RadioBlock
-              label={
-                <Text variant="body1" bold>
-                  {t('site.dashboard.privacy')}
-                </Text>
-              }
-              options={{
-                PUBLIC: {text: t('privacy.PUBLIC.title')},
-                PRIVATE: {text: t('privacy.PRIVATE.title')},
-              }}
-              groupProps={{
-                name: 'site-privacy',
-                onChange: onSitePrivacyChanged,
-                value: site.privacy,
-                ml: '',
-              }}
-            />
-          )}
-          <LocationDetail
-            label={t('geo.latitude.title')}
-            value={coords.latitude.toFixed(6)}
-          />
-          <LocationDetail
-            label={t('geo.longitude.title')}
-            value={coords.longitude.toFixed(6)}
-          />
-          <LocationDetail
-            label={t('geo.elevation.title')}
-            value={TEMP_ELEVATION}
-          />
-          {site && (
-            <>
-              <LocationDetail
-                label={t('site.dashboard.location_accuracy')}
-                value={TEMP_ACCURACY}
-              />
-              <LocationDetail
-                label={t('soil.bedrock')}
-                value={TEMP_NOT_FOUND}
-              />
-              <LocationDetail
-                label={t('site.dashboard.last_modified.label')}
-                value={t('site.dashboard.last_modified.value', {
-                  date: TEMP_MODIFIED_DATE,
-                  name: TEMP_MODIFIED_NAME,
-                })}
-              />
-            </>
-          )}
-        </Box>
-      </Accordion>
-      <Divider />
-      <Column space="20px" padding="16px">
-        <LocationPrediction
-          label={t('soil.soil_id').toUpperCase()}
-          prediction={TEMP_SOIL_ID_VALUE}
-          confidence={TEMP_SOIL_ID_CONFIDENCE}
-        />
-        <LocationPrediction
-          label={t('soil.ecological_site_id').toUpperCase()}
-          prediction={TEMP_ECO_SITE_PREDICTION}
-          confidence={TEMP_ECO_SITE_ID_CONFIDENCE}
-        />
-        <LocationPrediction
-          label={t('soil.land_capability_classification').toUpperCase()}
-          prediction={TEMP_LCC_PREDICTION}
-          confidence={TEMP_LCC_CONFIDENCE}
-        />
-      </Column>
+      {siteId ? (
+        <LocationDashboardTabs siteId={siteId} />
+      ) : (
+        <LocationDashboardView siteId={siteId} coords={coords} />
+      )}
     </ScreenScaffold>
   );
 };
-
-const styles = StyleSheet.create({mapView: {height: 170}});

--- a/dev-client/src/components/sites/LocationDashboardScreen.tsx
+++ b/dev-client/src/components/sites/LocationDashboardScreen.tsx
@@ -18,7 +18,9 @@ import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs
 import {SlopeScreen} from '../dataInputs/SlopeScreen';
 import {SoilScreen} from '../dataInputs/SoilScreen';
 import {useDefaultTabOptions} from '../../screens/TabBar';
-import {SpeedDial, SpeedDialButton} from '../common/SpeedDial';
+import {SpeedDial} from '../common/SpeedDial';
+import {Button} from 'native-base';
+import {Icon} from '../common/Icons';
 
 type Props = {siteId?: string; coords?: Coords};
 
@@ -54,18 +56,15 @@ const LocationDashboardTabs = (params: {siteId: string}) => {
     <>
       <Tab.Navigator initialRouteName="SITE">{tabs}</Tab.Navigator>
       <SpeedDial>
-        <SpeedDialButton
-          name="description"
-          label={t('site.dashboard.speed_dial.note_label')}
-        />
-        <SpeedDialButton
-          name="image"
-          label={t('site.dashboard.speed_dial.photo_label')}
-        />
-        <SpeedDialButton
-          name="check"
-          label={t('site.dashboard.speed_dial.bedrock_label')}
-        />
+        <Button variant="speedDial" leftIcon={<Icon name="description" />}>
+          {t('site.dashboard.speed_dial.note_label')}
+        </Button>
+        <Button variant="speedDial" leftIcon={<Icon name="image" />}>
+          {t('site.dashboard.speed_dial.photo_label')}
+        </Button>
+        <Button variant="speedDial" leftIcon={<Icon name="image" />}>
+          {t('site.dashboard.speed_dial.bedrock_label')}
+        </Button>
       </SpeedDial>
     </>
   );

--- a/dev-client/src/components/sites/LocationDashboardView.tsx
+++ b/dev-client/src/components/sites/LocationDashboardView.tsx
@@ -1,0 +1,182 @@
+import {useDispatch, useSelector} from '../../model/store';
+import {useTranslation} from 'react-i18next';
+import RadioBlock from '../common/RadioBlock';
+import {SitePrivacy, updateSite} from 'terraso-client-shared/site/siteSlice';
+import {useCallback} from 'react';
+import {Box, Divider, Text, Column} from 'native-base';
+import {Accordion} from '../common/Accordion';
+import {StaticMapView} from '../common/Map';
+import {StyleSheet} from 'react-native';
+import {Coords} from '../../model/map/mapSlice';
+import {ScrollView} from 'react-native';
+
+const TEMP_ELEVATION = '1900 ft';
+const TEMP_ACCURACY = '20 ft';
+const TEMP_MODIFIED_DATE = '8/15/23';
+const TEMP_MODIFIED_NAME = 'Sample Sam';
+const TEMP_NOT_FOUND = 'not found';
+const TEMP_SOIL_ID_VALUE = 'Clifton';
+const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
+const TEMP_LCC_PREDICTION = 'Class 1';
+const TEMP_SOIL_ID_CONFIDENCE = '80%';
+const TEMP_ECO_SITE_ID_CONFIDENCE = '80%';
+const TEMP_LCC_CONFIDENCE = '80%';
+
+type Props = {siteId?: string; coords?: Coords};
+
+const LocationDetail = ({label, value}: {label: string; value: string}) => (
+  <Text variant="body1">
+    <Text bold>{label}: </Text>
+    <Text>{value}</Text>
+  </Text>
+);
+
+type LocationPredictionProps = {
+  label: string;
+  prediction: string;
+  confidence: string;
+};
+const LocationPrediction = ({
+  label,
+  prediction,
+  confidence,
+}: LocationPredictionProps) => {
+  const {t} = useTranslation();
+
+  return (
+    <Column backgroundColor="primary.main" alignItems="center" py="18px">
+      <Text variant="body1" color="primary.contrast" bold>
+        {label}
+      </Text>
+      <Box h="5px" />
+      <Text variant="body2" color="primary.contrast">
+        <Text bold>{t('soil.prediction')}: </Text>
+        <Text>{prediction}</Text>
+      </Text>
+      <Text variant="body2" color="primary.contrast">
+        <Text bold>{t('soil.confidence')}: </Text>
+        <Text>{confidence}</Text>
+      </Text>
+    </Column>
+  );
+};
+
+export const LocationDashboardView = ({siteId, coords}: Props) => {
+  const {t} = useTranslation();
+  const dispatch = useDispatch();
+  const site = useSelector(state =>
+    siteId === undefined ? undefined : state.site.sites[siteId],
+  );
+  if (coords === undefined) {
+    coords = site!;
+  }
+  const project = useSelector(state =>
+    site?.projectId === undefined
+      ? undefined
+      : state.project.projects[site.projectId],
+  );
+
+  const onSitePrivacyChanged = useCallback(
+    (privacy: SitePrivacy) => dispatch(updateSite({id: site!.id, privacy})),
+    [site, dispatch],
+  );
+
+  return (
+    <ScrollView>
+      <StaticMapView
+        coords={coords}
+        style={styles.mapView}
+        displayCenterMarker={true}
+      />
+      <Accordion
+        initiallyOpen
+        Head={
+          <Text variant="body1" color="primary.contrast">
+            {t('general.details')}
+          </Text>
+        }>
+        <Box px="16px" py="8px">
+          {project && (
+            <LocationDetail label={t('projects.label')} value={project.name} />
+          )}
+          {project && (
+            <LocationDetail
+              label={t('site.dashboard.privacy')}
+              value={t(`privacy.${project.privacy}.title`)}
+            />
+          )}
+          {site && !project && (
+            <RadioBlock
+              label={
+                <Text variant="body1" bold>
+                  {t('site.dashboard.privacy')}
+                </Text>
+              }
+              options={{
+                PUBLIC: {text: t('privacy.PUBLIC.title')},
+                PRIVATE: {text: t('privacy.PRIVATE.title')},
+              }}
+              groupProps={{
+                name: 'site-privacy',
+                onChange: onSitePrivacyChanged,
+                value: site.privacy,
+                ml: '',
+              }}
+            />
+          )}
+          <LocationDetail
+            label={t('geo.latitude.title')}
+            value={coords.latitude.toFixed(6)}
+          />
+          <LocationDetail
+            label={t('geo.longitude.title')}
+            value={coords.longitude.toFixed(6)}
+          />
+          <LocationDetail
+            label={t('geo.elevation.title')}
+            value={TEMP_ELEVATION}
+          />
+          {site && (
+            <>
+              <LocationDetail
+                label={t('site.dashboard.location_accuracy')}
+                value={TEMP_ACCURACY}
+              />
+              <LocationDetail
+                label={t('soil.bedrock')}
+                value={TEMP_NOT_FOUND}
+              />
+              <LocationDetail
+                label={t('site.dashboard.last_modified.label')}
+                value={t('site.dashboard.last_modified.value', {
+                  date: TEMP_MODIFIED_DATE,
+                  name: TEMP_MODIFIED_NAME,
+                })}
+              />
+            </>
+          )}
+        </Box>
+      </Accordion>
+      <Divider />
+      <Column space="20px" padding="16px">
+        <LocationPrediction
+          label={t('soil.soil_id').toUpperCase()}
+          prediction={TEMP_SOIL_ID_VALUE}
+          confidence={TEMP_SOIL_ID_CONFIDENCE}
+        />
+        <LocationPrediction
+          label={t('soil.ecological_site_id').toUpperCase()}
+          prediction={TEMP_ECO_SITE_PREDICTION}
+          confidence={TEMP_ECO_SITE_ID_CONFIDENCE}
+        />
+        <LocationPrediction
+          label={t('soil.land_capability_classification').toUpperCase()}
+          prediction={TEMP_LCC_PREDICTION}
+          confidence={TEMP_LCC_CONFIDENCE}
+        />
+      </Column>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({mapView: {height: 170}});

--- a/dev-client/src/components/sites/SiteSettingsScreen.tsx
+++ b/dev-client/src/components/sites/SiteSettingsScreen.tsx
@@ -17,7 +17,7 @@ import {useNavigation} from '../../screens/AppScaffold';
 import {Icon} from '../common/Icons';
 import {useTranslation} from 'react-i18next';
 import {IconLabel} from '../common/RadioBlock';
-import {updateSite} from 'terraso-client-shared/site/siteSlice';
+import {deleteSite, updateSite} from 'terraso-client-shared/site/siteSlice';
 import {ScreenScaffold, AppBar} from '../../screens/ScreenScaffold';
 
 type Props = {
@@ -41,6 +41,12 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     () => dispatch(updateSite({id: site.id, name})),
     [dispatch, site, name],
   );
+
+  const onDelete = useCallback(async () => {
+    // TODO: confirm successful deletion before navigating home
+    navigate('HOME');
+    await dispatch(deleteSite(site));
+  }, [dispatch, navigate, site]);
 
   return (
     <ScreenScaffold
@@ -103,7 +109,8 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
           pl={0}
           variant="link"
           _text={{color: 'error.main'}}
-          startIcon={<Icon color="error.main" name="delete-forever" />}>
+          startIcon={<Icon color="error.main" name="delete-forever" />}
+          onPress={onDelete}>
           {t('site.dashboard.delete_button').toUpperCase()}
         </Button>
       </Column>

--- a/dev-client/src/constants.ts
+++ b/dev-client/src/constants.ts
@@ -12,3 +12,4 @@ export const PROJECT_NAME_MAX_LENGTH = 120;
 export const PROJECT_NAME_MIN_LENGTH = 3;
 export const PROJECT_DESCRIPTION_MAX_LENGTH = 240;
 export const BOTTOM_BAR_SIZE = '10%';
+export const FORM_LABEL_MAX = 10;

--- a/dev-client/src/screens/AppScaffold.tsx
+++ b/dev-client/src/screens/AppScaffold.tsx
@@ -26,6 +26,12 @@ import {updateLocation} from '../model/map/mapSlice';
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from '../constants';
 import {AddUserToProjectScreen} from '../components/projects/AddUserToProjectScreen';
 
+type UnknownToUndefined<T extends unknown> = unknown extends T ? undefined : T;
+export type ScreenDefinitions = Record<string, React.FC<any>>;
+export type ParamList<T extends ScreenDefinitions> = {
+  [K in keyof T]: UnknownToUndefined<React.ComponentProps<T[K]>>;
+};
+
 const screenDefinitions = {
   LOGIN: LoginScreen,
   PROJECT_LIST: ProjectListScreen,
@@ -38,22 +44,14 @@ const screenDefinitions = {
   SITE_SETTINGS: SiteSettingsScreen,
   SITE_TEAM_SETTINGS: SiteTeamSettingsScreen,
   ADD_USER_PROJECT: AddUserToProjectScreen,
-} satisfies Record<string, React.FC<any>>;
+} satisfies ScreenDefinitions;
 
-type ScreenName = keyof typeof screenDefinitions;
-type UnknownToUndefined<T extends unknown> = unknown extends T ? undefined : T;
-type RootStackParamList = {
-  [K in ScreenName]: UnknownToUndefined<
-    React.ComponentProps<(typeof screenDefinitions)[K]>
-  >;
-};
+type RootStackParamList = ParamList<typeof screenDefinitions>;
+type ScreenName = keyof RootStackParamList;
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 
-export type RootStackScreenProps = NativeStackScreenProps<
-  RootStackParamList,
-  ScreenName
->;
+export type RootStackScreenProps = NativeStackScreenProps<RootStackParamList>;
 
 const screens = Object.entries(screenDefinitions).map(([name, Screen]) => (
   <RootStack.Screen

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -11,7 +11,7 @@ import Mapbox, {Camera} from '@rnmapbox/maps';
 import {Coords} from '../model/map/mapSlice';
 import {useDispatch} from '../model/store';
 import {useSelector} from '../model/store';
-import {Site, fetchSitesForUser} from 'terraso-client-shared/site/siteSlice';
+import {Site} from 'terraso-client-shared/site/siteSlice';
 import {SiteListBottomSheet} from '../components/home/BottomSheet';
 import {useNavigation} from './AppScaffold';
 import {
@@ -20,7 +20,6 @@ import {
   ScreenScaffold,
   useHeaderHeight,
 } from './ScreenScaffold';
-import {fetchProjectsForUser} from 'terraso-client-shared/project/projectSlice';
 import MapSearch from '../components/home/MapSearch';
 import {Box, Column, Heading, Image, Link, Text} from 'native-base';
 import {coordsToPosition} from '../components/common/Map';
@@ -36,6 +35,7 @@ import {CardCloseButton} from '../components/common/Card';
 import {BottomSheetBackdropProps} from '@gorhom/bottom-sheet';
 import {useTextSearch} from '../components/common/search/search';
 import {useFilterSites} from '../components/sites/filter';
+import {fetchSoilDataForUser} from 'terraso-client-shared/soilId/soilIdSlice';
 
 export type CalloutState =
   | {
@@ -83,9 +83,9 @@ export const HomeScreen = () => {
   );
 
   useEffect(() => {
-    // load sites on mount
-    dispatch(fetchSitesForUser());
-    dispatch(fetchProjectsForUser());
+    if (currentUserID !== undefined) {
+      dispatch(fetchSoilDataForUser(currentUserID)).then(console.log);
+    }
   }, [dispatch, currentUserID]);
 
   const currentUserCoords = useSelector(state => state.map.userLocation.coords);
@@ -162,11 +162,11 @@ export const HomeScreen = () => {
   }, [navigation, calloutState]);
 
   const onInfo = useCallback(
-    () => infoBottomSheetRef?.current?.present(),
+    () => infoBottomSheetRef.current?.present(),
     [infoBottomSheetRef],
   );
   const onInfoClose = useCallback(
-    () => infoBottomSheetRef?.current?.dismiss(),
+    () => infoBottomSheetRef.current?.dismiss(),
     [infoBottomSheetRef],
   );
 

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -84,7 +84,7 @@ export const HomeScreen = () => {
 
   useEffect(() => {
     if (currentUserID !== undefined) {
-      dispatch(fetchSoilDataForUser(currentUserID)).then(console.log);
+      dispatch(fetchSoilDataForUser(currentUserID));
     }
   }, [dispatch, currentUserID]);
 

--- a/dev-client/src/screens/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen.tsx
@@ -1,6 +1,5 @@
-import {useEffect, useCallback, useMemo} from 'react';
-import {fetchProjectsForUser} from 'terraso-client-shared/project/projectSlice';
-import {useDispatch, useSelector} from '../model/store';
+import {useCallback, useMemo} from 'react';
+import {useSelector} from '../model/store';
 import {AppBar, AppBarIconButton, ScreenScaffold} from './ScreenScaffold';
 import {useTranslation} from 'react-i18next';
 import {useNavigation} from './AppScaffold';
@@ -12,11 +11,6 @@ import {SearchBar} from '../components/common/search/SearchBar';
 import {useTextSearch} from '../components/common/search/search';
 
 export const ProjectListScreen = () => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(fetchProjectsForUser());
-  }, [dispatch]);
-
   const allProjects = useSelector(state => state.project.projects);
   const activeProjects = useMemo(
     () => Object.values(allProjects).filter(project => !project.archived),

--- a/dev-client/src/screens/TabBar.tsx
+++ b/dev-client/src/screens/TabBar.tsx
@@ -1,0 +1,38 @@
+import {MaterialTopTabNavigationOptions} from '@react-navigation/material-top-tabs';
+import {useTheme} from 'native-base';
+import {useMemo} from 'react';
+
+export const useDefaultTabOptions = (): MaterialTopTabNavigationOptions => {
+  const {colors} = useTheme();
+  return useMemo(
+    () => ({
+      tabBarScrollEnabled: true,
+      tabBarActiveTintColor: colors.primary.contrast,
+      tabBarInactiveTintColor: colors.secondary.main,
+      tabBarItemStyle: {
+        width: 'auto',
+        flexDirection: 'row',
+        flexGrow: 1,
+        paddingHorizontal: 16,
+        paddingVertical: 9,
+      },
+      tabBarLabelStyle: {
+        fontSize: 14,
+        fontWeight: '500',
+        lineHeight: 24,
+        letterSpacing: 0.4,
+      },
+      tabBarStyle: {
+        backgroundColor: colors.grey[200],
+      },
+      tabBarIndicatorStyle: {
+        backgroundColor: colors.secondary.main,
+        height: '100%',
+      },
+      tabBarAndroidRipple: {
+        color: '#FFFFFF00',
+      },
+    }),
+    [colors],
+  );
+};

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -70,6 +70,14 @@ export const theme = extendTheme({
           },
         },
         md: {
+          px: '16px',
+          py: '6px',
+          _text: {
+            fontSize: '14px',
+            fontWeight: 500,
+            lineHeight: '24px',
+            letterSpacing: '0.4px',
+          },
           _icon: {
             size: 'md',
           },
@@ -85,6 +93,26 @@ export const theme = extendTheme({
           py: '8px',
         },
       },
+      variants: {
+        speedDial: {
+          size: 'md',
+          borderRadius: '50px',
+          shadow: 6,
+          backgroundColor: 'primary.contrast',
+          _icon: {
+            size: 'sm',
+            color: 'text.primary',
+          },
+          _text: {
+            color: 'text.primary',
+          },
+        },
+        fullWidth: {
+          borderRadius: '0px',
+          width: 'full',
+          justifyContent: 'start',
+        },
+      },
     },
     FAB: {
       baseStyle: {
@@ -97,7 +125,7 @@ export const theme = extendTheme({
         },
         right: '24px',
         bottom: '24px',
-        shadow: 2,
+        shadow: 6,
       },
     },
     Select: {
@@ -160,6 +188,9 @@ export const theme = extendTheme({
         md: {
           padding: '12px',
         },
+        lg: {
+          padding: '16px',
+        },
       },
       defaultProps: {
         size: 'sm',
@@ -169,8 +200,13 @@ export const theme = extendTheme({
       },
       variants: {
         FAB: {
-          padding: '16px',
           shadow: 2,
+          borderRadius: 'full',
+          backgroundColor: 'primary.main',
+          _icon: {
+            color: 'primary.contrast',
+            size: 'md',
+          },
         },
       },
     },
@@ -263,6 +299,11 @@ export const theme = extendTheme({
           size: '50px',
           borderRadius: 100,
         },
+      },
+    },
+    Modal: {
+      defaultProps: {
+        avoidKeyboard: true,
       },
     },
   },

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -6,6 +6,7 @@ export const theme = extendTheme({
       main: '#276749',
       contrast: '#FFFFFF',
       lightest: '#9AE6B4',
+      dark: '#22543D',
       // TODO: This is used for the colorScheme value for Radio
       // We should figure out how the color scheme stuff works and see if we can
       // map our current variables to 100, 200 values etc.
@@ -164,6 +165,12 @@ export const theme = extendTheme({
         size: 'sm',
         _icon: {
           size: 'md',
+        },
+      },
+      variants: {
+        FAB: {
+          padding: '16px',
+          shadow: 2,
         },
       },
     },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -257,12 +257,36 @@
     "soil_id": "Soil ID",
     "ecological_site_id": "Ecological Site ID",
     "land_capability_classification": "Land Capability Classification",
-    "profile": "Soil Profile",
+    "surface": "Soil Surface",
+    "pit": "Soil Pit",
     "add_depth_label": "ADD DEPTH",
+    "project_settings": {
+      "pit_required_label": "Soil pit required",
+      "required_data_title": "Data Collection Requirements"
+    },
+    "collection_method": {
+      "slope": "Slope and Landscape",
+      "soilTexture": "Texture",
+      "soilColor": "Color",
+      "verticalCracking": "Vertical Cracks",
+      "carbonates": "Carbonates",
+      "ph": "pH",
+      "soilOrganicCarbonMatter": "SOC/SOM",
+      "electricalConductivity": "Electrical Conductivity",
+      "sodiumAdsorptionRatio": "SAR",
+      "soilStructure": "Structure",
+      "landUseLandCover": "Land Use/Land Cover",
+      "soilLimitations": "Limitations",
+      "photos": "Photos",
+      "notes": "Notes"
+    },
     "depth_interval": {
       "add_title": "Add depth interval",
+      "edit_title": "Depth Interval",
+      "data_inputs_title": "Data Inputs",
       "label_help": "{{max}} characters max",
       "label_placeholder": "Label",
+      "apply_to_all_label": "Apply to all to intervals",
       "start_label": "From ({{unit}})",
       "end_label": "To ({{unit}})"
     }

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -79,7 +79,12 @@
         "label": "Last Modified",
         "value": "{{date}} {{name}}"
       },
-      "default_title": "Location Information"
+      "default_title": "Location Information",
+      "speed_dial": {
+        "note_label": "NOTE",
+        "photo_label": "PHOTO",
+        "bedrock_label": "BEDROCK"
+      }
     },
     "search": {
       "placeholder": "Search sites",
@@ -91,6 +96,11 @@
       "MANAGER": "Manager",
       "CONTRIBUTOR": "Contributor",
       "VIEWER": "Viewer"
+    },
+    "tabs": {
+      "SITE": "Site",
+      "SLOPE": "Slope",
+      "SOIL": "Soil"
     }
   },
   "projects": {
@@ -192,7 +202,8 @@
     "details": "Details",
     "apply": "Apply",
     "example_email": "name@domain.com",
-    "profile_image_alt": "Profile image"
+    "profile_image_alt": "Profile image",
+    "add": "ADD"
   },
   "screens": {
     "HOME": "LandPKS",
@@ -245,6 +256,15 @@
     "confidence": "Confidence",
     "soil_id": "Soil ID",
     "ecological_site_id": "Ecological Site ID",
-    "land_capability_classification": "Land Capability Classification"
+    "land_capability_classification": "Land Capability Classification",
+    "profile": "Soil Profile",
+    "add_depth_label": "ADD DEPTH",
+    "depth_interval": {
+      "add_title": "Add depth interval",
+      "label_help": "{{max}} characters max",
+      "label_placeholder": "Label",
+      "start_label": "From ({{unit}})",
+      "end_label": "To ({{unit}})"
+    }
   }
 }


### PR DESCRIPTION
## Description
Scaffolds the site dashboard so it is ready for future data inputs work. Creates the site tabs, and ability to add/edit a site's depth intervals so that all data inputs can be navigated to. Still needs a bunch more work, but wanted to make the code available now since it's interrelated with the relevant client-shared/backend PRs and paul asked me to! depends on https://github.com/techmatters/terraso-client-shared/pull/105 and https://github.com/techmatters/terraso-backend/pull/843

### Checklist
- [x] Corresponding issue has been opened

Fixes #395 
Fixes #432
Fixes #396 
Fixes #456

Limitations:
- project inputs screen raises warnings (but is functional if not beautiful)
- new formswitch component raises warnings (but is functional)
- project required data inputs are not wired to individual sites yet
- "apply to all intervals" checkbox on individual site depth interval editor does nothing
- no implementation of site or project depth interval presets
- delete site button needs modal confirmation
- redux structure of soilIdSlice doesn't handle newly-created sites