### PR TITLE
feat: Add free form text input

### DIFF
--- a/dev-client/src/components/common/FreeformTextInput.tsx
+++ b/dev-client/src/components/common/FreeformTextInput.tsx
@@ -1,0 +1,43 @@
+import {FormControl, Input} from 'native-base';
+import {useCallback, useState} from 'react';
+
+type Props = {
+  validationFunc: (input: string) => Promise<null | string>;
+  helperText?: string;
+  placeholder?: string;
+};
+
+/**
+ * A text input that allows the user to directly enter a text string.
+ * On submit, the result is validated. If incorrect, an error message is
+ * displayed.
+ */
+export const FreeformTextInput = ({
+  validationFunc,
+  helperText,
+  placeholder,
+}: Props) => {
+  const [hasError, setHasError] = useState<null | string>(null);
+  const [textValue, setTextValue] = useState<string>('');
+
+  const handleSubmit = useCallback(async () => {
+    const validationResults = await validationFunc(textValue);
+    if (validationResults !== null) {
+      setHasError(validationResults);
+    } else {
+      setTextValue('');
+    }
+  }, [validationFunc, textValue, setTextValue]);
+
+  <FormControl>
+    <Input
+      placeholder={placeholder !== undefined ? placeholder : ''}
+      onSubmitEditing={handleSubmit}
+      onChangeText={text => setTextValue(text)}
+      value={textValue}></Input>
+    {helperText !== '' ? (
+      <FormControl.HelperText>{{helperText}}</FormControl.HelperText>
+    ) : null}
+    <FormControl.ErrorMessage>{{hasError}}</FormControl.ErrorMessage>
+  </FormControl>;
+};

--- a/dev-client/src/components/common/FreeformTextInput.tsx
+++ b/dev-client/src/components/common/FreeformTextInput.tsx
@@ -21,7 +21,7 @@ export const FreeformTextInput = ({validationFunc, placeholder}: Props) => {
       setHasError(validationResults);
     } else {
       setTextValue('');
-      setHasError('');
+      setHasError(null);
     }
   }, [validationFunc, textValue, setTextValue]);
 

--- a/dev-client/src/components/common/FreeformTextInput.tsx
+++ b/dev-client/src/components/common/FreeformTextInput.tsx
@@ -3,20 +3,15 @@ import {useCallback, useState} from 'react';
 
 type Props = {
   validationFunc: (input: string) => Promise<null | string>;
-  helperText?: string;
   placeholder?: string;
 };
 
 /**
  * A text input that allows the user to directly enter a text string.
- * On submit, the result is validated. If incorrect, an error message is
- * displayed.
+ * On submit, the result is validated. If incorrect, an error message
+ * is displayed.
  */
-export const FreeformTextInput = ({
-  validationFunc,
-  helperText,
-  placeholder,
-}: Props) => {
+export const FreeformTextInput = ({validationFunc, placeholder}: Props) => {
   const [hasError, setHasError] = useState<null | string>(null);
   const [textValue, setTextValue] = useState<string>('');
 
@@ -26,18 +21,18 @@ export const FreeformTextInput = ({
       setHasError(validationResults);
     } else {
       setTextValue('');
+      setHasError('');
     }
   }, [validationFunc, textValue, setTextValue]);
 
-  <FormControl>
-    <Input
-      placeholder={placeholder !== undefined ? placeholder : ''}
-      onSubmitEditing={handleSubmit}
-      onChangeText={text => setTextValue(text)}
-      value={textValue}></Input>
-    {helperText !== '' ? (
-      <FormControl.HelperText>{{helperText}}</FormControl.HelperText>
-    ) : null}
-    <FormControl.ErrorMessage>{{hasError}}</FormControl.ErrorMessage>
-  </FormControl>;
+  return (
+    <FormControl isInvalid={hasError !== null}>
+      <Input
+        placeholder={placeholder !== undefined ? placeholder : ''}
+        onSubmitEditing={handleSubmit}
+        onChangeText={text => setTextValue(text)}
+        value={textValue}></Input>
+      <FormControl.ErrorMessage>{hasError}</FormControl.ErrorMessage>
+    </FormControl>
+  );
 };


### PR DESCRIPTION
This input is intended for the add user to project screen. It will just encapsulate the logic of validating the user emails exists and displaying an error message if invalid. In the future the error message may be more complex, like displaying a modal or something, so I've decided to make this a whole separate component.

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
