### PR TITLE
fix: Don't submit locationSource on create site

### DIFF
--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -190,10 +190,8 @@ export const CreateSiteView = ({
   const navigation = useNavigation();
 
   const onSave = useCallback(
-    async (form: FormState) => {
-      let input: Partial<FormState> = {...form};
-      delete input.locationSource;
-      const {coords, ...site} = validationSchema.cast(input);
+    async ({locationSource: _, ...form}: FormState) => {
+      const {coords, ...site} = validationSchema.cast(form);
       const createdSite = await createSiteCallback({
         ...site,
         ...parseCoords(coords),

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -191,7 +191,8 @@ export const CreateSiteView = ({
 
   const onSave = useCallback(
     async (form: FormState) => {
-      let {locationSource: _, ...input} = form;
+      let input: Partial<FormState> = {...form};
+      delete input['locationSource'];
       const {coords, ...site} = validationSchema.cast(input);
       const createdSite = await createSiteCallback({
         ...site,

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -191,7 +191,8 @@ export const CreateSiteView = ({
 
   const onSave = useCallback(
     async (form: FormState) => {
-      const {coords, ...site} = validationSchema.cast(form);
+      let {locationSource: _, ...input} = form;
+      const {coords, ...site} = validationSchema.cast(input);
       const createdSite = await createSiteCallback({
         ...site,
         ...parseCoords(coords),

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -192,7 +192,7 @@ export const CreateSiteView = ({
   const onSave = useCallback(
     async (form: FormState) => {
       let input: Partial<FormState> = {...form};
-      delete input['locationSource'];
+      delete input.locationSource;
       const {coords, ...site} = validationSchema.cast(input);
       const createdSite = await createSiteCallback({
         ...site,


### PR DESCRIPTION
This allows me to create a site locally, and logically makes sense. However I'm not sure why Typescript does not pick up on locationSource being included in the input to the GraphQL call here. @shrouxm any idea?

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
