### PR TITLE
feat: Add hook for when keyboard is open

### DIFF
--- a/dev-client/src/hooks/index.tsx
+++ b/dev-client/src/hooks/index.tsx
@@ -1,0 +1,22 @@
+import {useEffect, useState} from 'react';
+import {Keyboard} from 'react-native';
+
+export const useKeyboardOpen = () => {
+  const [keyboardOpen, setKeyboardOpen] = useState<boolean>(
+    Keyboard.isVisible(),
+  );
+  useEffect(() => {
+    const openListener = Keyboard.addListener('keyboardDidShow', () =>
+      setKeyboardOpen(true),
+    );
+    const closeListener = Keyboard.addListener('keyboardDidHide', () =>
+      setKeyboardOpen(false),
+    );
+    return () => {
+      if (openListener) openListener.remove();
+      if (closeListener) closeListener.remove();
+    };
+  });
+
+  return keyboardOpen;
+};

--- a/dev-client/src/hooks/index.tsx
+++ b/dev-client/src/hooks/index.tsx
@@ -13,10 +13,10 @@ export const useKeyboardOpen = () => {
       setKeyboardOpen(false),
     );
     return () => {
-      if (openListener) openListener.remove();
-      if (closeListener) closeListener.remove();
+      openListener.remove();
+      closeListener.remove();
     };
-  });
+  }, []);
 
   return keyboardOpen;
 };


### PR DESCRIPTION
## Description

This hook just returns a reactive value that is true when the keyboard is open, and false when it is closed. I'm using it to hide the submit button on a form when the keyboard is open, because I kept on accidentally submitting while testing - maybe it will be useful elsewhere.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
