### PR TITLE
fix: home screen map behavior

### DIFF
--- a/dev-client/src/components/common/Card.tsx
+++ b/dev-client/src/components/common/Card.tsx
@@ -1,6 +1,6 @@
 import {Box} from 'native-base';
 import {IconButton} from 'terraso-mobile-client/components/common/Icons';
-import {Pressable, StyleSheet} from 'react-native';
+import {Pressable} from 'react-native';
 import {forwardRef} from 'react';
 
 const TRIANGLE_BORDER_WIDTH = 15;
@@ -61,7 +61,7 @@ export const Card = ({
   buttons,
   onPress,
   children,
-  isPopover,
+  isPopover = false,
   ...boxProps
 }: CardProps) => {
   return (
@@ -69,7 +69,7 @@ export const Card = ({
       <Box
         variant="card"
         marginTop={isPopover ? '15px' : '0px'}
-        style={isPopover ? styles.shadow : {}}
+        shadow={isPopover ? 9 : undefined}
         {...boxProps}>
         {isPopover && <CardTriangle />}
         {children}
@@ -78,16 +78,3 @@ export const Card = ({
     </Pressable>
   );
 };
-
-const styles = StyleSheet.create({
-  shadow: {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 8,
-    },
-    shadowOpacity: 0.5,
-    shadowRadius: 6,
-    elevation: 6,
-  },
-});

--- a/dev-client/src/components/common/Card.tsx
+++ b/dev-client/src/components/common/Card.tsx
@@ -1,6 +1,6 @@
 import {Box} from 'native-base';
 import {IconButton} from 'terraso-mobile-client/components/common/Icons';
-import {Pressable} from 'react-native';
+import {Pressable, StyleSheet} from 'react-native';
 import {forwardRef} from 'react';
 
 const TRIANGLE_BORDER_WIDTH = 15;
@@ -67,7 +67,11 @@ export const Card = ({
   console.log('isPopover:', isPopover);
   return (
     <Pressable onPress={onPress}>
-      <Box variant="card" marginTop={isPopover ? '15px' : '0px'} {...boxProps}>
+      <Box
+        variant="card"
+        marginTop={isPopover ? '15px' : '0px'}
+        style={isPopover ? styles.shadow : {}}
+        {...boxProps}>
         {isPopover && <CardTriangle />}
         {children}
         {buttons}
@@ -75,3 +79,16 @@ export const Card = ({
     </Pressable>
   );
 };
+
+const styles = StyleSheet.create({
+  shadow: {
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 8,
+    },
+    shadowOpacity: 0.5,
+    shadowRadius: 6,
+    elevation: 6,
+  },
+});

--- a/dev-client/src/components/common/Card.tsx
+++ b/dev-client/src/components/common/Card.tsx
@@ -54,23 +54,21 @@ type CardProps = {
   buttons?: React.ReactNode;
   children?: React.ReactNode;
   onPress?: () => void;
-  showTriangle?: Boolean;
+  isPopover?: Boolean;
 } & React.ComponentProps<typeof Box>;
 
 export const Card = ({
   buttons,
   onPress,
   children,
-  showTriangle,
+  isPopover,
   ...boxProps
 }: CardProps) => {
+  console.log('isPopover:', isPopover);
   return (
     <Pressable onPress={onPress}>
-      <Box
-        variant="card"
-        marginTop={showTriangle ? '15px' : '0px'}
-        {...boxProps}>
-        {showTriangle && <CardTriangle />}
+      <Box variant="card" marginTop={isPopover ? '15px' : '0px'} {...boxProps}>
+        {isPopover && <CardTriangle />}
         {children}
         {buttons}
       </Box>

--- a/dev-client/src/components/common/Card.tsx
+++ b/dev-client/src/components/common/Card.tsx
@@ -64,7 +64,6 @@ export const Card = ({
   isPopover,
   ...boxProps
 }: CardProps) => {
-  console.log('isPopover:', isPopover);
   return (
     <Pressable onPress={onPress}>
       <Box

--- a/dev-client/src/components/home/BottomSheet.tsx
+++ b/dev-client/src/components/home/BottomSheet.tsx
@@ -58,7 +58,11 @@ export const SiteListBottomSheet = forwardRef<BottomSheetMethods, Props>(
 
     const renderSite = useCallback(
       ({item}: {item: Site}) => (
-        <SiteCard site={item} onShowSiteOnMap={showSiteOnMap} />
+        <SiteCard
+          site={item}
+          onShowSiteOnMap={showSiteOnMap}
+          isPopover={false}
+        />
       ),
       [showSiteOnMap],
     );

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -24,6 +24,7 @@ import {siteFeatureCollection} from 'terraso-mobile-client/components/home/siteF
 import {repositionCamera} from 'terraso-mobile-client/components/home/repositionCamera';
 import {SiteMapCallout} from 'terraso-mobile-client/components/home/SiteMapCallout';
 
+const DEFAULT_LOCATION = [-98.0, 38.5];
 const MAX_EXPANSION_ZOOM = 15;
 
 export type SiteMapProps = {
@@ -244,7 +245,13 @@ const SiteMap = (
       scaleBarEnabled={false}
       styleURL={styleURL}
       onPress={onPress}>
-      <Camera ref={cameraRef} />
+      <Camera
+        ref={cameraRef}
+        defaultSettings={{
+          centerCoordinate: DEFAULT_LOCATION,
+          zoomLevel: 3,
+        }}
+      />
       <Mapbox.Images images={mapImages} />
       <Mapbox.ShapeSource id="selectedSiteSource" shape={selectedSiteFeature}>
         <Mapbox.SymbolLayer

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -33,6 +33,7 @@ export type SiteMapProps = {
   calloutState: CalloutState;
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
+  onMapFinishedLoading?: () => void;
 };
 
 const SiteMap = (
@@ -42,6 +43,7 @@ const SiteMap = (
     setCalloutState,
     calloutState,
     styleURL,
+    onMapFinishedLoading,
   }: SiteMapProps,
   forwardedCameraRef: ForwardedRef<CameraRef>,
 ): JSX.Element => {
@@ -244,7 +246,8 @@ const SiteMap = (
       style={styles.mapView}
       scaleBarEnabled={false}
       styleURL={styleURL}
-      onPress={onPress}>
+      onPress={onPress}
+      onDidFinishLoadingMap={onMapFinishedLoading}>
       <Camera
         ref={cameraRef}
         defaultSettings={{

--- a/dev-client/src/components/home/SiteMapCallout.tsx
+++ b/dev-client/src/components/home/SiteMapCallout.tsx
@@ -38,7 +38,7 @@ export const SiteMapCallout = ({
       <SiteCard
         site={sites[state.siteId]}
         buttons={<CardCloseButton onPress={closeCallout} />}
-        showTriangle={true}
+        isPopover={true}
       />
     );
   } else if (state.kind === 'site_cluster') {
@@ -46,7 +46,7 @@ export const SiteMapCallout = ({
       <Card
         width="270px"
         buttons={<CardCloseButton onPress={closeCallout} />}
-        showTriangle={true}>
+        isPopover={true}>
         <FlatList
           data={state.siteIds}
           keyExtractor={id => id}

--- a/dev-client/src/components/home/TemporarySiteCallout.tsx
+++ b/dev-client/src/components/home/TemporarySiteCallout.tsx
@@ -34,9 +34,7 @@ export const TemporarySiteCallout = ({
   }, [navigation, coords]);
 
   return (
-    <Card
-      buttons={<CardCloseButton onPress={closeCallout} />}
-      showTriangle={true}>
+    <Card buttons={<CardCloseButton onPress={closeCallout} />} isPopover={true}>
       <Column space="12px">
         <CalloutDetail
           label={t('site.soil_id_prediction').toUpperCase()}

--- a/dev-client/src/components/sites/SiteCard.tsx
+++ b/dev-client/src/components/sites/SiteCard.tsx
@@ -16,13 +16,13 @@ type SiteCardProps = {
   site: Site;
   onShowSiteOnMap?: (site: Site) => void;
   buttons?: React.ReactNode;
-  showTriangle?: boolean;
+  isPopover: boolean;
 };
 export const SiteCard = ({
   site,
   onShowSiteOnMap,
   buttons,
-  showTriangle,
+  isPopover,
 }: SiteCardProps) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
@@ -38,8 +38,11 @@ export const SiteCard = ({
   );
 
   return (
-    <Card onPress={onCardPress} buttons={buttons} showTriangle={showTriangle}>
-      <Heading variant="h6" color="primary.main">
+    <Card onPress={onCardPress} buttons={buttons} isPopover={isPopover}>
+      <Heading
+        variant="h6"
+        color="primary.main"
+        style={isPopover ? styles.popoverHeader : {}}>
         {site.name}
       </Heading>
       {project && <Heading size="md">{project.name}</Heading>}
@@ -77,4 +80,9 @@ export const SiteCard = ({
   );
 };
 
-const styles = StyleSheet.create({mapView: {height: 60, width: 60}});
+const styles = StyleSheet.create({
+  mapView: {height: 60, width: 60},
+  popoverHeader: {
+    paddingRight: 30,
+  },
+});

--- a/dev-client/src/components/sites/SiteCard.tsx
+++ b/dev-client/src/components/sites/SiteCard.tsx
@@ -42,7 +42,7 @@ export const SiteCard = ({
       <Heading
         variant="h6"
         color="primary.main"
-        style={isPopover ? styles.popoverHeader : {}}>
+        pr={isPopover ? '30px' : undefined}>
         {site.name}
       </Heading>
       {project && <Heading size="md">{project.name}</Heading>}
@@ -80,9 +80,4 @@ export const SiteCard = ({
   );
 };
 
-const styles = StyleSheet.create({
-  mapView: {height: 60, width: 60},
-  popoverHeader: {
-    paddingRight: 30,
-  },
-});
+const styles = StyleSheet.create({mapView: {height: 60, width: 60}});

--- a/dev-client/src/components/sites/SiteCard.tsx
+++ b/dev-client/src/components/sites/SiteCard.tsx
@@ -16,7 +16,7 @@ type SiteCardProps = {
   site: Site;
   onShowSiteOnMap?: (site: Site) => void;
   buttons?: React.ReactNode;
-  isPopover: boolean;
+  isPopover?: boolean;
 };
 export const SiteCard = ({
   site,

--- a/dev-client/src/screens/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen.tsx
@@ -111,6 +111,16 @@ export const HomeScreen = () => {
     [camera],
   );
 
+  const [finishedInitialCameraMove, setFinishedInitialCameraMove] =
+    useState(false);
+
+  const onMapFinishedLoading = useCallback(() => {
+    if (finishedInitialCameraMove !== true && initialLocation !== null) {
+      moveToPoint(initialLocation);
+      setFinishedInitialCameraMove(true);
+    }
+  }, [initialLocation, moveToPoint, finishedInitialCameraMove]);
+
   useEffect(() => {
     if (initialLocation !== null && camera.current !== undefined) {
       moveToPoint(initialLocation);
@@ -191,6 +201,7 @@ export const HomeScreen = () => {
               calloutState={calloutState}
               setCalloutState={setCalloutState}
               styleURL={mapStyleURL}
+              onMapFinishedLoading={onMapFinishedLoading}
             />
           </Box>
           <SiteListBottomSheet


### PR DESCRIPTION
## Description
This is a collection of small updates to the home screen map UI/behavior:
- Fixes an issue where initial camera move didn't fire on iOS
- Sets the default map location to the USA
- Adds a drop shadow to the location popovers
- Adds padding to separate the site name header from the popover close button

### Related Issues
Fixes #499
Refs #436
