### PR TITLE
feat: home screen updates

### DIFF
--- a/dev-client/src/components/home/CustomUserLocation.tsx
+++ b/dev-client/src/components/home/CustomUserLocation.tsx
@@ -1,4 +1,3 @@
-import React, {FC} from 'react';
 import {UserLocation, CircleLayer, Location} from '@rnmapbox/maps';
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
 
@@ -23,33 +22,35 @@ const layerStyles = {
   },
 };
 
-interface UntappableUserLocationProps {
+type CustomUserLocationProps = {
   updateUserLocation?: (location: Location) => void;
-}
+};
 
-export const UntappableUserLocation: FC<UntappableUserLocationProps> = ({
+export const CustomUserLocation = ({
   updateUserLocation,
-}) => (
-  <UserLocation
-    onUpdate={updateUserLocation}
-    minDisplacement={USER_DISPLACEMENT_MIN_DISTANCE_M}>
-    <CircleLayer
-      key="mapboxUserLocationPulseCircle"
-      id="mapboxUserLocationPulseCircle"
-      belowLayerID="sitesLayer"
-      style={layerStyles.pulse}
-    />
-    <CircleLayer
-      key="mapboxUserLocationWhiteCircle"
-      id="mapboxUserLocationWhiteCircle"
-      belowLayerID="sitesLayer"
-      style={layerStyles.background}
-    />
-    <CircleLayer
-      key="mapboxUserLocationBlueCircle"
-      id="mapboxUserLocationBlueCircle"
-      aboveLayerID="mapboxUserLocationWhiteCircle"
-      style={layerStyles.foreground}
-    />
-  </UserLocation>
-);
+}: CustomUserLocationProps) => {
+  return (
+    <UserLocation
+      onUpdate={updateUserLocation}
+      minDisplacement={USER_DISPLACEMENT_MIN_DISTANCE_M}>
+      <CircleLayer
+        key="mapboxUserLocationPulseCircle"
+        id="mapboxUserLocationPulseCircle"
+        belowLayerID="sitesLayer"
+        style={layerStyles.pulse}
+      />
+      <CircleLayer
+        key="mapboxUserLocationWhiteCircle"
+        id="mapboxUserLocationWhiteCircle"
+        belowLayerID="sitesLayer"
+        style={layerStyles.background}
+      />
+      <CircleLayer
+        key="mapboxUserLocationBlueCircle"
+        id="mapboxUserLocationBlueCircle"
+        aboveLayerID="mapboxUserLocationWhiteCircle"
+        style={layerStyles.foreground}
+      />
+    </UserLocation>
+  );
+};

--- a/dev-client/src/components/home/CustomUserLocation.tsx
+++ b/dev-client/src/components/home/CustomUserLocation.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 import {UserLocation, CircleLayer, Location} from '@rnmapbox/maps';
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
 

--- a/dev-client/src/components/home/CustomUserLocation.tsx
+++ b/dev-client/src/components/home/CustomUserLocation.tsx
@@ -23,15 +23,22 @@ const layerStyles = {
 };
 
 type CustomUserLocationProps = {
+  onUserLocationPress: (event?: GeoJSON.GeoJsonProperties) => void;
   updateUserLocation?: (location: Location) => void;
 };
 
 export const CustomUserLocation = ({
+  onUserLocationPress,
   updateUserLocation,
 }: CustomUserLocationProps) => {
+  const handleUserLocationPress = (event?: GeoJSON.GeoJsonProperties) => {
+    onUserLocationPress(event);
+  };
+
   return (
     <UserLocation
       onUpdate={updateUserLocation}
+      onPress={handleUserLocationPress}
       minDisplacement={USER_DISPLACEMENT_MIN_DISTANCE_M}>
       <CircleLayer
         key="mapboxUserLocationPulseCircle"

--- a/dev-client/src/components/home/CustomUserLocation.tsx
+++ b/dev-client/src/components/home/CustomUserLocation.tsx
@@ -1,0 +1,55 @@
+import React, {FC} from 'react';
+import {UserLocation, CircleLayer, Location} from '@rnmapbox/maps';
+import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
+
+const mapboxBlue = 'rgba(51, 181, 229, 100)';
+
+const layerStyles = {
+  pulse: {
+    circleRadius: 15,
+    circleColor: mapboxBlue,
+    circleOpacity: 0.2,
+    circlePitchAlignment: 'map',
+  },
+  background: {
+    circleRadius: 9,
+    circleColor: '#fff',
+    circlePitchAlignment: 'map',
+  },
+  foreground: {
+    circleRadius: 6,
+    circleColor: mapboxBlue,
+    circlePitchAlignment: 'map',
+  },
+};
+
+interface UntappableUserLocationProps {
+  updateUserLocation?: (location: Location) => void;
+}
+
+export const UntappableUserLocation: FC<UntappableUserLocationProps> = ({
+  updateUserLocation,
+}) => (
+  <UserLocation
+    onUpdate={updateUserLocation}
+    minDisplacement={USER_DISPLACEMENT_MIN_DISTANCE_M}>
+    <CircleLayer
+      key="mapboxUserLocationPulseCircle"
+      id="mapboxUserLocationPulseCircle"
+      belowLayerID="sitesLayer"
+      style={layerStyles.pulse}
+    />
+    <CircleLayer
+      key="mapboxUserLocationWhiteCircle"
+      id="mapboxUserLocationWhiteCircle"
+      belowLayerID="sitesLayer"
+      style={layerStyles.background}
+    />
+    <CircleLayer
+      key="mapboxUserLocationBlueCircle"
+      id="mapboxUserLocationBlueCircle"
+      aboveLayerID="mapboxUserLocationWhiteCircle"
+      style={layerStyles.foreground}
+    />
+  </UserLocation>
+);

--- a/dev-client/src/components/home/MapSearch.tsx
+++ b/dev-client/src/components/home/MapSearch.tsx
@@ -119,9 +119,10 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
       top={0}
       zIndex={1}
       px={3}
-      py={3}>
-      <HStack space={3}>
-        <View flex={1}>
+      py={3}
+      pointerEvents="box-none">
+      <HStack space={3} pointerEvents="box-none">
+        <View flex={1} pointerEvents="box-none">
           <Autocomplete
             data={suggestions}
             hideResults={hideResults}

--- a/dev-client/src/components/home/MapSearch.tsx
+++ b/dev-client/src/components/home/MapSearch.tsx
@@ -96,6 +96,11 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
     Keyboard.dismiss();
   };
 
+  const clearQuery = () => {
+    setQuery('');
+    setHideResults(true);
+  };
+
   async function lookupFeature(mapboxId: string) {
     let {features} = await retrieveFeature(mapboxId);
     // TODO: For now we are just going to zoom to the first feature
@@ -151,6 +156,11 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
                 value={query}
                 placeholder={t('search.placeholder')}
                 InputLeftElement={<Icon ml={3} name="search" size="md" />}
+                InputRightElement={
+                  query.length > 0 ? (
+                    <Icon mr={3} name="close" size="sm" onPress={clearQuery} />
+                  ) : undefined
+                }
               />
             )}
           />

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -33,7 +33,7 @@ export type SiteMapProps = {
   calloutState: CalloutState;
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
-  onMapFinishedLoading?: () => void;
+  onMapFinishedLoading: () => void;
 };
 
 const SiteMap = (

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -1,4 +1,4 @@
-import Mapbox, {Camera, Location, UserLocation} from '@rnmapbox/maps';
+import Mapbox, {Camera, Location} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/src/types/OnPressEvent';
 import {
   memo,
@@ -13,7 +13,6 @@ import Icon from 'react-native-vector-icons/MaterialIcons';
 import {useTheme} from 'native-base';
 import {Keyboard, PixelRatio, Platform, StyleSheet} from 'react-native';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/components/Camera';
 import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen';
 import {
@@ -23,6 +22,7 @@ import {
 import {siteFeatureCollection} from 'terraso-mobile-client/components/home/siteFeatureCollection';
 import {repositionCamera} from 'terraso-mobile-client/components/home/repositionCamera';
 import {SiteMapCallout} from 'terraso-mobile-client/components/home/SiteMapCallout';
+import {CustomUserLocation} from 'terraso-mobile-client/components/home/CustomUserLocation';
 
 const DEFAULT_LOCATION = [-98.0, 38.5];
 const MAX_EXPANSION_ZOOM = 15;
@@ -277,6 +277,7 @@ const SiteMap = (
         />
         <Mapbox.CircleLayer
           id="siteClusterCircleLayer"
+          belowLayerID="sitesLayer"
           style={mapStyles.siteClusterCircleLayer}
           filter={['has', 'point_count']}
         />
@@ -295,10 +296,7 @@ const SiteMap = (
           style={mapStyles.temporarySiteLayer}
         />
       </Mapbox.ShapeSource>
-      <UserLocation
-        onUpdate={updateUserLocation}
-        minDisplacement={USER_DISPLACEMENT_MIN_DISTANCE_M}
-      />
+      <CustomUserLocation updateUserLocation={updateUserLocation} />
       <SiteMapCallout
         sites={sites}
         state={calloutState}

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -161,7 +161,11 @@ const SiteMap = (
 
   const onPress = useCallback(
     async (feature: GeoJSON.Feature) => {
-      if (feature.geometry !== null && feature.geometry.type === 'Point') {
+      if (
+        calloutState.kind === 'none' &&
+        feature.geometry !== null &&
+        feature.geometry.type === 'Point'
+      ) {
         const currentZoom = await mapRef.current?.getZoom();
         if (!currentZoom) {
           console.error('Unable to fetch the current zoom level');
@@ -185,7 +189,7 @@ const SiteMap = (
         setCalloutState({kind: 'none'});
       }
     },
-    [setCalloutState],
+    [calloutState, setCalloutState],
   );
 
   const mapImages = useMemo(

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -190,8 +190,8 @@ const SiteMap = (
 
   const onUserLocationPress = useCallback(
     async (event?: GeoJSON.GeoJsonProperties) => {
-      if (event && event.features[0] !== null) {
-        const feature = event.features[0];
+      if (event?.features[0] !== null) {
+        const feature = event?.features[0];
         onPress(feature);
       }
     },

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -192,6 +192,16 @@ const SiteMap = (
     [calloutState, setCalloutState],
   );
 
+  const onUserLocationPress = useCallback(
+    async (event?: GeoJSON.GeoJsonProperties) => {
+      if (event != null && event.features[0] != null) {
+        const feature = event.features[0];
+        onPress(feature);
+      }
+    },
+    [onPress],
+  );
+
   const mapImages = useMemo(
     () => ({
       sitePin: Icon.getImageSourceSync(
@@ -300,7 +310,10 @@ const SiteMap = (
           style={mapStyles.temporarySiteLayer}
         />
       </Mapbox.ShapeSource>
-      <CustomUserLocation updateUserLocation={updateUserLocation} />
+      <CustomUserLocation
+        onUserLocationPress={onUserLocationPress}
+        updateUserLocation={updateUserLocation}
+      />
       <SiteMapCallout
         sites={sites}
         state={calloutState}

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -190,8 +190,8 @@ const SiteMap = (
 
   const onUserLocationPress = useCallback(
     async (event?: GeoJSON.GeoJsonProperties) => {
-      if (event?.features[0] !== null) {
-        const feature = event?.features[0];
+      if (event?.features[0]) {
+        const feature = event.features[0];
         onPress(feature);
       }
     },

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -161,11 +161,7 @@ const SiteMap = (
 
   const onPress = useCallback(
     async (feature: GeoJSON.Feature) => {
-      if (
-        calloutState.kind === 'none' &&
-        feature.geometry !== null &&
-        feature.geometry.type === 'Point'
-      ) {
+      if (calloutState.kind === 'none' && feature.geometry?.type === 'Point') {
         const currentZoom = await mapRef.current?.getZoom();
         if (!currentZoom) {
           console.error('Unable to fetch the current zoom level');
@@ -194,7 +190,7 @@ const SiteMap = (
 
   const onUserLocationPress = useCallback(
     async (event?: GeoJSON.GeoJsonProperties) => {
-      if (event != null && event.features[0] != null) {
+      if (event && event.features[0] !== null) {
         const feature = event.features[0];
         onPress(feature);
       }

--- a/dev-client/src/components/home/SiteMap.tsx
+++ b/dev-client/src/components/home/SiteMap.tsx
@@ -33,7 +33,7 @@ export type SiteMapProps = {
   calloutState: CalloutState;
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
-  onMapFinishedLoading: () => void;
+  onMapFinishedLoading?: () => void;
 };
 
 const SiteMap = (


### PR DESCRIPTION
## Description
- Adds search bar button to clear search input 
- If a popover is open and user taps on the map, close the popover without opening another one
- Allow taps on the map through the transparent parts of the MapSearch component
- Allow users to open site popovers that are near or on to user's location. This was a tricky one; there's a known issue with rnmapbox where the blue UserLocation circle prevents taps on anything nearby. The recommended workaround, as far as I can tell, is to override the default UserLocation component and define a relevant belowLayerID (in our case, 'sitesLayer'). https://github.com/rnmapbox/maps/issues/241
- Allow users to open location popover near or on user's location. Mapbox's default UserLocation onPress handler doesn't have a defined return type, but it does return properties we can conditionally pass through to the existing SiteMap onPress handler. This allows users to open a location popover by tapping on their location if no sites already exist.

### Related Issues
Refs #426 
Refs #436 
Refs #333 
Refs #444 