### PR TITLE
fix: adjust keyboard settings for email address

### DIFF
--- a/dev-client/src/components/common/FreeformTextInput.tsx
+++ b/dev-client/src/components/common/FreeformTextInput.tsx
@@ -1,9 +1,10 @@
-import {FormControl, Input} from 'native-base';
+import {FormControl, IInputProps, Input} from 'native-base';
 import {useCallback, useState} from 'react';
 
 type Props = {
   validationFunc: (input: string) => Promise<null | string>;
   placeholder?: string;
+  inputProps?: IInputProps;
 };
 
 /**
@@ -11,7 +12,11 @@ type Props = {
  * On submit, the result is validated. If incorrect, an error message
  * is displayed.
  */
-export const FreeformTextInput = ({validationFunc, placeholder}: Props) => {
+export const FreeformTextInput = ({
+  validationFunc,
+  placeholder,
+  inputProps,
+}: Props) => {
   const [hasError, setHasError] = useState<null | string>(null);
   const [textValue, setTextValue] = useState<string>('');
 
@@ -32,6 +37,7 @@ export const FreeformTextInput = ({validationFunc, placeholder}: Props) => {
         onSubmitEditing={handleSubmit}
         onChangeText={text => setTextValue(text)}
         value={textValue}
+        {...inputProps}
       />
       <FormControl.ErrorMessage>{hasError}</FormControl.ErrorMessage>
     </FormControl>

--- a/dev-client/src/components/projects/AddUserToProjectScreen/index.tsx
+++ b/dev-client/src/components/projects/AddUserToProjectScreen/index.tsx
@@ -113,9 +113,11 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
         <FreeformTextInput
           validationFunc={validationFunc}
           placeholder={t('general.example_email')}
-          autoComplete="email"
-          autoCapitalize="none"
-          keyboardType="email-address"
+          inputProps={{
+            autoComplete: 'email',
+            autoCapitalize: 'none',
+            keyboardType: 'email-address',
+          }}
         />
       </Box>
       <MembershipControlList

--- a/dev-client/src/components/projects/AddUserToProjectScreen/index.tsx
+++ b/dev-client/src/components/projects/AddUserToProjectScreen/index.tsx
@@ -113,6 +113,9 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
         <FreeformTextInput
           validationFunc={validationFunc}
           placeholder={t('general.example_email')}
+          autoComplete="email"
+          autoCapitalize="none"
+          keyboardType="email-address"
         />
       </Box>
       <MembershipControlList


### PR DESCRIPTION
## Description
Adjust keyboard settings for email address:
* disable capitalization
* enable autofill
* use email address-optimized keyboard

Note sure if this works with `FreeformTextInput` as-is or needs to be passed in as XYZProps.