### PR TITLE
fix: improve Android build configuration

### DIFF
--- a/dev-client/android/build.gradle
+++ b/dev-client/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.8.10'
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
@@ -18,6 +19,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 

--- a/dev-client/android/build.gradle
+++ b/dev-client/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
     }
 }

--- a/dev-client/android/gradle.properties
+++ b/dev-client/android/gradle.properties
@@ -44,3 +44,8 @@ newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+# WARNING:Software Components will not be created automatically for Maven publishing from
+# Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property
+# android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.
+android.disableAutomaticComponentCreation=true

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -7270,9 +7270,9 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.11",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
-      "integrity": "sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg=="
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.7",
@@ -7298,9 +7298,9 @@
       }
     },
     "node_modules/@types/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-mnb1ngaGQPm6LFZaNdh3xPOoQMkrQb/KBPhPPN2p2Wk8XgeUqWj6xPnvyQ8rvcK/VFritVmQG8tvQuy7g+9/nQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.3.tgz",
+      "integrity": "sha512-FdHbjLiN2e8fk9QYQyVYZrK8svUDJpxSaSWLUga8EZS1RGAvvrqM9zbVARBtQuYPeLgnJxM2xloOswPwj1o2cQ==",
       "dependencies": {
         "ci-info": "^3.1.0"
       }
@@ -7349,9 +7349,9 @@
       "dev": true
     },
     "node_modules/@types/minimist": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
-      "integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.4.tgz",
+      "integrity": "sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ=="
     },
     "node_modules/@types/node": {
       "version": "20.7.1",
@@ -7359,9 +7359,9 @@
       "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg=="
     },
     "node_modules/@types/normalize-package-data": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
-      "integrity": "sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.3.tgz",
+      "integrity": "sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -18285,9 +18285,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.15.tgz",
-      "integrity": "sha512-lpT8hSQp9jAKp9mhtBU4Xjon8LPGBvLIuBiSVhMEtmLecTh2mO0tlqrAMp47tBXzMr13NJMQ2lf7RpQGLJ3HsQ=="
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
@@ -18917,9 +18917,9 @@
       "dev": true
     },
     "node_modules/tty-table": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.1.tgz",
-      "integrity": "sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.3.tgz",
+      "integrity": "sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "csv": "^5.5.3",


### PR DESCRIPTION
## Description
* Add Kotlin plugin to avoid warning:
> The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build. 
>This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.
>Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
>If the parent project does not need the plugin, add 'apply false' to the plugin line.
>See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
>The Kotlin plugin was loaded in the following projects: ':react-native-gesture-handler', ':rnmapbox_maps'

* Remove version number from gradle plugin to fix debug build failure on macOS
```
> Task :app:compileDebugJavaWithJavac FAILED
/Users/paul/.dev/mobile-client/dev-client/android/app/build/generated/rncli/src/main/java/com/facebook/react/PackageList.java:17: error: cannot find symbol
import com.rnappauth.RNAppAuthPackage```