### PR TITLE
fix: Adjusted SafeAreaView to fit on all devices

### DIFF
--- a/dev-client/src/components/home/BottomSheet.tsx
+++ b/dev-client/src/components/home/BottomSheet.tsx
@@ -47,6 +47,7 @@ import {SearchBar} from 'terraso-mobile-client/components/common/search/SearchBa
 import {SiteFilter} from 'terraso-mobile-client/components/sites/filter';
 import {ProjectSelect} from 'terraso-mobile-client/components/projects/ProjectSelect';
 import {USER_ROLES} from 'terraso-mobile-client/constants';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 const EmptySiteMessage = () => {
   const {t} = useTranslation();
@@ -63,6 +64,24 @@ const EmptySiteMessage = () => {
   );
 };
 
+/**
+ * This function calculated the initial snap value to the bottom sheet depending on the device specifications.
+ * To adjust this function consider change the result variable to desired minimum and maximum value
+ * @param bottomInsets Bottom insets value of the device
+ * @returns Starting snap value in %
+ */
+const getStartingSnapValue = (bottomInsets: number) => {
+  // We set the maximum bottom insets as 34 which is the currently maximum for a device
+  const weight0 = 1 - bottomInsets / 34; // Weight for 13
+  const weight34 = 1 - weight0; // Weight for 16
+
+  // Use the weights to calculate a weighted average
+  const result = weight0 * 13 + weight34 * 16;
+
+  // Round the result
+  return Math.round(result);
+};
+
 type Props = {
   sites: Site[];
   filteredSites: Site[];
@@ -76,6 +95,7 @@ export const SiteListBottomSheet = forwardRef<BottomSheetMethods, Props>(
   ) => {
     const {t} = useTranslation();
     const isLoadingData = useSelector(state => state.soilId.loading);
+    const deviceBottomInsets = useSafeAreaInsets().bottom;
 
     const renderSite = useCallback(
       ({item}: {item: Site}) => (
@@ -89,8 +109,12 @@ export const SiteListBottomSheet = forwardRef<BottomSheetMethods, Props>(
     );
 
     const snapPoints = useMemo(
-      () => ['15%', sites.length === 0 ? '50%' : '75%', '100%'],
-      [sites.length],
+      () => [
+        `${getStartingSnapValue(deviceBottomInsets)}%`,
+        sites.length === 0 ? '50%' : '75%',
+        '100%',
+      ],
+      [sites.length, deviceBottomInsets],
     );
 
     const {colors} = useTheme();

--- a/dev-client/src/screens/ScreenScaffold.tsx
+++ b/dev-client/src/screens/ScreenScaffold.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Box, Row, Heading, Column} from 'native-base';
+import {Box, Row, Heading, Column, useTheme} from 'native-base';
 import {
   IconButton,
   IconButtonProps,
@@ -32,8 +32,8 @@ import {useDispatch, useSelector} from 'terraso-mobile-client/model/store';
 import {useTranslation} from 'react-i18next';
 import {useRoute} from '@react-navigation/native';
 import {useNavigation} from 'terraso-mobile-client/screens/AppScaffold';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {StatusBar, View, LayoutChangeEvent} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {StatusBar, View, LayoutChangeEvent, StyleSheet} from 'react-native';
 import ConfirmModal from 'terraso-mobile-client/components/common/ConfirmModal';
 import {signOut} from 'terraso-client-shared/account/accountSlice';
 
@@ -69,15 +69,9 @@ export const AppBar = ({
 }: AppBarProps) => {
   const {t} = useTranslation();
   const route = useRoute();
-  const safeAreaTopInset = useSafeAreaInsets().top;
 
   return (
-    <Row
-      px="8px"
-      py="4px"
-      pt={`${safeAreaTopInset}px`}
-      minHeight="56px"
-      bg="primary.main">
+    <Row px="8px" py="4px" minHeight="56px" bg="primary.main">
       <Row flex={1} space="24px" alignItems="center">
         {LeftButton}
         <Heading variant="h6" color="primary.contrast">
@@ -158,6 +152,8 @@ export const ScreenScaffold = ({
   AppBar: PropsAppBar = <AppBar />,
   BottomNavigation: PropsBottomNavigation = <BottomNavigation />,
 }: Props) => {
+  const {colors} = useTheme();
+
   const [headerHeight, setHeaderHeight] = useState<number | undefined>(
     undefined,
   );
@@ -168,7 +164,11 @@ export const ScreenScaffold = ({
   );
 
   return (
-    <>
+    <SafeAreaView
+      style={[
+        styles.safeAreaContainer,
+        {backgroundColor: colors.primary.main},
+      ]}>
       <StatusBar
         barStyle="light-content"
         translucent
@@ -181,6 +181,12 @@ export const ScreenScaffold = ({
         </HeaderHeightContext.Provider>
         {PropsBottomNavigation}
       </Column>
-    </>
+    </SafeAreaView>
   );
 };
+
+const styles = StyleSheet.create({
+  safeAreaContainer: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Description
The current implementation of SafeAreaView was not including the bottom insets, so for example an iPhone 15 pro max the tab bar was not being displayed correctly. This PR not only adjust the bottom padding but also adjusts the sites listing initial snap point based on this values.