### PR TITLE
feat: create privacy bottom sheet

### DIFF
--- a/dev-client/src/components/common/Icons.tsx
+++ b/dev-client/src/components/common/Icons.tsx
@@ -88,6 +88,7 @@ export const HorizontalIconButton = React.forwardRef(
   ) => {
     const icon = (
       <NativeIconButton
+        p={0}
         ref={ref}
         icon={<Icon as={as} name={name} />}
         {...props}
@@ -96,7 +97,7 @@ export const HorizontalIconButton = React.forwardRef(
 
     return (
       <Pressable onPress={props.onPress}>
-        <Box p="1">
+        <Box>
           <HStack>
             {icon}
             <Text

--- a/dev-client/src/components/common/ScreenFormWrapper.tsx
+++ b/dev-client/src/components/common/ScreenFormWrapper.tsx
@@ -88,7 +88,7 @@ export const ScreenFormWrapper = forwardRef(
             <Spacer />
             <ConfirmModal
               trigger={onOpen => (
-                <Box pt={1} pr={5}>
+                <Box pt={2} pr={5}>
                   <HorizontalIconButton
                     p={0}
                     name="delete"

--- a/dev-client/src/components/common/infoModals/InfoModal.tsx
+++ b/dev-client/src/components/common/infoModals/InfoModal.tsx
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
 import {Box} from 'native-base';
 import {forwardRef} from 'react';
 import {

--- a/dev-client/src/components/common/infoModals/InfoModal.tsx
+++ b/dev-client/src/components/common/infoModals/InfoModal.tsx
@@ -1,0 +1,33 @@
+import {Box} from 'native-base';
+import {forwardRef} from 'react';
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import {useHeaderHeight} from 'terraso-mobile-client/screens/ScreenScaffold';
+import {CardCloseButton} from 'terraso-mobile-client/components/common/Card';
+import {PrivacyInfoContent} from 'terraso-mobile-client/components/common/infoModals/PrivacyInfoContent';
+
+export const InfoModal = forwardRef<BottomSheetModal, {onClose: () => void}>(
+  ({onClose}, ref) => {
+    const headerHeight = useHeaderHeight();
+    return (
+      <BottomSheetModal
+        ref={ref}
+        snapPoints={['100%']}
+        handleComponent={null}
+        topInset={headerHeight}
+        backdropComponent={BackdropComponent}>
+        <PrivacyInfoContent />
+        <Box position="absolute" top="18px" right="23px">
+          <CardCloseButton onPress={onClose} />
+        </Box>
+      </BottomSheetModal>
+    );
+  },
+);
+
+const BackdropComponent = (props: BottomSheetBackdropProps) => (
+  <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} />
+);

--- a/dev-client/src/components/common/infoModals/PrivacyInfoContent.tsx
+++ b/dev-client/src/components/common/infoModals/PrivacyInfoContent.tsx
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
 import {Column, Heading, Text, Box} from 'native-base';
 import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
 import {Linking} from 'react-native';

--- a/dev-client/src/components/common/infoModals/PrivacyInfoContent.tsx
+++ b/dev-client/src/components/common/infoModals/PrivacyInfoContent.tsx
@@ -1,0 +1,71 @@
+import {Column, Heading, Text} from 'native-base';
+import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
+import {Linking} from 'react-native';
+import {Trans, useTranslation} from 'react-i18next';
+import {HorizontalIconButton} from 'terraso-mobile-client/components/common/Icons';
+
+export const PrivacyInfoContent = () => {
+  const {t} = useTranslation();
+
+  return (
+    <BottomSheetScrollView>
+      <Column space={3} pb="65%" pt={5} px={5} mt="48px">
+        <Heading w="full" textAlign="left">
+          {t('general.info.privacy_title')}
+        </Heading>
+        <Text variant="body1">
+          <Trans i18nKey="general.info.privacy_item1">
+            <Text bold>first</Text>
+            <Text>second</Text>
+          </Trans>
+        </Text>
+        <Text variant="body1">
+          <Trans i18nKey="general.info.privacy_item2">
+            <Text bold>first</Text>
+            <Text>second</Text>
+          </Trans>
+        </Text>
+        <HorizontalIconButton
+          name={'open-in-new'}
+          label={t('general.info.data_portal_link_text')}
+          isUppercase={true}
+          onPress={() =>
+            Linking.openURL(t('general.info.data_portal_link_url'))
+          }
+        />
+        <Text variant="body1">
+          <Trans i18nKey="general.info.privacy_item3">
+            <Text bold>first</Text>
+            <Text>second</Text>
+          </Trans>
+        </Text>
+        <Text variant="body1">
+          <Trans i18nKey="general.info.privacy_item4">
+            <Text bold>first</Text>
+            <Text>second</Text>
+          </Trans>
+        </Text>
+        <Text variant="body1">
+          <Trans i18nKey="general.info.privacy_item5">
+            <Text bold>first</Text>
+            <Text>second</Text>
+          </Trans>
+        </Text>
+        <Text variant="body1">
+          <Trans i18nKey="general.info.privacy_item6">
+            <Text bold>first</Text>
+            <Text>second</Text>
+          </Trans>
+        </Text>
+        <HorizontalIconButton
+          name={'open-in-new'}
+          label={"t('general.info.privacy_policy_link_text')"}
+          isUppercase={true}
+          onPress={() =>
+            Linking.openURL(t('general.info.privacy_policy_link_url'))
+          }
+        />
+      </Column>
+    </BottomSheetScrollView>
+  );
+};

--- a/dev-client/src/components/common/infoModals/PrivacyInfoContent.tsx
+++ b/dev-client/src/components/common/infoModals/PrivacyInfoContent.tsx
@@ -1,4 +1,4 @@
-import {Column, Heading, Text} from 'native-base';
+import {Column, Heading, Text, Box} from 'native-base';
 import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
 import {Linking} from 'react-native';
 import {Trans, useTranslation} from 'react-i18next';
@@ -25,14 +25,17 @@ export const PrivacyInfoContent = () => {
             <Text>second</Text>
           </Trans>
         </Text>
-        <HorizontalIconButton
-          name={'open-in-new'}
-          label={t('general.info.data_portal_link_text')}
-          isUppercase={true}
-          onPress={() =>
-            Linking.openURL(t('general.info.data_portal_link_url'))
-          }
-        />
+        <Box pt={1} pb={1}>
+          <HorizontalIconButton
+            name={'open-in-new'}
+            label={t('general.info.data_portal_link_text')}
+            colorScheme="primary.main"
+            isUppercase={true}
+            onPress={() =>
+              Linking.openURL(t('general.info.data_portal_link_url'))
+            }
+          />
+        </Box>
         <Text variant="body1">
           <Trans i18nKey="general.info.privacy_item3">
             <Text bold>first</Text>
@@ -57,14 +60,17 @@ export const PrivacyInfoContent = () => {
             <Text>second</Text>
           </Trans>
         </Text>
-        <HorizontalIconButton
-          name={'open-in-new'}
-          label={"t('general.info.privacy_policy_link_text')"}
-          isUppercase={true}
-          onPress={() =>
-            Linking.openURL(t('general.info.privacy_policy_link_url'))
-          }
-        />
+        <Box pt={1} pb={1}>
+          <HorizontalIconButton
+            name={'open-in-new'}
+            label={t('general.info.privacy_policy_link_text')}
+            colorScheme="primary.main"
+            isUppercase={true}
+            onPress={() =>
+              Linking.openURL(t('general.info.privacy_policy_link_url'))
+            }
+          />
+        </Box>
       </Column>
     </BottomSheetScrollView>
   );

--- a/dev-client/src/components/projects/CreateProjectView/Form.tsx
+++ b/dev-client/src/components/projects/CreateProjectView/Form.tsx
@@ -94,6 +94,7 @@ export type ProjectFormValues = {
 
 type Props = {
   editForm?: boolean;
+  onInfoPress: () => void;
 };
 
 const SharedFormComponents = (showPlaceholders: boolean, t: TFunction) => {
@@ -159,7 +160,7 @@ export const EditForm = ({
   );
 };
 
-export default function Form({editForm = false}: Props) {
+export default function Form({editForm = false, onInfoPress}: Props) {
   const {t} = useTranslation();
   const {handleChange, handleBlur, values} =
     useFormikContext<ProjectFormValues>();
@@ -195,7 +196,11 @@ export default function Form({editForm = false}: Props) {
         label={
           <HStack alignItems="center">
             <Heading size="sm">{t('projects.create.privacy_label')}</Heading>
-            <IconButton name="info" _icon={{color: 'action.active'}} />
+            <IconButton
+              name="info"
+              onPress={onInfoPress}
+              _icon={{color: 'action.active'}}
+            />
           </HStack>
         }
         options={{

--- a/dev-client/src/components/projects/CreateProjectView/index.tsx
+++ b/dev-client/src/components/projects/CreateProjectView/index.tsx
@@ -26,7 +26,6 @@ import {useNavigation} from 'terraso-mobile-client/screens/AppScaffold';
 import {Formik} from 'formik';
 import {useTranslation} from 'react-i18next';
 import {useMemo} from 'react';
-import {Platform} from 'react-native';
 import {PROJECT_DEFAULT_MEASUREMENT_UNITS} from 'terraso-mobile-client/constants';
 
 type Props = {

--- a/dev-client/src/components/projects/CreateProjectView/index.tsx
+++ b/dev-client/src/components/projects/CreateProjectView/index.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Box, Fab, ScrollView} from 'native-base';
+import {Box, Button, KeyboardAvoidingView, ScrollView} from 'native-base';
 import Form, {
   ProjectFormValues,
   projectValidationSchema,
@@ -26,9 +26,14 @@ import {useNavigation} from 'terraso-mobile-client/screens/AppScaffold';
 import {Formik} from 'formik';
 import {useTranslation} from 'react-i18next';
 import {useMemo} from 'react';
+import {Platform} from 'react-native';
 import {PROJECT_DEFAULT_MEASUREMENT_UNITS} from 'terraso-mobile-client/constants';
 
-export default function CreateProjectView() {
+type Props = {
+  onInfoPress: () => void;
+};
+
+export const CreateProjectView = ({onInfoPress}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigation = useNavigation();
@@ -58,21 +63,25 @@ export default function CreateProjectView() {
       }}>
       {({isSubmitting, handleSubmit}) => {
         return (
-          <>
+          <KeyboardAvoidingView flex={1}>
             <ScrollView bg="background.default">
               <Box pt="20%" mx={5}>
-                <Form />
+                <Form onInfoPress={onInfoPress} />
               </Box>
             </ScrollView>
-            <Fab
-              label={t('general.save_fab')}
-              onPress={() => handleSubmit()}
-              disabled={isSubmitting}
-              renderInPortal={false}
-            />
-          </>
+            <Box position="absolute" bottom={8} right={3} p={3}>
+              <Button
+                onPress={() => handleSubmit()}
+                disabled={isSubmitting}
+                shadow={5}
+                size={'lg'}
+                _text={{textTransform: 'uppercase'}}>
+                {t('general.save_fab')}
+              </Button>
+            </Box>
+          </KeyboardAvoidingView>
         );
       }}
     </Formik>
   );
-}
+};

--- a/dev-client/src/components/projects/ProjectInputTab.tsx
+++ b/dev-client/src/components/projects/ProjectInputTab.tsx
@@ -53,7 +53,7 @@ export const ProjectInputTab = ({
   const navigation = useNavigation();
   const project = useSelector(state => state.project.projects[projectId]);
   const dispatch = useDispatch();
-  const {onInfoPress} = useInfoPress();
+  const onInfoPress = useInfoPress();
 
   const onEditInstructions = useCallback(() => {
     return navigation.navigate('EDIT_PROJECT_INSTRUCTIONS', {project: project});

--- a/dev-client/src/components/projects/ProjectInputTab.tsx
+++ b/dev-client/src/components/projects/ProjectInputTab.tsx
@@ -18,6 +18,7 @@
 import {Button, Row, Text, Box, HStack} from 'native-base';
 import {useTranslation} from 'react-i18next';
 import {Accordion} from 'terraso-mobile-client/components/common/Accordion';
+import RadioBlock from 'terraso-mobile-client/components/common/RadioBlock';
 import {FormSwitch} from 'terraso-mobile-client/components/common/Form';
 import {useDispatch, useSelector} from 'terraso-mobile-client/model/store';
 import {
@@ -32,6 +33,7 @@ import {
   updateProjectDepthInterval,
   updateProjectSoilSettings,
 } from 'terraso-client-shared/soilId/soilIdSlice';
+import {updateProject} from 'terraso-client-shared/project/projectSlice';
 import {Icon, IconButton} from 'terraso-mobile-client/components/common/Icons';
 import {Modal} from 'terraso-mobile-client/components/common/Modal';
 import {AddIntervalModal} from 'terraso-mobile-client/components/dataInputs/AddIntervalModal';
@@ -39,6 +41,7 @@ import {useMemo, useCallback} from 'react';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {ScrollView} from 'react-native';
 import {useNavigation} from 'terraso-mobile-client/screens/AppScaffold';
+import {useInfoPress} from 'terraso-mobile-client/screens/ProjectViewScreen';
 
 type Props = NativeStackScreenProps<TabStackParamList, TabRoutes.INPUTS>;
 export const ProjectInputTab = ({
@@ -49,14 +52,52 @@ export const ProjectInputTab = ({
   const {t} = useTranslation();
   const navigation = useNavigation();
   const project = useSelector(state => state.project.projects[projectId]);
+  const dispatch = useDispatch();
+  const {onInfoPress} = useInfoPress();
 
   const onEditInstructions = useCallback(() => {
     return navigation.navigate('EDIT_PROJECT_INSTRUCTIONS', {project: project});
   }, [navigation, project]);
 
+  const onProjectPrivacyChanged = useCallback(
+    (privacy: 'PRIVATE' | 'PUBLIC') =>
+      dispatch(updateProject({id: project!.id, privacy})),
+    [project, dispatch],
+  );
+
   return (
     <ScrollView>
       <Box p={4} alignItems="flex-start">
+        <HStack pb={4}>
+          <RadioBlock
+            label={
+              <HStack>
+                <Text variant="body1" bold>
+                  {t('site.dashboard.privacy')}
+                </Text>
+                <IconButton
+                  pt={0}
+                  pb={0}
+                  pl={2}
+                  size="md"
+                  name="info"
+                  onPress={onInfoPress}
+                  _icon={{color: 'action.active'}}
+                />
+              </HStack>
+            }
+            options={{
+              PUBLIC: {text: t('privacy.PUBLIC.title')},
+              PRIVATE: {text: t('privacy.PRIVATE.title')},
+            }}
+            groupProps={{
+              name: 'project-privacy',
+              onChange: onProjectPrivacyChanged,
+              value: project.privacy,
+              ml: '',
+            }}
+          />
+        </HStack>
         <Text bold fontSize={'md'}>
           {t('projects.inputs.instructions.title')}
         </Text>

--- a/dev-client/src/components/projects/ProjectInputTab.tsx
+++ b/dev-client/src/components/projects/ProjectInputTab.tsx
@@ -87,8 +87,8 @@ export const ProjectInputTab = ({
               </HStack>
             }
             options={{
-              PUBLIC: {text: t('privacy.PUBLIC.title')},
-              PRIVATE: {text: t('privacy.PRIVATE.title')},
+              PUBLIC: {text: t('privacy.public.title')},
+              PRIVATE: {text: t('privacy.private.title')},
             }}
             groupProps={{
               name: 'project-privacy',

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -39,6 +39,7 @@ import {
   FormLabel,
   FormTooltip,
 } from 'terraso-mobile-client/components/common/Form';
+import {IconButton} from 'terraso-mobile-client/components/common/Icons';
 
 type FormState = Omit<
   InferType<ReturnType<typeof siteValidationSchema>>,
@@ -54,11 +55,13 @@ const CreateSiteForm = ({
   setValues,
   values,
   sitePin,
-}: FormikProps<FormState> & {sitePin: Coords | undefined}) => {
+  onInfoPress,
+}: FormikProps<FormState> & {
+  sitePin: Coords | undefined;
+  onInfoPress: () => void;
+}) => {
   const {t} = useTranslation();
-
   const {accuracyM} = useSelector(state => state.map.userLocation);
-
   const currentCoords = useMemo(() => sitePin, [sitePin]);
 
   useEffect(() => {
@@ -108,14 +111,15 @@ const CreateSiteForm = ({
       <FormField name="privacy">
         <FormLabel>
           {t('privacy.label')}
-          <FormTooltip icon="help">
-            <Text color="primary.contrast" variant="body1">
-              {t('site.create.privacy_tooltip')}
-              <Text underline color="primary.lightest">
-                {t('site.create.privacy_tooltip_link')}
-              </Text>
-            </Text>
-          </FormTooltip>
+          <IconButton
+            pt={0}
+            pb={0}
+            pl={2}
+            size="md"
+            name="info"
+            onPress={onInfoPress}
+            _icon={{color: 'primary'}}
+          />
         </FormLabel>
         <FormRadioGroup
           values={['PUBLIC', 'PRIVATE']}
@@ -143,16 +147,17 @@ type Props = {
   createSiteCallback: (
     input: SiteAddMutationInput,
   ) => Promise<Site | undefined>;
+  onInfoPress: () => void;
 };
 
 export const CreateSiteView = ({
   defaultProjectId,
   createSiteCallback,
   sitePin,
+  onInfoPress,
 }: Props) => {
   const {t} = useTranslation();
   const validationSchema = useMemo(() => siteValidationSchema(t), [t]);
-
   const userLocation = useSelector(state => state.map.userLocation);
   const defaultProject = useSelector(state =>
     defaultProjectId ? state.project.projects[defaultProjectId] : undefined,
@@ -189,7 +194,13 @@ export const CreateSiteView = ({
           projectId: defaultProject?.id,
           privacy: defaultProject?.privacy ?? 'PUBLIC',
         }}>
-        {props => <CreateSiteForm {...props} sitePin={sitePin} />}
+        {props => (
+          <CreateSiteForm
+            {...props}
+            sitePin={sitePin}
+            onInfoPress={onInfoPress}
+          />
+        )}
       </Formik>
     </ScrollView>
   );

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -133,7 +133,7 @@ const CreateSiteForm = ({
                 size="md"
                 name="info"
                 onPress={onInfoPress}
-                _icon={{color: 'primary'}}
+                _icon={{color: 'action.active'}}
               />
             </FormLabel>
             <FormRadioGroup

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -144,7 +144,7 @@ const CreateSiteForm = ({
                 <FormRadio
                   value={value}
                   isDisabled={projectPrivacy !== undefined}>
-                  {t(`privacy.${value}.title`)}
+                  {t(`privacy.${value.toLowerCase()}.title`)}
                 </FormRadio>
               )}
             />

--- a/dev-client/src/components/sites/CreateSiteView.tsx
+++ b/dev-client/src/components/sites/CreateSiteView.tsx
@@ -15,8 +15,18 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Text, Fab, FormControl, ScrollView, VStack} from 'native-base';
+import {
+  Text,
+  FormControl,
+  ScrollView,
+  VStack,
+  Spacer,
+  Button,
+  KeyboardAvoidingView,
+  Box,
+} from 'native-base';
 import {useCallback, useMemo, useEffect} from 'react';
+import {Platform} from 'react-native';
 import {SiteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 import {useNavigation} from 'terraso-mobile-client/screens/AppScaffold';
 import {siteValidationSchema} from 'terraso-mobile-client/components/sites/validation';
@@ -77,67 +87,82 @@ const CreateSiteForm = ({
   );
 
   return (
-    <VStack p="16px" pt="30px" space="18px">
-      <FormField name="name">
-        <FormLabel>{t('site.create.name_label')}</FormLabel>
-        <FormInput placeholder={t('site.create.name_placeholder')} />
-      </FormField>
-      <FormField name="coords">
-        <FormLabel>{t('site.create.location_label')}</FormLabel>
-        <Text>
-          {t('site.create.location_accuracy', {accuracyM: accuracyM})}
-        </Text>
-        <FormInput keyboardType="decimal-pad" />
-        <FormControl.Label variant="subtle">
-          {t('site.create.coords_label')}
-        </FormControl.Label>
-      </FormField>
-      <FormField name="projectId">
-        <FormLabel>
-          {t('site.create.add_to_project_label')}
-          <FormTooltip icon="help">
-            <Text color="primary.contrast" variant="body1">
-              {t('site.create.add_to_project_tooltip')}
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      flex={1}
+      keyboardVerticalOffset={40}>
+      <ScrollView>
+        <VStack p="16px" pt="30px" space="18px">
+          <FormField name="name">
+            <FormLabel>{t('site.create.name_label')}</FormLabel>
+            <FormInput placeholder={t('site.create.name_placeholder')} />
+          </FormField>
+          <FormField name="coords">
+            <FormLabel>{t('site.create.location_label')}</FormLabel>
+            <Text>
+              {t('site.create.location_accuracy', {accuracyM: accuracyM})}
             </Text>
-          </FormTooltip>
-        </FormLabel>
-        <ProjectSelect
-          projectId={values.projectId}
-          setProjectId={projectId =>
-            setValues(current => ({...current, projectId}))
-          }
-        />
-      </FormField>
-      <FormField name="privacy">
-        <FormLabel>
-          {t('privacy.label')}
-          <IconButton
-            pt={0}
-            pb={0}
-            pl={2}
-            size="md"
-            name="info"
-            onPress={onInfoPress}
-            _icon={{color: 'primary'}}
-          />
-        </FormLabel>
-        <FormRadioGroup
-          values={['PUBLIC', 'PRIVATE']}
-          variant="oneLine"
-          value={projectPrivacy ?? values.privacy}
-          renderRadio={value => (
-            <FormRadio value={value} isDisabled={projectPrivacy !== undefined}>
-              {t(`privacy.${value}.title`)}
-            </FormRadio>
-          )}
-        />
-      </FormField>
-      <Fab
-        label={t('general.save_fab')}
-        onPress={() => handleSubmit()}
-        disabled={isSubmitting}
-      />
-    </VStack>
+            <FormInput keyboardType="decimal-pad" />
+            <FormControl.Label variant="subtle">
+              {t('site.create.coords_label')}
+            </FormControl.Label>
+          </FormField>
+          <FormField name="projectId">
+            <FormLabel>
+              {t('site.create.add_to_project_label')}
+              <FormTooltip icon="help">
+                <Text color="primary.contrast" variant="body1">
+                  {t('site.create.add_to_project_tooltip')}
+                </Text>
+              </FormTooltip>
+            </FormLabel>
+            <ProjectSelect
+              projectId={values.projectId}
+              setProjectId={projectId =>
+                setValues(current => ({...current, projectId}))
+              }
+            />
+          </FormField>
+          <FormField name="privacy">
+            <FormLabel>
+              {t('privacy.label')}
+              <IconButton
+                pt={0}
+                pb={0}
+                pl={2}
+                size="md"
+                name="info"
+                onPress={onInfoPress}
+                _icon={{color: 'primary'}}
+              />
+            </FormLabel>
+            <FormRadioGroup
+              values={['PUBLIC', 'PRIVATE']}
+              variant="oneLine"
+              value={projectPrivacy ?? values.privacy}
+              renderRadio={value => (
+                <FormRadio
+                  value={value}
+                  isDisabled={projectPrivacy !== undefined}>
+                  {t(`privacy.${value}.title`)}
+                </FormRadio>
+              )}
+            />
+          </FormField>
+          <Spacer />
+        </VStack>
+      </ScrollView>
+      <Box position="absolute" bottom={10} right={3} p={3}>
+        <Button
+          onPress={() => handleSubmit()}
+          disabled={isSubmitting}
+          shadow={5}
+          size={'lg'}
+          _text={{textTransform: 'uppercase'}}>
+          {t('general.save_fab')}
+        </Button>
+      </Box>
+    </KeyboardAvoidingView>
   );
 };
 
@@ -184,24 +209,22 @@ export const CreateSiteView = ({
   );
 
   return (
-    <ScrollView>
-      <Formik<FormState>
-        onSubmit={onSave}
-        validationSchema={validationSchema}
-        initialValues={{
-          name: '',
-          coords: defaultCoords ? coordsToString(defaultCoords) : '',
-          projectId: defaultProject?.id,
-          privacy: defaultProject?.privacy ?? 'PUBLIC',
-        }}>
-        {props => (
-          <CreateSiteForm
-            {...props}
-            sitePin={sitePin}
-            onInfoPress={onInfoPress}
-          />
-        )}
-      </Formik>
-    </ScrollView>
+    <Formik<FormState>
+      onSubmit={onSave}
+      validationSchema={validationSchema}
+      initialValues={{
+        name: '',
+        coords: defaultCoords ? coordsToString(defaultCoords) : '',
+        projectId: defaultProject?.id,
+        privacy: defaultProject?.privacy ?? 'PUBLIC',
+      }}>
+      {props => (
+        <CreateSiteForm
+          {...props}
+          sitePin={sitePin}
+          onInfoPress={onInfoPress}
+        />
+      )}
+    </Formik>
   );
 };

--- a/dev-client/src/components/sites/LocationDashboardScreen.tsx
+++ b/dev-client/src/components/sites/LocationDashboardScreen.tsx
@@ -42,7 +42,7 @@ import {Button} from 'native-base';
 import {Icon} from 'terraso-mobile-client/components/common/Icons';
 import {InfoModal} from 'terraso-mobile-client/components/common/infoModals/InfoModal';
 
-const InfoPressContext = createContext({onInfoPress: () => {}});
+const InfoPressContext = createContext(() => {});
 
 export const useInfoPress = () => useContext(InfoPressContext);
 
@@ -134,7 +134,7 @@ export const LocationDashboardScreen = ({siteId, coords}: Props) => {
   );
 
   return (
-    <InfoPressContext.Provider value={{onInfoPress}}>
+    <InfoPressContext.Provider value={onInfoPress}>
       <BottomSheetModalProvider>
         <ScreenScaffold
           AppBar={

--- a/dev-client/src/components/sites/LocationDashboardView.tsx
+++ b/dev-client/src/components/sites/LocationDashboardView.tsx
@@ -87,7 +87,7 @@ const LocationPrediction = ({
 export const LocationDashboardView = ({siteId, coords}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
-  const {onInfoPress} = useInfoPress();
+  const onInfoPress = useInfoPress();
 
   const site = useSelector(state =>
     siteId === undefined ? undefined : state.site.sites[siteId],

--- a/dev-client/src/components/sites/LocationDashboardView.tsx
+++ b/dev-client/src/components/sites/LocationDashboardView.tsx
@@ -20,13 +20,15 @@ import {useTranslation} from 'react-i18next';
 import RadioBlock from 'terraso-mobile-client/components/common/RadioBlock';
 import {SitePrivacy, updateSite} from 'terraso-client-shared/site/siteSlice';
 import {useCallback} from 'react';
-import {Box, Divider, Text, Column} from 'native-base';
+import {Box, Divider, Text, Column, HStack} from 'native-base';
 import {Accordion} from 'terraso-mobile-client/components/common/Accordion';
 import {StaticMapView} from 'terraso-mobile-client/components/common/Map';
 import {StyleSheet} from 'react-native';
 import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {ScrollView} from 'react-native';
 import {ProjectInstructionsButton} from 'terraso-mobile-client/components/sites/ProjectInstructionsButton';
+import {IconButton} from 'terraso-mobile-client/components/common/Icons';
+import {useInfoPress} from 'terraso-mobile-client/components/sites/LocationDashboardScreen';
 
 const TEMP_ELEVATION = '1900 ft';
 const TEMP_ACCURACY = '20 ft';
@@ -40,7 +42,10 @@ const TEMP_SOIL_ID_CONFIDENCE = '80%';
 const TEMP_ECO_SITE_ID_CONFIDENCE = '80%';
 const TEMP_LCC_CONFIDENCE = '80%';
 
-type Props = {siteId?: string; coords?: Coords};
+type Props = {
+  siteId?: string;
+  coords?: Coords;
+};
 
 const LocationDetail = ({label, value}: {label: string; value: string}) => (
   <Text variant="body1">
@@ -82,6 +87,7 @@ const LocationPrediction = ({
 export const LocationDashboardView = ({siteId, coords}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
+  const {onInfoPress} = useInfoPress();
 
   const site = useSelector(state =>
     siteId === undefined ? undefined : state.site.sites[siteId],
@@ -125,23 +131,36 @@ export const LocationDashboardView = ({siteId, coords}: Props) => {
             />
           )}
           {site && !project && (
-            <RadioBlock
-              label={
-                <Text variant="body1" bold>
-                  {t('site.dashboard.privacy')}
-                </Text>
-              }
-              options={{
-                PUBLIC: {text: t('privacy.PUBLIC.title')},
-                PRIVATE: {text: t('privacy.PRIVATE.title')},
-              }}
-              groupProps={{
-                name: 'site-privacy',
-                onChange: onSitePrivacyChanged,
-                value: site.privacy,
-                ml: '',
-              }}
-            />
+            <HStack>
+              <RadioBlock
+                label={
+                  <HStack>
+                    <Text variant="body1" bold>
+                      {t('site.dashboard.privacy')}
+                    </Text>
+                    <IconButton
+                      pt={0}
+                      pb={0}
+                      pl={2}
+                      size="md"
+                      name="info"
+                      onPress={onInfoPress}
+                      _icon={{color: 'primary'}}
+                    />
+                  </HStack>
+                }
+                options={{
+                  PUBLIC: {text: t('privacy.PUBLIC.title')},
+                  PRIVATE: {text: t('privacy.PRIVATE.title')},
+                }}
+                groupProps={{
+                  name: 'site-privacy',
+                  onChange: onSitePrivacyChanged,
+                  value: site.privacy,
+                  ml: '',
+                }}
+              />
+            </HStack>
           )}
           <LocationDetail
             label={t('geo.latitude.title')}

--- a/dev-client/src/components/sites/LocationDashboardView.tsx
+++ b/dev-client/src/components/sites/LocationDashboardView.tsx
@@ -150,8 +150,8 @@ export const LocationDashboardView = ({siteId, coords}: Props) => {
                   </HStack>
                 }
                 options={{
-                  PUBLIC: {text: t('privacy.PUBLIC.title')},
-                  PRIVATE: {text: t('privacy.PRIVATE.title')},
+                  PUBLIC: {text: t('privacy.public.title')},
+                  PRIVATE: {text: t('privacy.private.title')},
                 }}
                 groupProps={{
                   name: 'site-privacy',

--- a/dev-client/src/screens/CreateProjectScreen.tsx
+++ b/dev-client/src/screens/CreateProjectScreen.tsx
@@ -15,17 +15,34 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import CreateProjectView from 'terraso-mobile-client/components/projects/CreateProjectView';
+import {useCallback, useRef} from 'react';
+import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {CreateProjectView} from 'terraso-mobile-client/components/projects/CreateProjectView';
 import {
   AppBar,
   ScreenCloseButton,
   ScreenScaffold,
 } from 'terraso-mobile-client/screens/ScreenScaffold';
+import {InfoModal} from 'terraso-mobile-client/components/common/infoModals/InfoModal';
 
 export const CreateProjectScreen = () => {
+  const infoModalRef = useRef<BottomSheetModal>(null);
+
+  const onInfoPress = useCallback(
+    () => infoModalRef.current?.present(),
+    [infoModalRef],
+  );
+  const onInfoClose = useCallback(
+    () => infoModalRef.current?.dismiss(),
+    [infoModalRef],
+  );
+
   return (
-    <ScreenScaffold AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
-      <CreateProjectView />
-    </ScreenScaffold>
+    <BottomSheetModalProvider>
+      <ScreenScaffold AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
+        <CreateProjectView onInfoPress={onInfoPress} />
+      </ScreenScaffold>
+      <InfoModal ref={infoModalRef} onClose={onInfoClose} />
+    </BottomSheetModalProvider>
   );
 };

--- a/dev-client/src/screens/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen.tsx
@@ -15,7 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback} from 'react';
+import {useCallback, useRef} from 'react';
+import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import {CreateSiteView} from 'terraso-mobile-client/components/sites/CreateSiteView';
 import {useDispatch} from 'terraso-mobile-client/model/store';
 import {
@@ -29,6 +30,7 @@ import {
   ScreenCloseButton,
   ScreenScaffold,
 } from 'terraso-mobile-client/screens/ScreenScaffold';
+import {InfoModal} from 'terraso-mobile-client/components/common/infoModals/InfoModal';
 
 type Props =
   | {
@@ -42,6 +44,7 @@ type Props =
 
 export const CreateSiteScreen = (props: Props = {}) => {
   const dispatch = useDispatch();
+  const infoModalRef = useRef<BottomSheetModal>(null);
 
   const createSiteCallback = useCallback(
     async (input: SiteAddMutationInput) => {
@@ -59,15 +62,28 @@ export const CreateSiteScreen = (props: Props = {}) => {
     [dispatch],
   );
 
+  const onInfo = useCallback(
+    () => infoModalRef.current?.present(),
+    [infoModalRef],
+  );
+  const onInfoClose = useCallback(
+    () => infoModalRef.current?.dismiss(),
+    [infoModalRef],
+  );
+
   return (
-    <ScreenScaffold
-      BottomNavigation={null}
-      AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
-      <CreateSiteView
-        createSiteCallback={createSiteCallback}
-        defaultProjectId={'projectId' in props ? props.projectId : undefined}
-        sitePin={'coords' in props ? props.coords : undefined}
-      />
-    </ScreenScaffold>
+    <BottomSheetModalProvider>
+      <ScreenScaffold
+        BottomNavigation={null}
+        AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
+        <CreateSiteView
+          createSiteCallback={createSiteCallback}
+          defaultProjectId={'projectId' in props ? props.projectId : undefined}
+          sitePin={'coords' in props ? props.coords : undefined}
+          onInfoPress={onInfo}
+        />
+      </ScreenScaffold>
+      <InfoModal ref={infoModalRef} onClose={onInfoClose} />
+    </BottomSheetModalProvider>
   );
 };

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -15,21 +15,47 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {createContext, useContext, useCallback, useRef} from 'react';
 import ProjectTabs from 'terraso-mobile-client/components/projects/ProjectTabs';
 import {
   AppBar,
+  ScreenCloseButton,
   ScreenScaffold,
 } from 'terraso-mobile-client/screens/ScreenScaffold';
+import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import {useSelector} from 'terraso-mobile-client/model/store';
+import {InfoModal} from 'terraso-mobile-client/components/common/infoModals/InfoModal';
 
 type Props = {projectId: string};
 
+const InfoPressContext = createContext({onInfoPress: () => {}});
+
+export const useInfoPress = () => useContext(InfoPressContext);
+
 export const ProjectViewScreen = ({projectId}: Props) => {
   const project = useSelector(state => state.project.projects[projectId]);
+  const infoModalRef = useRef<BottomSheetModal>(null);
+
+  const onInfoPress = useCallback(
+    () => infoModalRef.current?.present(),
+    [infoModalRef],
+  );
+  const onInfoClose = useCallback(
+    () => infoModalRef.current?.dismiss(),
+    [infoModalRef],
+  );
 
   return (
-    <ScreenScaffold AppBar={<AppBar LeftButton={null} title={project?.name} />}>
-      <ProjectTabs project={project} />
-    </ScreenScaffold>
+    <InfoPressContext.Provider value={{onInfoPress}}>
+      <BottomSheetModalProvider>
+        <ScreenScaffold
+          AppBar={
+            <AppBar LeftButton={<ScreenCloseButton />} title={project?.name} />
+          }>
+          <ProjectTabs project={project} />
+        </ScreenScaffold>
+        <InfoModal ref={infoModalRef} onClose={onInfoClose} />
+      </BottomSheetModalProvider>
+    </InfoPressContext.Provider>
   );
 };

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -28,7 +28,7 @@ import {InfoModal} from 'terraso-mobile-client/components/common/infoModals/Info
 
 type Props = {projectId: string};
 
-const InfoPressContext = createContext({onInfoPress: () => {}});
+const InfoPressContext = createContext(() => {});
 
 export const useInfoPress = () => useContext(InfoPressContext);
 
@@ -46,7 +46,7 @@ export const ProjectViewScreen = ({projectId}: Props) => {
   );
 
   return (
-    <InfoPressContext.Provider value={{onInfoPress}}>
+    <InfoPressContext.Provider value={onInfoPress}>
       <BottomSheetModalProvider>
         <ScreenScaffold
           AppBar={

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -261,7 +261,20 @@
     "cancel_fab": "Cancel",
     "delete_fab": "Delete",
     "done_fab": "Done",
-    "close_fab": "Close"
+    "close_fab": "Close",
+    "info": {
+      "privacy_title": "LandPKS Data Privacy",
+      "privacy_item1": "<0>The data visible in public sites</0> includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).",
+      "privacy_item2": "<0>Public sites</0> are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.",
+      "privacy_item3": "<0>Unaffiliated private sites</0> are only visible to you. You can change the privacy of the site at any time.",
+      "privacy_item4": "<0>A project’s privacy setting determines the privacy of its affiliated sites.</0> Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.",
+      "privacy_item5": "<0>When a site is transferred to a project,</0> the project will determine the site’s privacy setting.",
+      "privacy_item6": "Read more about our data privacy policy:",
+      "data_portal_link_url": "https://landpotential.org/",
+      "data_portal_link_text": "LandPKS Data Portal",
+      "privacy_policy_link_url": "https://landpotential.org/",
+      "privacy_policy_link_text": "LandPKS Privacy Policy"
+    }
   },
   "screens": {
     "HOME": "LandPKS",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -302,11 +302,11 @@
   },
   "privacy": {
     "label": "Data Privacy",
-    "PUBLIC": {
+    "public": {
       "inline": "public",
       "title": "Public"
     },
-    "PRIVATE": {
+    "private": {
       "inline": "private",
       "title": "Private"
     }


### PR DESCRIPTION
## Description
Adds an InfoModal bottom sheet for privacy info on various screens.

### Related Issues
Fixes #586

### Verification steps
1. When creating a site, tap the info (i) button to open the privacy bottom sheet.
2. View the main site dashboard on a created site. If no project has been assigned, you should see radio buttons for privacy. Tap the info button to open the privacy bottom sheet.
3. When creating a project, tap the info button to open the sheet.
4. View the inputs tab on a created project. You should see privacy radio buttons with an info button that opens a bottom sheet.

