### PR TITLE
fix: Change Form components onChange listener

### DIFF
--- a/dev-client/src/components/common/Form.tsx
+++ b/dev-client/src/components/common/Form.tsx
@@ -65,19 +65,19 @@ export const useFieldContext = <
         formikContext.setFieldValue(name, value);
       }
     },
-    [formikContext.values, name],
+    [formikContext, name],
   );
 
   return name === undefined
     ? fieldContext!
     : formikContext === undefined
-    ? {}
-    : {
-        name,
-        value: formikContext.values[name] as Value,
-        onChange,
-        onBlur: formikContext.handleBlur(name) as unknown as () => void,
-      };
+      ? {}
+      : {
+          name,
+          value: formikContext.values[name] as Value,
+          onChange,
+          onBlur: formikContext.handleBlur(name) as unknown as () => void,
+        };
 };
 
 type FormFieldProps<Name extends string> = React.PropsWithChildren<{
@@ -187,7 +187,7 @@ export const FormSwitch = memo(
 );
 
 type CheckboxProps = WrapperProps &
-  Omit<React.ComponentProps<typeof Checkbox>, 'value'> & {value?: boolean};
+  Omit<React.ComponentProps<typeof CheckBox>, 'value'> & {value?: boolean};
 export const FormCheckbox = memo(
   ({value: isChecked, ...props}: CheckboxProps) => {
     const {value, onChange} = useFieldContext<boolean>(props.name);

--- a/dev-client/src/components/common/Form.tsx
+++ b/dev-client/src/components/common/Form.tsx
@@ -15,6 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import CheckBox from '@react-native-community/checkbox';
 import {ErrorMessage as FormikErrorMessage, useFormikContext} from 'formik';
 import {
   FormControl,
@@ -22,7 +23,6 @@ import {
   Radio,
   Popover,
   Switch,
-  Checkbox,
   Row,
   Text,
   TextArea,
@@ -34,6 +34,7 @@ import {
   useRef,
   useImperativeHandle,
   forwardRef,
+  useCallback,
 } from 'react';
 import {TextInput} from 'react-native';
 import {IconButton} from 'terraso-mobile-client/components/common/Icons';
@@ -58,16 +59,25 @@ export const useFieldContext = <
     | undefined;
   const formikContext = useFormikContext<FormValues>();
 
+  const onChange = useCallback(
+    (value: Value) => {
+      if (name !== undefined) {
+        formikContext.setFieldValue(name, value);
+      }
+    },
+    [formikContext.values, name],
+  );
+
   return name === undefined
     ? fieldContext!
     : formikContext === undefined
-      ? {}
-      : {
-          name,
-          value: formikContext.values[name] as Value,
-          onChange: formikContext.handleChange(name) as (_: Value) => void,
-          onBlur: formikContext.handleBlur(name) as unknown as () => void,
-        };
+    ? {}
+    : {
+        name,
+        value: formikContext.values[name] as Value,
+        onChange,
+        onBlur: formikContext.handleBlur(name) as unknown as () => void,
+      };
 };
 
 type FormFieldProps<Name extends string> = React.PropsWithChildren<{
@@ -183,10 +193,13 @@ export const FormCheckbox = memo(
     const {value, onChange} = useFieldContext<boolean>(props.name);
     return (
       <FormFieldWrapper errorMessage={null} {...props}>
-        <Checkbox
-          value=""
-          isChecked={isChecked ?? value}
-          onChange={onChange}
+        <CheckBox
+          value={isChecked ?? value}
+          onValueChange={value => {
+            if (onChange) {
+              onChange(value);
+            }
+          }}
           {...props}
         />
       </FormFieldWrapper>

--- a/dev-client/src/components/common/Form.tsx
+++ b/dev-client/src/components/common/Form.tsx
@@ -195,11 +195,7 @@ export const FormCheckbox = memo(
       <FormFieldWrapper errorMessage={null} {...props}>
         <CheckBox
           value={isChecked ?? value}
-          onValueChange={value => {
-            if (onChange) {
-              onChange(value);
-            }
-          }}
+          onValueChange={onChange}
           {...props}
         />
       </FormFieldWrapper>


### PR DESCRIPTION
## Description
- The Formik `onChange` listener expects an event. React native events are synthetic and often do not contain all of the properties of a browser DOM event, which Formik is expecting.
- Changed from using the `onChange` listener, to `setValue`, which should have the correct effect.
- I think this was likely working for selects and text inputs, because there seems to be some custom logic in the Formik code about if a string is passed to `onChange` . I didn't really look into it more though.
- Tested it out with Checkbox, Input and TextArea Form elements to make sure it works
- Also changes the Soil data tab to use the checkbox library instead of the NativeBase one

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Related to #502 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
