### PR TITLE
fix: hide archive project button

### DIFF
--- a/dev-client/src/components/projects/ProjectSettingsTab.tsx
+++ b/dev-client/src/components/projects/ProjectSettingsTab.tsx
@@ -69,9 +69,9 @@ export default function ProjectSettingsTab({
   const closeArchiveProject = () => {
     setIsArchiveModalOpen(false);
   };
-  const openArchiveProject = () => {
-    setIsArchiveModalOpen(true);
-  };
+  // const openArchiveProject = () => {
+  //   setIsArchiveModalOpen(true);
+  // };
   const triggerArchiveProject = () => {
     setIsDeleteModalOpen(false);
     dispatch(archiveProject({id: projectId, archived: true}));
@@ -93,12 +93,14 @@ export default function ProjectSettingsTab({
           {t('projects.settings.copy_download_link').toUpperCase()}
         </IconLink>
         <Text ml={10}>{t('projects.settings.download_link_description')}</Text>
+        {/*
         <IconLink
           iconName="archive"
           isUnderlined={false}
           onPress={openArchiveProject}>
           {t('projects.settings.archive').toUpperCase()}
         </IconLink>
+          */}
         <IconLink
           iconName="delete-forever"
           underlined={false}


### PR DESCRIPTION
## Description
Remove archive project button on project settings screen.

Fixes #597.

## Notes
Redo of https://github.com/techmatters/terraso-mobile-client/pull/598, which was reverted by https://github.com/techmatters/terraso-mobile-client/commit/5b44fbd8f5bd892742c4cf8607ac52b4a979c780.