### PR TITLE
fix: path in android/settings.gradle

### DIFF
--- a/dev-client/android/settings.gradle
+++ b/dev-client/android/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'Terraso LandPKS'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
-includeBuild('../node_modules/react-native-gradle-plugin')
+includeBuild('../node_modules/@react-native/gradle-plugin')
 buildCache {
     local {
         directory = new File(rootDir, 'build-cache')


### PR DESCRIPTION
## Description
I had to make this change to `android/settings.gradle` to get the app to compile locally, which is required for react native version 0.72+ according to [this thread](https://github.com/facebook/react-native/issues/36643). I was surprised because I assume other things should have been failing without that setting so I'm wondering if I'm missing something? @paulschreiber @david-code 
