### PR TITLE
feat: user role context

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -37,7 +37,7 @@
         "react-native-svg": "^14.0.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-vector-icons": "^10.0.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#23fb61c",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#ad73879",
         "uuid": "^9.0.1",
         "yup": "^1.3.2"
       },
@@ -19306,14 +19306,14 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#23fb61c5dc7259d3bf5b1372cb8af726e426228a",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#ad738791ae9dab0a8136487d5b460398a172a4bd",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#2162f0e",
+        "terraso-backend": "github:techmatters/terraso-backend#abd145f",
         "uuid": "^9.0.1"
       }
     },

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -37,7 +37,7 @@
         "react-native-svg": "^14.0.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-vector-icons": "^10.0.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#ad73879",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#e97bb4b",
         "uuid": "^9.0.1",
         "yup": "^1.3.2"
       },
@@ -19306,7 +19306,7 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#ad738791ae9dab0a8136487d5b460398a172a4bd",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#e97bb4b75b17905a8e8c8006b5ccdeccac66ce0d",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -44,7 +44,7 @@
     "react-native-svg": "^14.0.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.0.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#ad73879",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#e97bb4b",
     "uuid": "^9.0.1",
     "yup": "^1.3.2"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -44,7 +44,7 @@
     "react-native-svg": "^14.0.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.0.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#23fb61c",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#ad73879",
     "uuid": "^9.0.1",
     "yup": "^1.3.2"
   },

--- a/dev-client/src/components/RestrictByRole.tsx
+++ b/dev-client/src/components/RestrictByRole.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {useMemo} from 'react';
+import {SiteUserRole} from 'terraso-client-shared/selectors';
+import {useSiteRoleContext} from 'terraso-mobile-client/context/SiteRoleContext';
+
+type RestrictSiteRoleProps = {
+  role: SiteUserRole | SiteUserRole[];
+} & React.PropsWithChildren;
+
+/** Only display child components with specified site role */
+export const RestrictBySiteRole = ({role, children}: RestrictSiteRoleProps) => {
+  const siteRole = useSiteRoleContext();
+  const display = useMemo(() => {
+    if (siteRole === null) {
+      return false;
+    }
+    if (role instanceof Array) {
+      return (
+        role.filter(
+          ({kind, role: userRole}) =>
+            siteRole.kind === kind && siteRole.role === userRole,
+        ).length > 0
+      );
+    }
+    return role === siteRole;
+  }, [siteRole, role]);
+
+  return display ? {children} : <></>;
+};

--- a/dev-client/src/context/SiteRoleContext.tsx
+++ b/dev-client/src/context/SiteRoleContext.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {createContext, useContext} from 'react';
+import {
+  SiteUserRole,
+  selectUserRoleSite,
+} from 'terraso-client-shared/selectors';
+import {useSelector} from 'terraso-mobile-client/store';
+
+const SiteRoleContext = createContext<SiteUserRole | null>(null);
+
+type Props = {
+  siteId: string;
+} & React.PropsWithChildren;
+
+export const useSiteRoleContext = () => {
+  return useContext(SiteRoleContext);
+};
+
+export const SiteRoleContextProvider = ({siteId, children}: Props) => {
+  const role = useSelector(state => selectUserRoleSite(state, siteId));
+
+  return (
+    <SiteRoleContext.Provider value={role}>{children}</SiteRoleContext.Provider>
+  );
+};


### PR DESCRIPTION
## Description

This commit adds a simple way to restrict when a given component is
displayed. The `RestrictBySiteRole`component only displays its
children if the user has the correct role in relation to the site.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
