### PR TITLE
fix: Reintroduce missing project filter

### DIFF
--- a/dev-client/src/screens/HomeScreen/components/SiteFilterModal.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteFilterModal.tsx
@@ -15,14 +15,15 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
-
 import {USER_ROLES} from 'terraso-mobile-client/constants';
 import {
   TextInputFilter,
   ListFilterModal,
   SelectFilter,
 } from 'terraso-mobile-client/components/ListFilter';
+import {useSelector} from 'terraso-mobile-client/store';
 
 type Props = {
   useDistance: boolean;
@@ -49,6 +50,17 @@ export const SiteFilterModal = ({useDistance}: Props) => {
     ].map(label => [label, t('site.search.sort.' + label)]),
   );
 
+  const projects = useSelector(state => state.project.projects);
+
+  const projectOptions = useMemo(
+    () => ({
+      ...Object.fromEntries(
+        Object.values(projects).map(({id, name}) => [id, name]),
+      ),
+    }),
+    [projects],
+  );
+
   return (
     <ListFilterModal
       searchInput={
@@ -63,6 +75,12 @@ export const SiteFilterModal = ({useDistance}: Props) => {
         options={sortOptions}
         name="sort"
         nullableOption={t('general.filter.no_sort')}
+      />
+      <SelectFilter
+        label={t('site.search.filter_projects')}
+        options={projectOptions}
+        name="project"
+        nullableOption={t('general.filter.no_project')}
       />
       <SelectFilter
         label={t('site.search.filter_role')}

--- a/dev-client/src/screens/HomeScreen/utils/siteFeatureCollection.ts
+++ b/dev-client/src/screens/HomeScreen/utils/siteFeatureCollection.ts
@@ -21,6 +21,7 @@ export const siteFeatureCollection = (
   sites: Pick<Site, 'id' | 'latitude' | 'longitude'>[],
 ): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
   type: 'FeatureCollection',
+  // TODO: Filter sometimes returns undefined; figure out why and fix
   features: sites.map(site => ({
     type: 'Feature',
     id: site.id,


### PR DESCRIPTION
## Description

I stupidly got rid of this when I merged with main. Found an [issue](https://github.com/techmatters/terraso-mobile-client/issues/706) testing this, but I'm not able to reproduce it consistently. QA will be helpful to see if this is an issue that shows up in the deployed app.
