### PR TITLE
fix: support landscape orientation on iphones

### DIFF
--- a/dev-client/ios/Terraso LandPKS/Info.plist
+++ b/dev-client/ios/Terraso LandPKS/Info.plist
@@ -71,6 +71,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
## Description
Allows the iOS app to use a landscape orientation. @paulschreiber or @david-code can you verify that this works by building the iOS app with this change, navigating to the slope meter screen, and confirming that it displays in landscape orientation?

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #763 

### Verification steps
Landscape orientation should work on iOS.