### PR TITLE
fix: remove map icon size workaround, fixed upstream

### DIFF
--- a/dev-client/src/components/StaticMapView.tsx
+++ b/dev-client/src/components/StaticMapView.tsx
@@ -16,7 +16,7 @@
  */
 
 import Mapbox from '@rnmapbox/maps';
-import {PixelRatio, Platform, StyleProp, ViewStyle} from 'react-native';
+import {StyleProp, ViewStyle} from 'react-native';
 import {Icon} from 'terraso-mobile-client/components/Icons';
 import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {Position} from '@rnmapbox/maps/lib/typescript/src/types/Position';
@@ -86,9 +86,6 @@ export const positionToCoords = ([longitude, latitude]: Position): Coords => ({
   latitude,
   longitude,
 });
-
-export const mapIconSizeForPlatform = (size: number) =>
-  Math.round(size * Platform.select({android: PixelRatio.get(), default: 1}));
 
 const defaultAnchor = {x: 0.5, y: 0};
 

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -28,14 +28,11 @@ import {
 } from 'react';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import {useTheme} from 'native-base';
-import {Keyboard, PixelRatio, Platform, StyleSheet} from 'react-native';
+import {Keyboard, PixelRatio, StyleSheet} from 'react-native';
 import {Site} from 'terraso-client-shared/site/siteSlice';
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/src/components/Camera';
 import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
-import {
-  mapIconSizeForPlatform,
-  positionToCoords,
-} from 'terraso-mobile-client/components/StaticMapView';
+import {positionToCoords} from 'terraso-mobile-client/components/StaticMapView';
 import {siteFeatureCollection} from 'terraso-mobile-client/screens/HomeScreen/utils/siteFeatureCollection';
 import {repositionCamera} from 'terraso-mobile-client/screens/HomeScreen/utils/repositionCamera';
 import {SiteMapCallout} from 'terraso-mobile-client/screens/HomeScreen/components/SiteMapCallout';
@@ -222,17 +219,17 @@ const SiteMap = (
     () => ({
       sitePin: Icon.getImageSourceSync(
         'location-on',
-        mapIconSizeForPlatform(35),
+        35,
         colors.secondary.main,
       ),
       selectedSitePin: Icon.getImageSourceSync(
         'location-on',
-        mapIconSizeForPlatform(64),
+        64,
         colors.secondary.main,
       ),
       temporarySitePin: Icon.getImageSourceSync(
         'location-on',
-        mapIconSizeForPlatform(35),
+        35,
         colors.action.active,
       ),
     }),
@@ -252,8 +249,7 @@ const SiteMap = (
         iconImage: 'selectedSitePin',
       } satisfies Mapbox.SymbolLayerStyle,
       siteClusterCircleLayer: {
-        circleRadius:
-          35 / Platform.select({android: PixelRatio.get(), default: 1}),
+        circleRadius: 35 / PixelRatio.get(),
         circleColor: colors.secondary.main,
       } satisfies Mapbox.CircleLayerStyle,
       siteClusterTextLayer: {


### PR DESCRIPTION
## Description
Please check this looks good in iOS emulator before merging!

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #764 

### Verification steps
Icons should look reasonably sized on both platforms.