### PR TITLE
fix: changing confirmation message for deleting notes

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -89,7 +89,7 @@
       "edit_title": "Site Note",
       "note_attribution": "{{createdAt}} by {{name}}",
       "confirm_removal_title": "Delete note?",
-      "confirm_removal_body": "This action can't be undone.",
+      "confirm_removal_body": "This action cannot be undone.",
       "min_length_error": "Must be at least {{min}} characters",
       "placeholder_text": "Start typing your note…",
       "projectInstructions": "Site Instructions"

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -89,7 +89,7 @@
       "edit_title": "Site Note",
       "note_attribution": "{{createdAt}} by {{name}}",
       "confirm_removal_title": "Delete note?",
-      "confirm_removal_body": "Are you sure you want to remove this note?",
+      "confirm_removal_body": "This action can't be undone.",
       "min_length_error": "Must be at least {{min}} characters",
       "placeholder_text": "Start typing your note…",
       "projectInstructions": "Site Instructions"


### PR DESCRIPTION
## Description
Changing the text of the confirmation dialog for deleting notes

### Related Issues
One fix for #750 