### PR TITLE
fix: update empty project text

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -127,7 +127,7 @@
     "title": "Projects",
     "header": "Projects",
     "none": {
-      "header": "You don't have any projects",
+      "header": "You don’t have any projects",
       "info": "Projects let you group sites, set data needs, manage team members, and see audit logs."
     },
     "learn_more": "Learn more about using projects",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -127,8 +127,8 @@
     "title": "Projects",
     "header": "Projects",
     "none": {
-      "header": "You don't currently have any projects",
-      "info": "A project is a group of sites you can manage on your own or with a team. Projects allow you to configure data inputs, add team members and sites, and view audit logs."
+      "header": "You don't have any projects",
+      "info": "Projects let you group sites, set data needs, manage team members, and see audit logs."
     },
     "learn_more": "Learn more about using projects",
     "create_button": "Create project",


### PR DESCRIPTION
## Description
Update the text on the projects tab when the list of projects is empty

### Related Issues
One fix for #754 