### PR TITLE
feat: performance improvements

### DIFF
--- a/dev-client/src/components/Card.tsx
+++ b/dev-client/src/components/Card.tsx
@@ -53,12 +53,10 @@ export const Card = ({
   ...boxProps
 }: Props) => {
   return (
+    // TODO(performance): Should be investigated in terms of performance as it's what's being
+    // renedered in the very non-performant FlatList in the HomeScreen's BottomSheet
     <Pressable onPress={onPress}>
-      <Box
-        variant="card"
-        marginTop={isPopover ? '15px' : '0px'}
-        shadow={isPopover ? 9 : undefined}
-        {...boxProps}>
+      <Box variant="card" marginTop={'0px'} shadow={undefined} {...boxProps}>
         {isPopover && <CardTriangle />}
         {children}
         {buttons}

--- a/dev-client/src/components/Modal.tsx
+++ b/dev-client/src/components/Modal.tsx
@@ -24,7 +24,7 @@ import {
   useMemo,
 } from 'react';
 import {CardCloseButton} from 'terraso-mobile-client/components/CardCloseButton';
-import {Pressable, StyleSheet} from 'react-native';
+import {View, Pressable, StyleSheet, Modal as RNModal} from 'react-native';
 import {useDisclose, Modal as NativeBaseModal} from 'native-base';
 import {KeyboardAvoidingView} from 'react-native';
 
@@ -69,22 +69,37 @@ export const Modal = forwardRef<ModalHandle, Props>(
             {trigger(handle.onOpen)}
           </Pressable>
         )}
-        <NativeBaseModal isOpen={isOpen} onClose={onClose}>
+        {/* // TODO(performance): Fixme
+        This component adds a significant number of elements to the render tree
+        even when it's not visible - replacing it with a regular RN Modal for now because of that,
+        although that partly breaks the functionality and looks different than the original
+
+         */}
+        {/* <NativeBaseModal isOpen={isOpen} onClose={onClose}> */}
+        <RNModal
+          visible={isOpen}
+          presentationStyle="pageSheet"
+          animationType="slide"
+          onDismiss={onClose}
+          onRequestClose={onClose}>
           <KeyboardAvoidingView
             style={styles.nativeBaseModalChild}
             behavior="padding"
             keyboardVerticalOffset={100}>
-            <NativeBaseModal.Content
+            {/* <NativeBaseModal.Content
               borderRadius="24px"
               padding="18px"
-              {..._content}>
+              {..._content}> */}
+            <View style={styles.modalContainer}>
               <ModalContext.Provider value={handle}>
                 {children}
               </ModalContext.Provider>
               {CloseButton}
-            </NativeBaseModal.Content>
+            </View>
+            {/* </NativeBaseModal.Content> */}
           </KeyboardAvoidingView>
-        </NativeBaseModal>
+        </RNModal>
+        {/* </NativeBaseModal> */}
       </>
     );
   },
@@ -94,5 +109,11 @@ const styles = StyleSheet.create({
   nativeBaseModalChild: {
     width: '100%',
     alignItems: 'center',
+  },
+  modalContainer: {
+    // TODO(performance): Adjust styles
+    backgroundColor: 'white',
+    padding: 18,
+    borderRadius: 24,
   },
 });

--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -17,7 +17,7 @@
 
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Box, Heading, Text, Badge, Row} from 'native-base';
-import {useCallback} from 'react';
+import React, {useCallback} from 'react';
 import {Site} from 'terraso-client-shared/site/siteSlice';
 import {useSelector} from 'terraso-mobile-client/store';
 import {useTranslation} from 'react-i18next';
@@ -36,12 +36,7 @@ type Props = {
   isPopover?: boolean;
 };
 
-export const SiteCard = ({
-  site,
-  onShowSiteOnMap,
-  buttons,
-  isPopover,
-}: Props) => {
+const SiteCard = ({site, onShowSiteOnMap, buttons, isPopover}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
   const project = useSelector(state =>
@@ -97,5 +92,11 @@ export const SiteCard = ({
     </Card>
   );
 };
+
+// TODO(performance): Check whether it would be beneficial to memoize this component
+// const SiteCardMemoized = React.memo(SiteCard);
+// export {SiteCardMemoized};
+
+export {SiteCard};
 
 const styles = StyleSheet.create({mapView: {height: 60, width: 60}});

--- a/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
@@ -25,7 +25,7 @@ import {useDispatch} from 'terraso-mobile-client/store';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Formik} from 'formik';
 import {useTranslation} from 'react-i18next';
-import {useMemo} from 'react';
+import React, {useMemo} from 'react';
 import {PROJECT_DEFAULT_MEASUREMENT_UNITS} from 'terraso-mobile-client/constants';
 
 type Props = {
@@ -60,25 +60,56 @@ export const CreateProjectForm = ({onInfoPress}: Props) => {
         description: '',
         privacy: 'PRIVATE',
       }}>
-      {({isSubmitting, handleSubmit}) => (
-        <KeyboardAvoidingView flex={1}>
-          <ScrollView bg="background.default">
-            <Box pt="20%" mx={5}>
-              <Form onInfoPress={onInfoPress} />
-            </Box>
-          </ScrollView>
-          <Box position="absolute" bottom={8} right={3} p={3}>
-            <Button
-              onPress={() => handleSubmit()}
-              disabled={isSubmitting}
-              shadow={5}
-              size={'lg'}
-              _text={{textTransform: 'uppercase'}}>
-              {t('general.save_fab')}
-            </Button>
-          </Box>
-        </KeyboardAvoidingView>
+      {({isSubmitting, handleSubmit, handleChange, handleBlur, values}) => (
+        <FormContainer
+          isSubmitting={isSubmitting}
+          handleSubmit={handleSubmit}
+          handleChange={handleChange}
+          handleBlur={handleBlur}
+          onInfoPress={onInfoPress}
+          privacy={values.privacy}
+        />
       )}
     </Formik>
   );
 };
+
+// TODO(performance): Adjust types, think about simplifying the structure here a little bit
+// and/or extracting this component to a separate file
+const FormContainer = React.memo(
+  ({
+    isSubmitting,
+    handleSubmit,
+    handleChange,
+    handleBlur,
+    onInfoPress,
+    privacy,
+  }) => {
+    const {t} = useTranslation();
+
+    return (
+      <KeyboardAvoidingView flex={1}>
+        <ScrollView bg="background.default">
+          <Box pt="20%" mx={5}>
+            <Form
+              onInfoPress={onInfoPress}
+              handleChange={handleChange}
+              handleBlur={handleBlur}
+              privacy={privacy}
+            />
+          </Box>
+        </ScrollView>
+        <Box position="absolute" bottom={8} right={3} p={3}>
+          <Button
+            onPress={handleSubmit}
+            disabled={isSubmitting}
+            shadow={5}
+            size={'lg'}
+            _text={{textTransform: 'uppercase'}}>
+            {t('general.save_fab')}
+          </Button>
+        </Box>
+      </KeyboardAvoidingView>
+    );
+  },
+);

--- a/dev-client/src/screens/CreateProjectScreen/components/Form.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/Form.tsx
@@ -24,7 +24,7 @@ import {
   TextArea,
   VStack,
 } from 'native-base';
-import {Formik, useFormikContext} from 'formik';
+import {Formik} from 'formik';
 import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {IconButton} from 'terraso-mobile-client/components/Icons';
 import {useTranslation} from 'react-i18next';
@@ -130,6 +130,7 @@ export const EditForm = ({
   submitProps,
 }: Omit<FormProps, 'privacy'>) => {
   const {t} = useTranslation();
+
   return (
     <Formik<Omit<ProjectUpdateMutationInput, 'id'>>
       validationSchema={editProjectValidationSchema(t)}
@@ -163,12 +164,17 @@ export const EditForm = ({
   );
 };
 
-export default function Form({editForm = false, onInfoPress}: Props) {
+// TODO(performance): Adjust types
+export default function Form({
+  editForm = false,
+  onInfoPress,
+  handleChange,
+  handleBlur,
+  privacy,
+}: Props) {
   const {t} = useTranslation();
-  const {handleChange, handleBlur, values} =
-    useFormikContext<ProjectFormValues>();
+
   const inputParams = (field: keyof ProjectFormValues) => ({
-    value: values[field],
     onChangeText: handleChange(field),
     onBlur: handleBlur(field),
   });
@@ -183,7 +189,13 @@ export default function Form({editForm = false, onInfoPress}: Props) {
     <VStack space={3}>
       {EditHeader}
       <FormLabel>{t('projects.create.name_label')}</FormLabel>
-      <Input placeholder={t('projects.add.name')} {...inputParams('name')} />
+      <Input
+        placeholder={t('projects.add.name')}
+        defaultValue=""
+        autoCorrect={false}
+        scrollEnabled={false}
+        {...inputParams('name')}
+      />
       <ErrorMessage fieldName="name" />
 
       <FormLabel>{t('projects.create.description_label')}</FormLabel>
@@ -192,6 +204,7 @@ export default function Form({editForm = false, onInfoPress}: Props) {
         numberOfLines={3}
         fontSize={16}
         autoCompleteType="off"
+        autoCorrect={false}
         {...inputParams('description')}
       />
       <ErrorMessage fieldName="description" />
@@ -211,7 +224,7 @@ export default function Form({editForm = false, onInfoPress}: Props) {
           PRIVATE: {text: t('projects.create.private')},
         }}
         groupProps={{
-          value: values.privacy,
+          value: privacy, // TODO(performance): Investigate whether this input _really_ has to be controlled
           variant: 'oneLine',
           onChange: handleChange('privacy'),
           name: 'data-privacy',

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -88,6 +88,14 @@ export const CreateSiteForm = ({
         <VStack p="16px" pt="30px" space="18px">
           <FormField name="name">
             <FormLabel>{t('site.create.name_label')}</FormLabel>
+
+            {/* TODO(performance):
+            1. All text inputs should be adjusted into uncontrolled components
+               - https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components
+               - https://github.com/facebook/react-native/issues/20119
+            2. The code should be rewritten/reorganized/memoized so that a change to a text input's value doesn't
+            trigger a re-render of the whole Form/Component (chokes the JS thread and results in terrible frame drops)
+            */}
             <FormInput placeholder={t('site.create.name_placeholder')} />
           </FormField>
           <FormField name="coords">

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -68,9 +68,15 @@ export const CreateSiteView = ({
         ...parseCoords(coords),
       });
       if (createdSite !== undefined) {
-        navigation.replace('HOME', {
-          site: createdSite,
-        });
+        navigation.pop();
+
+        // TODO(performance): This is a big no-no as it creates a new HomeScreen
+        // and adds it to the Stack every time the user creates a new site,
+        // progressively taking up more and more RAM and choking up the app.
+        // (Relates to https://github.com/techmatters/terraso-mobile-client/pull/698)
+        // navigation.replace('HOME', {
+        //   site: createdSite,
+        // });
       }
     },
     [createSiteCallback, navigation, validationSchema],

--- a/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
@@ -31,6 +31,12 @@ import {SiteFilterModal} from 'terraso-mobile-client/screens/HomeScreen/componen
 import {getStartingSnapValue} from 'terraso-mobile-client/screens/HomeScreen/utils/getStartingSnapValue';
 import {useListFilter} from 'terraso-mobile-client/components/ListFilter';
 
+// TODO(performance): Same as in ProjectList.tsx
+const WINDOW_SIZE = 3;
+const MAX_TO_RENDER_PER_BATCH = 3;
+// const ITEM_HEIGHT = ??
+const SEPARATOR_HEIGHT = 8;
+
 type Props = {
   sites: Site[];
   showSiteOnMap: (site: Site) => void;
@@ -77,6 +83,13 @@ export const SiteListBottomSheet = forwardRef<BottomSheetMethods, Props>(
 
     const useDistance = useMemo(() => siteDistances !== null, [siteDistances]);
 
+    // TODO(performance): Same as in ProjectList.tsx
+    // const getItemLayout = useCallback((_: any, index: number) => {
+    //   const itemHeight = ITEM_HEIGHT + SEPARATOR_HEIGHT;
+    //   const offset = itemHeight * index;
+    //   return {length: itemHeight, offset, index};
+    // }, []);
+
     return (
       <BottomSheet
         ref={ref}
@@ -98,9 +111,12 @@ export const SiteListBottomSheet = forwardRef<BottomSheetMethods, Props>(
           <BottomSheetFlatList
             style={listStyle}
             data={filteredSites}
+            maxToRenderPerBatch={MAX_TO_RENDER_PER_BATCH}
+            windowSize={WINDOW_SIZE}
+            // getItemLayout={getItemLayout}
             keyExtractor={site => site.id}
             renderItem={renderSite}
-            ItemSeparatorComponent={() => <Box h="8px" />}
+            ItemSeparatorComponent={() => <Box h={`${SEPARATOR_HEIGHT}px`} />}
             ListFooterComponent={<Box h="10px" />}
             ListEmptyComponent={<Text>{t('site.search.no_matches')}</Text>}
           />

--- a/dev-client/src/screens/ProjectListScreen/components/ProjectList.tsx
+++ b/dev-client/src/screens/ProjectListScreen/components/ProjectList.tsx
@@ -16,20 +16,49 @@
  */
 
 import {Box, FlatList, Text} from 'native-base';
+import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {Project} from 'terraso-client-shared/project/projectSlice';
 import {useListFilter} from 'terraso-mobile-client/components/ListFilter';
 import {ProjectPreviewCard} from 'terraso-mobile-client/screens/ProjectListScreen/components/ProjectPreviewCard';
 
+// TODO(performance):
+// Some relevant reading: https://reactnative.dev/docs/optimizing-flatlist-configuration#windowsize
+const WINDOW_SIZE = 6; // Default is 21, bringing it down as the items in this FlatList are very costly to render
+const MAX_TO_RENDER_PER_BATCH = 5; // Similar as above, default is 10
+// const ITEM_HEIGHT = ??
+const SEPARATOR_HEIGHT = 8;
+
+type RenderItemProps = {
+  item: Project;
+};
+
 export const ProjectList = () => {
   const {t} = useTranslation();
   const {filteredItems} = useListFilter<Project>();
+
+  const renderItem = useCallback(
+    ({item}: RenderItemProps) => <ProjectPreviewCard project={item} />,
+    [],
+  );
+
+  // TODO(performance): Consider adjusting ProjectPreviewCard with the design team
+  // to always have a fixed height so you can leverage getItemLayout (example below):
+  // const getItemLayout = useCallback((_: any, index: number) => {
+  //   const length = ITEM_HEIGHT + SEPARATOR_HEIGHT;
+  //   const offset = length * index;
+  //   return {length, offset, index};
+  // }, []);
+
   return (
     <FlatList
       data={filteredItems}
-      renderItem={({item}) => <ProjectPreviewCard project={item} />}
-      ItemSeparatorComponent={() => <Box h="8px" />}
+      renderItem={renderItem}
+      windowSize={WINDOW_SIZE}
+      maxToRenderPerBatch={MAX_TO_RENDER_PER_BATCH}
+      // getItemLayout={getItemLayout}
+      ItemSeparatorComponent={() => <Box h={`${SEPARATOR_HEIGHT}px`} />}
       keyExtractor={project => project.id}
       ListEmptyComponent={<Text>{t('projects.search.no_matches')}</Text>}
     />


### PR DESCRIPTION
This PR relates to the performance issues discussed in https://github.com/techmatters/terraso-mobile-client/issues/120

## Summary
- I haven’t found anything that would affect iOS _specifically_, as brought up in the above issue
- That being said, I saw multiple performance problems that make the app perform very poorly in general (shouldn’t be heavily skewed towards one platform though, but more on that later)
- Since my time was limited and we’re working from different time zones, I decided my best bet was to try and resolve (or at least point out to you) as many issues as I could, hoping either:
    - whatever perf gains I could achieve would diminish the significance of the unidentified iOS-only problem, or
    - fortuitously, I resolve/ameliorate the problem, because it’s not actually restricted to iOS, but rather was only showing up on iOS in your tests due to some other quirks (like the specifics of your setup) we currently don’t know about
- Following this strategy, I improved what was impacting the performance the most according to my tests and I managed to make some nice performance gains even with only some of the issues I observed resolved. More results below, but tl;dr is:
    - the RAM usage (on iOS, release build) is stable at around 200-300MB (previously I could easily get it to 700MB+, depending on the amount of time spent in the app)
    - there are significantly fewer instances of sudden frame drops throughout the app, and the ones that do persist are less severe
    - the performance of FlatLists is slightly better (but could be improved even further with more work)
    - CreateProjectScreen is much more responsive to user typing compared to other input-based screens (say, CreateSiteScreen, which I did not update). With more time, analogous improvements could be made for the remaining text inputs/screens that use them throughout the app and you can use CreateProjectScreen as a reference here.

## Details

To reiterate and to be extra explicit: I haven’t been able to replicate an identical iOS lag/freeze as the one in https://github.com/techmatters/terraso-mobile-client/issues/120, but judging by how that looks in the recording, but also the app’s behaviour, its patterns of using system resources, the load it puts on the main and the JS threads, my current theory is that it’s not a singular issue causing the lags, but rather multiple unrelated issues compounding to slowly but surely smother the app (especially the JS thread). And that results in lags and unresponsiveness like the one you saw in your tests, where the app’s business logic part (i.e. JavaScript) is so overwhelmed it doesn’t appropriately process the touch events (i.e. button presses) coming to it from the native world.

### The issues

Of the issues I found: some I resolved immediately; some, specifically ones that required more time than I had available or some discussions/decisions on your end, I solved partially and/or marked in code with comments.

Here's what I've noticed:
- Creating a new site redirects the user back to the HomeScreen but it’s not the original HomeScreen, a new one is created each time a new site is created, which quickly gobbles up system resources
- There are at least two very non-performant FlatLists in the app:
    - the one on the HomeScreen, in the BottomSheet, which displays a list of sites
    - the one on the ProjectListScreen, which displays a list of projects
- At any given moment the app renders **a lot** of elements that are not displayed in the viewport, e.g. because they belong to a different screen, etc. (HomeScreen, ProjectViewScreen or LocationDashboardScreen are good examples of this; you can investigate it with React Native's iOS performance monitor.)
- The process of memoization is a two-step one and in many places it is only implemented halfway through, meaning the memoization doesn't have an effect. (WIP)
- Formik forms use input fields that:
    - make the whole (heavy) Form component rerender with every keystroke, rather than only rerendering the input field
    - are controlled (i.e. receive a `value` prop) which is mostly fine on the web, but can be problematic for React Native due to its asynchronous nature and the fact the JS <> Native communication is happening over the bridge (see [here](https://github.com/facebook/react-native/issues/20119) and [here](https://www.youtube.com/watch?v=83ffAY-CmL4&t=1366s) for more context). And since the app is struggling already, it is indeed problematic here, resulting in input fields being extremely laggy, sometimes to the point of updating only after a multiple-second delay
- NativeBase components are used extensively which is especially painful in the case of FlatList items, which should be as lean as possible
    

### iOS vs Android

I would argue that Android suffers from the same performance problems as iOS as they are mostly JS-specific, and during my tests I could, for example, easily crash the Android emulator (debug build, Google Pixel 3) due to insufficient RAM after creating just a handful (~4-5) of new sites. Frame drops and some lags were also present.

That being said, the particular interaction of switching back and forth between the HomeScreen and ProjectListScreen tabs, which in your implementation uses the Stack navigator (rather than the Bottom Tabs navigator appropriate for this use case, which we've talked about in https://github.com/techmatters/terraso-mobile-client/pull/698), is different on Android and iOS (a sort of fade-in on Android vs a slide from the edge of the screen on iOS), as the underlying native primitives also differ. And these differences might be the reason why the overall poor performance of the app affects this interaction unevenly on the two platforms. Although I have to say I'm speculating here, this isn't a conventional use case and I'd encourage you again to consider using [Bottom Tabs](https://reactnavigation.org/docs/bottom-tab-navigator) for your bottom navigation (or [Material Bottom Tabs](https://reactnavigation.org/docs/material-bottom-tab-navigator) if animations/transition effects are what you're looking for).


## Results

### iOS

- Memory usage, release build

| Before | After |
|---|---|
| <img width="696" alt="ios memory before" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/f8d7f9b9-89c9-48e9-8acd-0a90119f50fb"> | <img width="685" alt="ios memory after" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/e1a07e52-ab73-48f0-bdda-b41d7236da78"> |


- Number of views rendered, debug build

| Before | After |
|---|---|
| ![ios views rendered before](https://github.com/techmatters/terraso-mobile-client/assets/33576269/81774d7d-d3b5-4088-8caa-365e9f788521) | ![ios views rendered after](https://github.com/techmatters/terraso-mobile-client/assets/33576269/2ded36c7-cd61-4b5c-9a56-e35154a26db3) |

- Other stuff

| <img width="300" alt="frame drops" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/4bb54cf1-9e36-4e44-a3e9-34629882f32b"> | <img width="250" alt="3gb ram usage" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/d1891841-764e-420a-90b4-3b96a38db4bc"> |
|---|---|
|  Serious JS thread frame drops | Extreme RAM usage on the latest `main` (debug build, but still) |

- Text input recordings
(WIP)

### Android

As noted earlier, I had no trouble getting Android to 700MB+ memory usage too, at which point it was crashing:
<img width="350" alt="android" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/0a2070a6-b5e4-4402-b647-99fc38452b7d">

Providing it with more memory resulted in bigger consumption:
<img width="350" alt="Screenshot 2024-01-25 at 13 58 50" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/fa1e8ed3-0ad5-44a8-a007-930440cf8ab0">

Plus the overall experience was laggy, just like the iOS one, therefore I'm sceptical all of these issues are relevant for iOS exclusively.


## Other remarks

- The bottom navigation could benefit from some visual feedback when the tabs are pressed
- I agree with @CourtneyLee333 that the map preview for SiteCard items isn't very beneficial for the users, and considering that FlatList items should be kept as lightweight as possible I recommend you remove it. Plus it's very glitchy visually during rendering on iOS in my experience.
- As another avenue to explore in terms of performance you might consider looking at your [bridge](https://www.callstack.com/blog/react-native-how-to-check-what-passes-through-your-bridge). (But I'm not an expert here and I'd leave that for later and take care of the more obvious issues first.)


### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Relates to #120 

### Verification steps
> App should be relatively usable (interactions take at most 1 second to render).

(^Added by @shrouxm, I sincerely hope the app can clear this bar with these changes, but it is possible that more work will be required to achieve that for every scenario/interaction.)