### PR TITLE
fix: camera permissions prompt

### DIFF
--- a/dev-client/ios/Podfile.lock
+++ b/dev-client/ios/Podfile.lock
@@ -369,7 +369,7 @@ PODS:
   - react-native-pager-view (6.2.3):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-safe-area-context (4.8.1):
+  - react-native-safe-area-context (4.8.2):
     - React-Core
   - React-NativeModulesApple (0.72.6):
     - hermes-engine
@@ -484,7 +484,8 @@ PODS:
   - RNCCheckbox (0.5.16):
     - BEMCheckBox (~> 1.4)
     - React-Core
-  - RNGestureHandler (2.12.0):
+  - RNGestureHandler (2.14.0):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - rnmapbox-maps (10.1.3):
     - MapboxMaps (~> 10.16.2)
@@ -501,17 +502,17 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - ReactCommon/turbomodule/core
-  - RNScreens (3.27.0):
+  - RNScreens (3.29.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - RNSentry (5.15.1):
+  - RNSentry (5.15.2):
     - hermes-engine
     - React-Core
     - React-hermes
     - Sentry/HybridSDK (= 8.17.1)
-  - RNSVG (14.0.0):
+  - RNSVG (14.1.0):
     - React-Core
-  - RNVectorIcons (10.0.2):
+  - RNVectorIcons (10.0.3):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - Sentry/HybridSDK (8.17.1):
@@ -770,7 +771,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 384787fd76976f5aec9465aff6fa9e9129af1e74
   react-native-mmkv-storage: cfb6854594cfdc5f7383a9e464bb025417d1721c
   react-native-pager-view: cf96a223846458cc7e932017636b5c6d8cc2c549
-  react-native-safe-area-context: cd1169d797a2ef722a00bfc5af10748d5b6c94f9
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   React-NativeModulesApple: 1802a680a4cd891d2ab97780771bcb2ff11fdc0b
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3
   React-RCTActionSheet: 17ab132c748b4471012abbcdcf5befe860660485
@@ -789,19 +790,19 @@ SPEC CHECKSUMS:
   React-utils: 1dc03e6e55f56388b6fdde3768a66c885bacb627
   ReactCommon: cfe086d2e2ec9f2907c66666c856082608fba822
   RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
-  RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
+  RNGestureHandler: a5039da2ac028b073ae801289476060b34d559b1
   rnmapbox-maps: 3790367749dfb2fe0f9ccdd52ef4e1510dce4695
   RNReanimated: 8a6a83984cb4d61ebf1065b6137150b6b31ce609
-  RNScreens: 3e56c56bd35436215a56f48a753e30e8ce018a09
-  RNSentry: a6202c19ca31b69969dface2ea0db093e36c97a3
-  RNSVG: 255767813dac22db1ec2062c8b7e7b856d4e5ae6
-  RNVectorIcons: 72a70504e1b0aebcc2d3bbcdf65a75f5f77175f3
+  RNScreens: 1c2444658fbb696a094272d946708167b1f63409
+  RNSentry: b7f4f53bb7076f119558f8898fca901b48213f12
+  RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
+  RNVectorIcons: 6731bd488db95f4197433b30d81d03dc228b367e
   Sentry: d9f99f9cc13777c5d938650c1e1c85047bb4f0d1
   SentryPrivate: 839b1e58addf58624087a80b2628e543193fa8ef
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Turf: 13d1a92d969ca0311bbc26e8356cca178ce95da2
   Yoga: b76f1acfda8212aa16b7e26bcce3983230c82603
 
-PODFILE CHECKSUM: 03b433cb98cde5146fc904ac3ffeea339030920d
+PODFILE CHECKSUM: 4c05707bd4e8650d95a9758c0438b73519bac13a
 
 COCOAPODS: 1.14.3

--- a/dev-client/ios/Terraso LandPKS/Info.plist
+++ b/dev-client/ios/Terraso LandPKS/Info.plist
@@ -72,13 +72,13 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -46,13 +46,17 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
     };
   }, []);
 
-  useEffect(
-    () =>
-      DeviceMotion.addListener(motion =>
-        setDeviceTiltDeg(toDegrees(motion.rotation.beta)),
-      ).remove,
-    [setDeviceTiltDeg],
-  );
+  useEffect(() => {
+    DeviceMotion.setUpdateInterval(300);
+    return DeviceMotion.addListener(motion => {
+      if (
+        motion?.rotation?.beta !== undefined &&
+        !isNaN(motion?.rotation?.beta)
+      ) {
+        setDeviceTiltDeg(toDegrees(motion.rotation.beta));
+      }
+    }).remove;
+  }, []);
 
   const requestPermissionIfPossible = () => {
     if (permission?.canAskAgain) {

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -74,7 +74,7 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
     <ScreenScaffold AppBar={null} BottomNavigation={null}>
       <Row flex={1} alignItems="stretch" px="24px" py="20px">
         <Box flex={1} justifyContent="center">
-          {!permission?.granted ? (
+          {permission?.granted ? (
             <Camera style={styles.camera}>
               <Column flex={1} alignItems="stretch">
                 <Box flex={1} />

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -20,7 +20,7 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import {Camera} from 'expo-camera';
 import {DeviceMotion} from 'expo-sensors';
-import {Box, Button, Column, Heading, Row} from 'native-base';
+import {Box, Button, Column, Heading, Link, Row, Text} from 'native-base';
 import {CardCloseButton} from 'terraso-mobile-client/components/CardCloseButton';
 import {useTranslation} from 'react-i18next';
 import {Icon, IconButton} from 'terraso-mobile-client/components/Icons';
@@ -58,14 +58,6 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
     }).remove;
   }, []);
 
-  const requestPermissionIfPossible = () => {
-    if (permission?.canAskAgain) {
-      return requestPermission();
-    } else {
-      Linking.openSettings();
-    }
-  };
-
   const onClose = useCallback(() => navigation.pop(), [navigation]);
   const onUse = useCallback(async () => {
     if (deviceTiltDeg === null) {
@@ -85,7 +77,7 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
   return (
     <ScreenScaffold AppBar={null} BottomNavigation={null}>
       <Row flex={1} alignItems="stretch" px="24px" py="20px">
-        <Box flex={1} justifyContent="center">
+        <Box flex={1} justifyContent="center" alignItems="center">
           {permission?.granted ? (
             <Camera style={styles.camera}>
               <Column flex={1} alignItems="stretch">
@@ -95,70 +87,63 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
                 <Box flex={1} bg="#00000080" />
               </Column>
             </Camera>
+          ) : permission?.canAskAgain ? (
+            <Button size="lg" onPress={requestPermission}>
+              {t('slope.steepness.camera_grant')}
+            </Button>
           ) : (
             <>
-              <CardCloseButton
-                size="lg"
-                _box={{
-                  position: 'absolute',
-                  top: 0,
-                  right: 0,
-                  padding: 0,
-                  alignSelf: 'flex-end',
-                }}
-                onPress={onClose}
-              />
-              <Button size="lg" onPress={requestPermissionIfPossible}>
-                {t('slope.steepness.camera_grant')}
-              </Button>
+              <Heading variant="h6">{t('slope.steepness.no_camera')}</Heading>
+              <Text variant="body1" textAlign="center">
+                {t('slope.steepness.no_camera_explanation')}
+              </Text>
+              <Link onPress={Linking.openSettings}>
+                {t('general.open_settings')}
+              </Link>
             </>
           )}
         </Box>
-        {permission?.granted && (
-          <Column alignItems="center">
-            <CardCloseButton
+        <Column alignItems="center">
+          <CardCloseButton
+            size="lg"
+            _box={{
+              position: 'relative',
+              top: 0,
+              right: 0,
+              padding: 0,
+              alignSelf: 'flex-end',
+            }}
+            onPress={onClose}
+          />
+          <Column
+            px="56px"
+            flex={1}
+            justifyContent="center"
+            alignItems="center">
+            <Row alignItems="center">
+              <Heading variant="h6">{t('slope.steepness.slope_meter')}</Heading>
+              <IconButton name="info" _icon={{color: 'action.active'}} />
+            </Row>
+            <Box height="12px" />
+            <Heading variant="h5" fontWeight={700}>
+              {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
+            </Heading>
+            <Box height="5px" />
+            <Heading variant="h6">
+              {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
+            </Heading>
+            <Box height="18px" />
+            <Button
+              onPress={onUse}
               size="lg"
-              _box={{
-                position: 'relative',
-                top: 0,
-                right: 0,
-                padding: 0,
-                alignSelf: 'flex-end',
-              }}
-              onPress={onClose}
-            />
-            <Column
-              px="56px"
-              flex={1}
-              justifyContent="center"
-              alignItems="center">
-              <Row alignItems="center">
-                <Heading variant="h6">
-                  {t('slope.steepness.slope_meter')}
-                </Heading>
-                <IconButton name="info" _icon={{color: 'action.active'}} />
-              </Row>
-              <Box height="12px" />
-              <Heading variant="h5" fontWeight={700}>
-                {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
-              </Heading>
-              <Box height="5px" />
-              <Heading variant="h6">
-                {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
-              </Heading>
-              <Box height="18px" />
-              <Button
-                onPress={onUse}
-                size="lg"
-                px="46px"
-                py="18px"
-                _text={{textTransform: 'uppercase'}}
-                leftIcon={<Icon name="check" />}>
-                {t('general.use')}
-              </Button>
-            </Column>
+              px="46px"
+              py="18px"
+              _text={{textTransform: 'uppercase'}}
+              leftIcon={<Icon name="check" />}>
+              {t('general.use')}
+            </Button>
           </Column>
-        )}
+        </Column>
       </Row>
     </ScreenScaffold>
   );

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -85,7 +85,7 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
             </Camera>
           ) : (
             <Button size="lg" onPress={requestPermission}>
-              Grant Camera Permission
+              {t('slope.steepness.camera_grant')}
             </Button>
           )}
         </Box>

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -25,7 +25,7 @@ import {CardCloseButton} from 'terraso-mobile-client/components/CardCloseButton'
 import {useTranslation} from 'react-i18next';
 import {Icon, IconButton} from 'terraso-mobile-client/components/Icons';
 import {degreeToPercent} from 'terraso-mobile-client/screens/SlopeScreen/utils/steepnessConversion';
-import {StyleSheet} from 'react-native';
+import {Linking, StyleSheet} from 'react-native';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {useDispatch} from 'terraso-mobile-client/store';
 import {updateSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
@@ -53,6 +53,14 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
       ).remove,
     [setDeviceTiltDeg],
   );
+
+  const requestPermissionIfPossible = () => {
+    if (permission?.canAskAgain) {
+      return requestPermission();
+    } else {
+      Linking.openSettings();
+    }
+  };
 
   const onClose = useCallback(() => navigation.pop(), [navigation]);
   const onUse = useCallback(async () => {
@@ -84,52 +92,69 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
               </Column>
             </Camera>
           ) : (
-            <Button size="lg" onPress={requestPermission}>
-              {t('slope.steepness.camera_grant')}
-            </Button>
+            <>
+              <CardCloseButton
+                size="lg"
+                _box={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  padding: 0,
+                  alignSelf: 'flex-end',
+                }}
+                onPress={onClose}
+              />
+              <Button size="lg" onPress={requestPermissionIfPossible}>
+                {t('slope.steepness.camera_grant')}
+              </Button>
+            </>
           )}
         </Box>
-        <Column alignItems="center">
-          <CardCloseButton
-            size="lg"
-            _box={{
-              position: 'relative',
-              top: 0,
-              right: 0,
-              padding: 0,
-              alignSelf: 'flex-end',
-            }}
-            onPress={onClose}
-          />
-          <Column
-            px="56px"
-            flex={1}
-            justifyContent="center"
-            alignItems="center">
-            <Row alignItems="center">
-              <Heading variant="h6">{t('slope.steepness.slope_meter')}</Heading>
-              <IconButton name="info" _icon={{color: 'action.active'}} />
-            </Row>
-            <Box height="12px" />
-            <Heading variant="h5" fontWeight={700}>
-              {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
-            </Heading>
-            <Box height="5px" />
-            <Heading variant="h6">
-              {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
-            </Heading>
-            <Box height="18px" />
-            <Button
-              onPress={onUse}
+        {permission?.granted && (
+          <Column alignItems="center">
+            <CardCloseButton
               size="lg"
-              px="46px"
-              py="18px"
-              _text={{textTransform: 'uppercase'}}
-              leftIcon={<Icon name="check" />}>
-              {t('general.use')}
-            </Button>
+              _box={{
+                position: 'relative',
+                top: 0,
+                right: 0,
+                padding: 0,
+                alignSelf: 'flex-end',
+              }}
+              onPress={onClose}
+            />
+            <Column
+              px="56px"
+              flex={1}
+              justifyContent="center"
+              alignItems="center">
+              <Row alignItems="center">
+                <Heading variant="h6">
+                  {t('slope.steepness.slope_meter')}
+                </Heading>
+                <IconButton name="info" _icon={{color: 'action.active'}} />
+              </Row>
+              <Box height="12px" />
+              <Heading variant="h5" fontWeight={700}>
+                {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
+              </Heading>
+              <Box height="5px" />
+              <Heading variant="h6">
+                {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
+              </Heading>
+              <Box height="18px" />
+              <Button
+                onPress={onUse}
+                size="lg"
+                px="46px"
+                py="18px"
+                _text={{textTransform: 'uppercase'}}
+                leftIcon={<Icon name="check" />}>
+                {t('general.use')}
+              </Button>
+            </Column>
           </Column>
-        </Column>
+        )}
       </Row>
     </ScreenScaffold>
   );

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -328,7 +328,8 @@
       "privacy_policy_link_url": "https://landpotential.org/",
       "privacy_policy_link_text": "LandPKS Privacy Policy"
     },
-    "required": "required"
+    "required": "required",
+    "open_settings": "Open Settings"
   },
   "errors": {
     "soilId": "Error saving soil ID information."
@@ -458,6 +459,8 @@
       "degree_placeholder": "Degree",
       "slope_meter": "Slope Meter",
       "camera_grant": "Grant Camera Permission",
+      "no_camera": "No Camera Access",
+      "no_camera_explanation": "For best results, allow LandPKS to use your camera in Settings",
       "select_labels": {
         "FLAT": "Flat 0-2%",
         "GENTLE": "Gentle 1-15%",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -457,6 +457,7 @@
       "degree_help": "0°-89°",
       "degree_placeholder": "Degree",
       "slope_meter": "Slope Meter",
+      "camera_grant": "Grant Camera Permission",
       "select_labels": {
         "FLAT": "Flat 0-2%",
         "GENTLE": "Gentle 1-15%",


### PR DESCRIPTION
george boole, how you vex me so

## Description
Fixes camera permissions prompt for the slope meter screen. @paulschreiber can you check if this works on your iOS device before merging?

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #765 

### Verification steps
Slope screen should show a button saying "grant camera permissions" when camera permissions have not been granted, and then show the camera when they have been. Camera should disappear again if permissions are revoked.