### PR TITLE
fix: use valid justifyContent value in theme.ts

### DIFF
--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -167,7 +167,7 @@ export const theme = extendTheme({
         fullWidth: {
           borderRadius: '0px',
           width: 'full',
-          justifyContent: 'start',
+          justifyContent: 'flex-start',
         },
         confirmModal: {
           py: '10px',


### PR DESCRIPTION
## Description
Use valid justifyContent value in theme.ts. Avoids warning.