### PR TITLE
fix: make the 'not a valid dimension' native-base warning go away

### DIFF
--- a/dev-client/src/screens/SiteScreen/SiteScreen.tsx
+++ b/dev-client/src/screens/SiteScreen/SiteScreen.tsx
@@ -159,7 +159,7 @@ export const SiteScreen = ({siteId, coords}: Props) => {
                   name: 'site-privacy',
                   onChange: onSitePrivacyChanged,
                   value: site.privacy,
-                  ml: '',
+                  ml: '0',
                 }}
               />
             </HStack>


### PR DESCRIPTION
## Description

Fixes the `"" is not a valid dimension. Dimensions must be a number, "auto" (...)` warning.

<img width="522" alt="Screenshot 2024-01-26 at 18 09 22" src="https://github.com/techmatters/terraso-mobile-client/assets/33576269/a82fcfa7-4ed4-489b-b784-5ef35fdca9f4">


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
