### PR TITLE
chore: add UIRequiresFullScreen to Info.plist

### DIFF
--- a/dev-client/ios/Terraso LandPKS/Info.plist
+++ b/dev-client/ios/Terraso LandPKS/Info.plist
@@ -85,5 +85,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIRequiresFullScreen</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
Add UIRequiresFullScreen to Info.plist. We hope this wll help with locking to landscape orientation on iOS.