### PR TITLE
chore: update CocoaPods to 1.15.2+

### DIFF
--- a/dev-client/Gemfile
+++ b/dev-client/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '>= 2.6.10'
+ruby '>= 3.2.2'
 
-gem 'cocoapods', '>= 1.12.1'
+gem 'cocoapods', '>= 1.15.2'

--- a/dev-client/Gemfile.lock
+++ b/dev-client/Gemfile.lock
@@ -22,10 +22,10 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.6)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -40,7 +40,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+    cocoapods-core (1.15.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -75,7 +75,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    minitest (5.21.2)
+    minitest (5.22.0)
     molinillo (0.8.0)
     mutex_m (0.2.0)
     nanaimo (0.3.0)
@@ -89,7 +89,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.23.0)
+    xcodeproj (1.24.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -101,7 +101,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (>= 1.12.1)
+  cocoapods (>= 1.15.2)
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
## Description
Update CocoaPods to 1.15.2+. 1.15.0/1.15.1 were broken.