### PR TITLE
fix: use macOS runners for both builds

### DIFF
--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   android-build:
     name: Android Build
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DISABLE_AUTO_UPLOAD: ${{ inputs.upload == 'false' && 'true' || 'false' }}


### PR DESCRIPTION
## Description
Use macOS runners for both builds.