### PR TITLE
fix: slope-class-names

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -662,7 +662,7 @@
       "no_camera_explanation": "For best results, allow LandPKS to use your camera in Settings",
       "select_labels": {
         "FLAT": "Flat 0-2%",
-        "GENTLE": "Gentle 1-15%",
+        "GENTLE": "Gentle 2-5%",
         "MODERATE": "Moderate 5-10%",
         "ROLLING": "Rolling 10-15%",
         "HILLY": "Hilly 15-30%",


### PR DESCRIPTION
## Description
Changing 1-15% to 2-5%, as pointed out on a demo 

### Related Issues
No formal issue filed, it was pointed out in the weekly BLM meeting just now