### PR TITLE
fix: change site search filter label text to correct term

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -101,7 +101,7 @@
       "filter_role": "Filter sites by role:",
       "no_matches": "No sites match the current search and filter options.",
       "sort": {
-        "label": "Sort projects by:",
+        "label": "Sort sites by:",
         "nameAsc": "Name (A to Z)",
         "nameDesc": "Name (Z to A)",
         "lastModAsc": "Last Modified (most recent)",


### PR DESCRIPTION
## Description
Update label on the site filter screen from "sort projects by" to "sort sites by".

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #751 

### Verification steps

Open the site search dialog. Verify that the affected label now shows 'site' instead of 'project.'