### PR TITLE
fix: update empty-project text and styling

### DIFF
--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -23,7 +23,6 @@ import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useTranslation} from 'react-i18next';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Link, Spinner} from 'native-base';
-import {IconButton} from 'terraso-mobile-client/components/Icons';
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
 import {
   ListFilterModal,
@@ -38,7 +37,6 @@ import {ProjectList} from 'terraso-mobile-client/screens/ProjectListScreen/compo
 import {
   Box,
   VStack,
-  Heading,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 
@@ -90,13 +88,9 @@ export const ProjectListScreen = () => {
         ) : (
           activeProjects.length === 0 && (
             <>
-              <Heading size="sm">{t('projects.none.header')}</Heading>
+              <Text variant="body1-strong">{t('projects.none.header')}</Text>
               <Text>{t('projects.none.info')}</Text>
               <Link _text={{color: 'primary.main'}} alignItems="center" mb="4">
-                <IconButton
-                  name="open-in-new"
-                  _icon={{color: 'action.active'}}
-                />
                 {t('projects.learn_more')}
               </Link>
             </>

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -403,7 +403,7 @@ export const theme = extendTheme({
       baseStyle: {
         _text: {
           fontSize: '16px',
-          fontWeight: 400,
+          fontWeight: 800,
           lineHeight: '24px',
           letterSpacing: '0.15px',
           color: 'primary.main',

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -127,7 +127,7 @@
     "title": "Projects",
     "header": "Projects",
     "none": {
-      "header": "You don’t have any projects",
+      "header": "You don’t have any projects.",
       "info": "Projects let you group sites, set data needs, manage team members, and see audit logs."
     },
     "learn_more": "Learn more about using projects",


### PR DESCRIPTION
Fix first paragraph with corrected styling (bold text, not a heading) and proper punctuation. Also fix link type (remove external-link icon) and style font weight.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #917 

### Verification steps

Open an account with an empty project screen and confirm the changes appear as expected.
