### PR TITLE
chore: use filippoLeporati93/android-release-signer action

### DIFF
--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Sign Android app bundle
         if: ${{ inputs.upload == 'true' }}
-        uses: r0adkll/sign-android-release@v1
+        uses: filippoLeporati93/android-release-signer@v1
         with:
           releaseDirectory: ./dev-client/android/app/build/outputs/bundle/release
           signingKeyBase64: ${{ secrets.ANDROID_SIGNING_KEY }}


### PR DESCRIPTION
## Description
Use filippoLeporati93/android-release-signer action — @r0adkll/sign-android-release has been abandoned.