### PR TITLE
fix: Update GitHub CI build caching

### DIFF
--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -17,6 +17,14 @@ on:
         required: false
         type: string
         default: 'v1'
+      SENTRY_ORG:
+        required: false
+        type: string
+        default: 'techmatters'
+      SENTRY_PROJECT:
+        required: false
+        type: string
+        default: 'terraso-lpks'
     secrets:
       MAPBOX_DOWNLOADS_TOKEN:
         required: true
@@ -62,8 +70,8 @@ jobs:
       SENTRY_ENABLED: ${{ secrets.SENTRY_ENABLED }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DISABLE_AUTO_UPLOAD: ${{ inputs.upload == 'false' && 'true' || 'false' }}
-      SENTRY_ORG: techmatters
-      SENTRY_PROJECT: terraso-lpks
+      SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
 
     steps:
       - name: Check out git repository

--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -88,6 +88,13 @@ jobs:
         working-directory: dev-client
         run: npm ci
 
+      - name: Restore Android Expo cache
+        uses: actions/cache@v4
+        with:
+          path: dev-client/android
+          key: ${{ runner.os }}-android-${{ hashFiles('**/package-lock.json', '**/app.config.ts') }}
+          restore-keys: ${{ runner.os }}-android-
+
       - name: Generate android directory
         working-directory: dev-client
         run: npm run prebuild -- -p android

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -111,7 +111,9 @@ jobs:
       - name: Restore iOS Expo cache
         uses: actions/cache@v4
         with:
-          path: dev-client/ios
+          path: |
+            dev-client/ios
+            dev-client/node_modules
           key: ${{ runner.os }}-ios-${{ hashFiles('**/package-lock.json', '**/app.config.ts') }}
           restore-keys: ${{ runner.os }}-ios-
 

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -17,6 +17,14 @@ on:
         required: false
         type: string
         default: 'v1'
+      SENTRY_ORG:
+        required: false
+        type: string
+        default: 'techmatters'
+      SENTRY_PROJECT:
+        required: false
+        type: string
+        default: 'terraso-lpks'
     secrets:
       MAPBOX_DOWNLOADS_TOKEN:
         required: true
@@ -68,8 +76,8 @@ jobs:
       SENTRY_ENABLED: ${{ secrets.SENTRY_ENABLED }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DISABLE_AUTO_UPLOAD: ${{ inputs.upload == 'false' && 'true' || 'false' }}
-      SENTRY_ORG: techmatters
-      SENTRY_PROJECT: terraso-lpks
+      SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
 
     steps:
       - name: Check out git repository

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -78,6 +78,10 @@ jobs:
       SENTRY_DISABLE_AUTO_UPLOAD: ${{ inputs.upload == 'false' && 'true' || 'false' }}
       SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
+      CLANG: clang
+      CLANGPLUSPLUS: clang++
+      LD: clang
+      LDPLUSPLUS: clang++
 
     steps:
       - name: Check out git repository
@@ -89,6 +93,16 @@ jobs:
           node-version-file: '.tool-versions'
           cache: 'npm'
           cache-dependency-path: dev-client/package-lock.json
+
+      - name: Install and configure ccache
+        run: |
+          brew install ccache
+          ln -s $(which ccache) /usr/local/bin/gcc
+          ln -s $(which ccache) /usr/local/bin/g++
+          ln -s $(which ccache) /usr/local/bin/cc
+          ln -s $(which ccache) /usr/local/bin/c++
+          ln -s $(which ccache) /usr/local/bin/clang
+          ln -s $(which ccache) /usr/local/bin/clang++
 
       - name: Install Node dependencies
         working-directory: dev-client

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -97,6 +97,13 @@ jobs:
         working-directory: dev-client
         run: npm ci
 
+      - name: Restore iOS Expo cache
+        uses: actions/cache@v4
+        with:
+          path: dev-client/ios
+          key: ${{ runner.os }}-ios-${{ hashFiles('**/package-lock.json', '**/app.config.ts') }}
+          restore-keys: ${{ runner.os }}-ios-
+
       - name: Generate ios directory
         working-directory: dev-client
         run: npm run prebuild -- -p ios
@@ -106,17 +113,6 @@ jobs:
         with:
           bundler-cache: true
           working-directory: dev-client
-
-      - name: Restore Pods cache
-        uses: actions/cache@v4
-        with:
-          path: dev-client/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
-          restore-keys: ${{ runner.os }}-pods-
-
-      - name: CocoaPod Install
-        working-directory: dev-client/ios
-        run: bundle exec pod install
 
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -83,9 +83,6 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v4
 
-      - name: Enable build cache
-        uses: mikehardy/buildcache-action@v2
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -13,7 +13,7 @@
     "test": "jest",
     "check-ts": "tsc --noEmit",
     "check-modules": "depcheck",
-    "prebuild": "expo prebuild --clean"
+    "prebuild": "expo prebuild"
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",


### PR DESCRIPTION
## Description
* Get sentry project and org from environment
* cache `android` and `ios` folders

### Related Issues
Fixes #969.