### PR TITLE
feat: improve soil color UX

### DIFF
--- a/dev-client/src/navigation/constants.ts
+++ b/dev-client/src/navigation/constants.ts
@@ -15,6 +15,13 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
+
+export const DEFAULT_STACK_NAVIGATOR_OPTIONS: NativeStackNavigationOptions = {
+  headerShown: false,
+  freezeOnBlur: true,
+};
+
 export const enum TabRoutes {
   INPUTS = 'Inputs',
   TEAM = 'Team',

--- a/dev-client/src/navigation/hooks/useNavigation.ts
+++ b/dev-client/src/navigation/hooks/useNavigation.ts
@@ -15,12 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {useNavigation as useNavigationNative} from '@react-navigation/native';
-import {
-  RootStackParamList,
-  ScreenName,
-} from 'terraso-mobile-client/navigation/types';
+import {RootStackParamList} from 'terraso-mobile-client/navigation/types';
+import {createNavigationHook} from 'terraso-mobile-client/navigation/utils/utils';
 
-export const useNavigation = <Name extends ScreenName = ScreenName>() =>
-  useNavigationNative<NativeStackNavigationProp<RootStackParamList, Name>>();
+export const useNavigation = createNavigationHook<RootStackParamList>();

--- a/dev-client/src/navigation/navigators/LocationDashboardTabNavigator.tsx
+++ b/dev-client/src/navigation/navigators/LocationDashboardTabNavigator.tsx
@@ -21,7 +21,7 @@ import {useTranslation} from 'react-i18next';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 
 import {ParamList} from 'terraso-mobile-client/navigation/types';
-import {ScreenDefinitions} from 'terraso-mobile-client/navigation/screenDefinitions';
+import {ScreenDefinitions} from 'terraso-mobile-client/navigation/types';
 import {SiteScreen} from 'terraso-mobile-client/screens/SiteScreen/SiteScreen';
 import {SiteNotesScreen} from 'terraso-mobile-client/screens/SiteNotesScreen/SiteNotesScreen';
 import {SlopeScreen} from 'terraso-mobile-client/screens/SlopeScreen/SlopeScreen';

--- a/dev-client/src/navigation/navigators/RootNavigator.tsx
+++ b/dev-client/src/navigation/navigators/RootNavigator.tsx
@@ -30,15 +30,11 @@ import {
   screens,
   modalScreens,
 } from 'terraso-mobile-client/navigation/screenDefinitions';
+import {DEFAULT_STACK_NAVIGATOR_OPTIONS} from 'terraso-mobile-client/navigation/constants';
 
-const defaultScreenOptions: NativeStackNavigationOptions = {
-  headerShown: false,
-  freezeOnBlur: true,
-};
 const modalScreenOptions: NativeStackNavigationOptions = {
-  headerShown: false,
+  ...DEFAULT_STACK_NAVIGATOR_OPTIONS,
   animation: 'slide_from_bottom',
-  freezeOnBlur: true,
 };
 
 export const RootNavigator = () => {
@@ -86,7 +82,7 @@ export const RootNavigator = () => {
   return (
     <RootStack.Navigator
       initialRouteName={isLoggedIn ? 'BOTTOM_TABS' : 'LOGIN'}>
-      <RootStack.Group screenOptions={defaultScreenOptions}>
+      <RootStack.Group screenOptions={DEFAULT_STACK_NAVIGATOR_OPTIONS}>
         {screens}
       </RootStack.Group>
       <RootStack.Group screenOptions={modalScreenOptions}>

--- a/dev-client/src/navigation/screenDefinitions.tsx
+++ b/dev-client/src/navigation/screenDefinitions.tsx
@@ -15,7 +15,6 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import React from 'react';
 import {LoginScreen} from 'terraso-mobile-client/screens/LoginScreen';
 import {ProjectListScreen} from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
 import {ProjectViewScreen} from 'terraso-mobile-client/screens/ProjectViewScreen';
@@ -32,7 +31,10 @@ import {SiteSettingsScreen} from 'terraso-mobile-client/screens/SiteSettingsScre
 import {SiteTeamSettingsScreen} from 'terraso-mobile-client/screens/SiteTeamSettingsScreen';
 import {AddUserToProjectScreen} from 'terraso-mobile-client/screens/AddUserToProjectScreen/AddUserToProjectScreen';
 import {ManageTeamMemberScreen} from 'terraso-mobile-client/screens/ManageTeamMemberScreen';
-import {RootStack, ScreenName} from 'terraso-mobile-client/navigation/types';
+import {
+  RootStack,
+  ScreenDefinitions,
+} from 'terraso-mobile-client/navigation/types';
 import {SlopeShapeScreen} from 'terraso-mobile-client/screens/SlopeScreen/SlopeShapeScreen';
 import {SlopeSteepnessScreen} from 'terraso-mobile-client/screens/SlopeScreen/SlopeSteepnessScreen';
 import {SlopeMeterScreen} from 'terraso-mobile-client/screens/SlopeScreen/SlopeMeterScreen';
@@ -48,11 +50,8 @@ import {PhScreen} from 'terraso-mobile-client/screens/SoilScreen/PhScreen';
 import {TextureGuideScreen} from 'terraso-mobile-client/screens/SoilScreen/TextureGuideScreen';
 import {BottomTabsScreen} from 'terraso-mobile-client/screens/BottomTabsScreen';
 import {ColorGuideScreen} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/ColorGuideScreen';
-import {ColorAnalysisScreen} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/ColorAnalysisScreen';
-import {ColorCropReferenceScreen} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/ColorCropReferenceScreen';
-import {ColorCropSoilScreen} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/ColorCropSoilScreen';
-
-export type ScreenDefinitions = Record<string, React.FC<any>>;
+import {ColorAnalysisScreen} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorAnalysisScreen';
+import {generateScreens} from 'terraso-mobile-client/navigation/utils/utils';
 
 export const bottomTabScreensDefinitions = {
   PROJECT_LIST: ProjectListScreen,
@@ -86,8 +85,6 @@ export const screenDefinitions = {
   TEXTURE_GUIDE: TextureGuideScreen,
   COLOR_GUIDE: ColorGuideScreen,
   COLOR_ANALYSIS: ColorAnalysisScreen,
-  COLOR_CROP_REFERENCE: ColorCropReferenceScreen,
-  COLOR_CROP_SOIL: ColorCropSoilScreen,
 } satisfies ScreenDefinitions;
 
 export const modalScreenDefinitions = {
@@ -102,22 +99,6 @@ export const combinedScreenDefinitions = {
   ...modalScreenDefinitions,
 } satisfies ScreenDefinitions;
 
-export const screens = Object.entries(screenDefinitions).map(
-  ([name, Screen]) => (
-    <RootStack.Screen
-      name={name as ScreenName}
-      key={name}
-      children={props => <Screen {...((props.route.params ?? {}) as any)} />}
-    />
-  ),
-);
+export const screens = generateScreens(RootStack, screenDefinitions);
 
-export const modalScreens = Object.entries(modalScreenDefinitions).map(
-  ([name, Screen]) => (
-    <RootStack.Screen
-      name={name as ScreenName}
-      key={name}
-      children={props => <Screen {...((props.route.params ?? {}) as any)} />}
-    />
-  ),
-);
+export const modalScreens = generateScreens(RootStack, modalScreenDefinitions);

--- a/dev-client/src/navigation/types.ts
+++ b/dev-client/src/navigation/types.ts
@@ -23,7 +23,6 @@ import React from 'react';
 import {
   bottomTabScreensDefinitions,
   combinedScreenDefinitions,
-  ScreenDefinitions,
 } from 'terraso-mobile-client/navigation/screenDefinitions';
 
 type UnknownToUndefined<T extends unknown> = unknown extends T ? undefined : T;
@@ -40,3 +39,5 @@ export const RootStack = createNativeStackNavigator<RootStackParamList>();
 export type RootStackScreenProps = NativeStackScreenProps<RootStackParamList>;
 
 export type ScreenName = keyof RootStackParamList;
+
+export type ScreenDefinitions = Record<string, React.FC<any>>;

--- a/dev-client/src/navigation/utils/utils.tsx
+++ b/dev-client/src/navigation/utils/utils.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {TypedNavigator} from '@react-navigation/native';
+import {ScreenDefinitions} from 'terraso-mobile-client/navigation/types';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {
+  ParamListBase,
+  useNavigation as useNavigationNative,
+} from '@react-navigation/native';
+
+export const generateScreens = <
+  T extends TypedNavigator<any, any, any, any, any>,
+>(
+  Navigator: T,
+  definitions: ScreenDefinitions,
+) =>
+  Object.entries(definitions).map(([name, Screen]) => (
+    <Navigator.Screen
+      name={name}
+      key={name}
+      children={props => <Screen {...((props.route.params ?? {}) as any)} />}
+    />
+  ));
+
+export const createNavigationHook =
+  <ParamList extends ParamListBase>() =>
+  <Name extends keyof ParamList>() =>
+    useNavigationNative<NativeStackNavigationProp<ParamList, Name>>();

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
@@ -28,7 +28,6 @@ import {
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch} from 'terraso-mobile-client/store';
-import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 import {PhotoConditions} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/PhotoConditions';
 import {Fab} from 'native-base';
 import {updateDepthDependentSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
@@ -39,17 +38,11 @@ import {
   isValidSoilColor,
 } from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/utils/munsellConversions';
 import {
-  Photo,
   PhotoWithBase64,
   decodeBase64Jpg,
 } from 'terraso-mobile-client/components/ImagePicker';
-
-export type ColorAnalysisProps = {
-  photo: Photo;
-  pitProps?: SoilPitInputScreenProps;
-  reference?: PhotoWithBase64;
-  soil?: PhotoWithBase64;
-};
+import {useColorAnalysisContext} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorAnalysisScreen';
+import {useColorAnalysisNavigation} from 'terraso-mobile-client/screens/ColorAnalysisScreen/navigation/navigation';
 
 const analyzeImage = async ({
   reference,
@@ -71,21 +64,26 @@ const analyzeImage = async ({
     .munsell;
 };
 
-export const ColorAnalysisScreen = (props: ColorAnalysisProps) => {
-  const {pitProps, reference, soil, photo} = props;
+export const ColorAnalysisHomeScreen = () => {
+  const {
+    pitProps,
+    photo,
+    state: {reference, soil},
+  } = useColorAnalysisContext();
   const navigation = useNavigation();
+  const colorAnalysisNavigation = useColorAnalysisNavigation();
   const {t} = useTranslation();
   const dispatch = useDispatch();
 
   const onAnalyze = useMemo(() => {
-    if (!pitProps || !reference || !soil) {
+    if (!reference || !soil) {
       return null;
     }
 
     return async () => {
       const color = await analyzeImage({
-        reference,
-        soil,
+        reference: reference.photo,
+        soil: soil.photo,
       });
 
       if (isValidSoilColor(color)) {
@@ -105,12 +103,12 @@ export const ColorAnalysisScreen = (props: ColorAnalysisProps) => {
   }, [reference, soil, pitProps, dispatch, navigation]);
 
   const onReference = useCallback(() => {
-    navigation.navigate('COLOR_CROP_REFERENCE', props);
-  }, [navigation, props]);
+    colorAnalysisNavigation.navigate('COLOR_CROP_REFERENCE');
+  }, [colorAnalysisNavigation]);
 
   const onSoil = useCallback(() => {
-    navigation.navigate('COLOR_CROP_SOIL', props);
-  }, [navigation, props]);
+    colorAnalysisNavigation.navigate('COLOR_CROP_SOIL');
+  }, [colorAnalysisNavigation]);
 
   return (
     <ScreenScaffold>
@@ -137,8 +135,8 @@ export const ColorAnalysisScreen = (props: ColorAnalysisProps) => {
         <Row justifyContent="space-between">
           {(
             [
-              ['reference', onReference, reference],
-              ['soil', onSoil, soil],
+              ['reference', onReference, reference?.photo],
+              ['soil', onSoil, soil?.photo],
             ] as const
           ).map(([key, onPress, croppedPhoto]) => (
             <Column key={key} alignItems="flex-start">

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  Dispatch,
+  SetStateAction,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
+import {Photo} from 'terraso-mobile-client/components/ImagePicker';
+import {CropResult} from 'terraso-mobile-client/screens/ColorAnalysisScreen/components/ColorCropScreen';
+import {
+  Stack,
+  screens,
+} from 'terraso-mobile-client/screens/ColorAnalysisScreen/navigation/navigation';
+import {DEFAULT_STACK_NAVIGATOR_OPTIONS} from 'terraso-mobile-client/navigation/constants';
+
+export type ColorAnalysisProps = {
+  photo: Photo;
+  pitProps: SoilPitInputScreenProps;
+};
+
+type ColorAnalysisContextState = {
+  reference?: CropResult;
+  soil?: CropResult;
+};
+
+type ColorAnalysisContextType = ColorAnalysisProps & {
+  state: ColorAnalysisContextState;
+  setState: Dispatch<SetStateAction<ColorAnalysisContextState>>;
+};
+
+const ColorAnalysisContext = createContext<
+  ColorAnalysisContextType | undefined
+>(undefined);
+
+export const useColorAnalysisContext = () => useContext(ColorAnalysisContext)!;
+
+export const ColorAnalysisScreen = ({photo, pitProps}: ColorAnalysisProps) => {
+  const [state, setState] = useState<ColorAnalysisContextState>({});
+  const contextValue = useMemo(
+    () => ({
+      photo,
+      pitProps,
+      state,
+      setState,
+    }),
+    [photo, pitProps, state, setState],
+  );
+
+  return (
+    <ColorAnalysisContext.Provider value={contextValue}>
+      <Stack.Navigator
+        initialRouteName="COLOR_ANALYSIS_HOME"
+        screenOptions={DEFAULT_STACK_NAVIGATOR_OPTIONS}>
+        {screens}
+      </Stack.Navigator>
+    </ColorAnalysisContext.Provider>
+  );
+};

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorCropReferenceScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorCropReferenceScreen.tsx
@@ -17,31 +17,38 @@
 
 import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
-import {PhotoWithBase64} from 'terraso-mobile-client/components/ImagePicker';
-import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {ColorAnalysisProps} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/ColorAnalysisScreen';
-import {ColorCropScreen} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/ColorCropScreen';
+import {useColorAnalysisContext} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorAnalysisScreen';
+import {useColorAnalysisNavigation} from 'terraso-mobile-client/screens/ColorAnalysisScreen/navigation/navigation';
+import {
+  ColorCropScreen,
+  CropResult,
+} from 'terraso-mobile-client/screens/ColorAnalysisScreen/components/ColorCropScreen';
 
-export const ColorCropReferenceScreen = (props: ColorAnalysisProps) => {
-  const {photo} = props;
+export const ColorCropReferenceScreen = () => {
   const {t} = useTranslation();
-  const navigation = useNavigation();
+  const {
+    photo,
+    state: {reference, soil},
+    setState,
+  } = useColorAnalysisContext();
+  const colorAnalysisNavigation = useColorAnalysisNavigation();
 
   const onCrop = useCallback(
-    (crop: PhotoWithBase64) => {
-      const newProps = {...props, reference: crop};
-      if (props.soil) {
-        navigation.navigate('COLOR_ANALYSIS', newProps);
+    (crop: CropResult) => {
+      setState(state => ({...state, reference: crop}));
+      if (soil !== undefined) {
+        colorAnalysisNavigation.navigate('COLOR_ANALYSIS_HOME');
       } else {
-        navigation.replace('COLOR_CROP_SOIL', newProps);
+        colorAnalysisNavigation.navigate('COLOR_CROP_SOIL');
       }
     },
-    [navigation, props],
+    [colorAnalysisNavigation, setState, soil],
   );
 
   return (
     <ColorCropScreen
       photo={photo}
+      initialCrop={reference?.crop}
       onCrop={onCrop}
       title={t('soil.color.reference')}
       description={t('soil.color.crop_reference')}

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorCropSoilScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorCropSoilScreen.tsx
@@ -17,31 +17,38 @@
 
 import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
-import {PhotoWithBase64} from 'terraso-mobile-client/components/ImagePicker';
-import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {ColorAnalysisProps} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/ColorAnalysisScreen';
-import {ColorCropScreen} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/ColorCropScreen';
+import {useColorAnalysisContext} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorAnalysisScreen';
+import {useColorAnalysisNavigation} from 'terraso-mobile-client/screens/ColorAnalysisScreen/navigation/navigation';
+import {
+  ColorCropScreen,
+  CropResult,
+} from 'terraso-mobile-client/screens/ColorAnalysisScreen/components/ColorCropScreen';
 
-export const ColorCropSoilScreen = (props: ColorAnalysisProps) => {
-  const {photo} = props;
+export const ColorCropSoilScreen = () => {
   const {t} = useTranslation();
-  const navigation = useNavigation();
+  const {
+    photo,
+    state: {reference, soil},
+    setState,
+  } = useColorAnalysisContext();
+  const colorAnalysisNavigation = useColorAnalysisNavigation();
 
   const onCrop = useCallback(
-    (crop: PhotoWithBase64) => {
-      const newProps = {...props, soil: crop};
-      if (props.reference) {
-        navigation.navigate('COLOR_ANALYSIS', newProps);
+    (crop: CropResult) => {
+      setState(state => ({...state, soil: crop}));
+      if (reference !== undefined) {
+        colorAnalysisNavigation.navigate('COLOR_ANALYSIS_HOME');
       } else {
-        navigation.replace('COLOR_CROP_REFERENCE', newProps);
+        colorAnalysisNavigation.navigate('COLOR_CROP_REFERENCE');
       }
     },
-    [navigation, props],
+    [colorAnalysisNavigation, setState, reference],
   );
 
   return (
     <ColorCropScreen
       photo={photo}
+      initialCrop={soil?.crop}
       onCrop={onCrop}
       title={t('soil.color.soil')}
       description={t('soil.color.crop_soil')}

--- a/dev-client/src/screens/ColorAnalysisScreen/components/ColorCropScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/components/ColorCropScreen.tsx
@@ -44,7 +44,13 @@ import {
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 
-export type Crop = {top: number; left: number; size: number};
+type Crop = {top: number; left: number; size: number};
+
+export type CropResult = {
+  photo: PhotoWithBase64;
+  crop: Crop;
+};
+
 type Dimensions = {width: number; height: number};
 
 const minDim = (dimensions: Dimensions) => {
@@ -64,15 +70,24 @@ const clampCrop = (crop: Crop, dimensions: Dimensions): Crop => {
 
 type Props = {
   photo: Photo;
-  onCrop: (_: PhotoWithBase64) => void;
+  initialCrop?: Crop;
+  onCrop: (_: CropResult) => void;
   title: string;
   description: string;
 };
-export const ColorCropScreen = ({photo, onCrop, title, description}: Props) => {
+export const ColorCropScreen = ({
+  photo,
+  initialCrop,
+  onCrop,
+  title,
+  description,
+}: Props) => {
   const {t} = useTranslation();
 
   const frameDimension = useSharedValue<number>(minDim(photo));
-  const crop = useSharedValue<Crop>({top: 0, left: 0, size: minDim(photo)});
+  const crop = useSharedValue<Crop>(
+    initialCrop ?? {top: 0, left: 0, size: minDim(photo)},
+  );
   const start = useSharedValue<Crop>({...crop.value});
 
   const pan = Gesture.Pan()
@@ -157,7 +172,10 @@ export const ColorCropScreen = ({photo, onCrop, title, description}: Props) => {
       throw Error('unexpected error: missing base64 encoding of cropped photo');
     }
 
-    onCrop({...croppedPhoto, base64: croppedPhoto.base64});
+    onCrop({
+      crop: crop.value,
+      photo: {...croppedPhoto, base64: croppedPhoto.base64},
+    });
   }, [photo.uri, onCrop, crop]);
 
   return (

--- a/dev-client/src/screens/ColorAnalysisScreen/navigation/navigation.ts
+++ b/dev-client/src/screens/ColorAnalysisScreen/navigation/navigation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {ParamList} from 'terraso-mobile-client/navigation/types';
+import {ColorCropReferenceScreen} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorCropReferenceScreen';
+import {ColorCropSoilScreen} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorCropSoilScreen';
+import {
+  generateScreens,
+  createNavigationHook,
+} from 'terraso-mobile-client/navigation/utils/utils';
+import {ScreenDefinitions} from 'terraso-mobile-client/navigation/types';
+import {ColorAnalysisHomeScreen} from 'terraso-mobile-client/screens/ColorAnalysisScreen//ColorAnalysisHomeScreen';
+
+const screenDefinitions = {
+  COLOR_ANALYSIS_HOME: ColorAnalysisHomeScreen,
+  COLOR_CROP_REFERENCE: ColorCropReferenceScreen,
+  COLOR_CROP_SOIL: ColorCropSoilScreen,
+} as const satisfies ScreenDefinitions;
+
+type ColorAnalysisParamList = ParamList<typeof screenDefinitions>;
+
+export const useColorAnalysisNavigation =
+  createNavigationHook<ColorAnalysisParamList>();
+
+export const Stack = createNativeStackNavigator<ColorAnalysisParamList>();
+
+export const screens = generateScreens(Stack, screenDefinitions);

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
@@ -33,9 +33,7 @@ import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigatio
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
-export const ColorGuideScreen = (
-  props: SoilPitInputScreenProps | undefined,
-) => {
+export const ColorGuideScreen = (props: SoilPitInputScreenProps) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
 

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -345,7 +345,7 @@
     "SITE_TRANSFER_PROJECT": "Project #{{id}}",
     "CREATE_SITE": "Create Site",
     "COLOR_GUIDE": "Soil Color Guide",
-    "COLOR_ANALYSIS": "Photo Analysis"
+    "COLOR_ANALYSIS_HOME": "Photo Analysis"
   },
   "login": {
     "title": "LandPKS",


### PR DESCRIPTION
## Description
Reorganizes the soil color analysis screens into a subnavigator for better state management. Now when you enter the crop screen, it re-uses the previous crop. And when leaving a crop screen, you go back to the previous crop screen if there was one, which will re-use the previous crop. 

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Progress on #974 
