### PR TITLE
build: update react-native-gesture-handler to 2.16.0

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -41,7 +41,7 @@
         "react-i18next": "^14.1.0",
         "react-native": "^0.73.6",
         "react-native-autocomplete-input": "^5.4.0",
-        "react-native-gesture-handler": "^2.15.0",
+        "react-native-gesture-handler": "^2.16.0",
         "react-native-get-random-values": "^1.10.0",
         "react-native-gradle-plugin": "^0.71.19",
         "react-native-mmkv-storage": "^0.9.1",
@@ -22198,9 +22198,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.15.0.tgz",
-      "integrity": "sha512-cmMGW8k86o/xgVTBZZOPohvR5re4Vh65PUxH4HbBBJAYTog4aN4wTVTUlnoky01HuSN8/X4h3tI/K3XLPoDnsg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.0.tgz",
+      "integrity": "sha512-1hFkx7RIfeJSyTQQ0Nkv4icFVZ5+XjQkd47OgZMBFzoB7ecL+nFSz8KLi3OCWOhq+nbHpSPlSG5VF3CQNCJpWA==",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -49,7 +49,7 @@
     "react-i18next": "^14.1.0",
     "react-native": "^0.73.6",
     "react-native-autocomplete-input": "^5.4.0",
-    "react-native-gesture-handler": "^2.15.0",
+    "react-native-gesture-handler": "^2.16.0",
     "react-native-get-random-values": "^1.10.0",
     "react-native-gradle-plugin": "^0.71.19",
     "react-native-mmkv-storage": "^0.9.1",


### PR DESCRIPTION
## Description
update react-native-gesture-handler to 2.16.0.