### PR TITLE
fix: increase project description font size

### DIFF
--- a/dev-client/src/screens/CreateProjectScreen/components/Form.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/Form.tsx
@@ -107,6 +107,7 @@ const SharedFormComponents = (showPlaceholders: boolean, t: TFunction) => {
       name="description"
       placeholder={showPlaceholders ? t('projects.add.description') : undefined}
       variant="outline"
+      fontSize={16}
       numberOfLines={3}
       autoCompleteType="off"
       label={t('projects.add.description')}


### PR DESCRIPTION
## Description
Increases font the size of the project description text field.

### Related Issues
This will address #957.

<img width="417" alt="image" src="https://github.com/techmatters/terraso-mobile-client/assets/86784/7451dccf-329a-4f59-b864-3b540772ffaa">
