### PR TITLE
fix: use same color for info and help icons on create site form

### DIFF
--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -133,7 +133,7 @@ export const CreateSiteForm = ({
                 size="md"
                 name="info"
                 onPress={onInfoPress}
-                _icon={{color: 'action.active'}}
+                _icon={{color: 'action.active_subtle'}}
               />
             </FormLabel>
             <FormRadioGroup


### PR DESCRIPTION
## Description
Use the same color for info and help icons on create site form.

<img width="390" alt="image" src="https://github.com/techmatters/terraso-mobile-client/assets/86784/0b43622a-1442-4682-9320-af02b47865f0">

### Related Issues
This will address #916.