### PR TITLE
fix: add ACTIVITY_RECOGNITION to blocked permissions

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -92,6 +92,7 @@ export default ({config}: ConfigContext): ExpoConfig => ({
       'android.permissions.ACCESS_FINE_LOCATION',
     ],
     blockedPermissions: [
+      'android.permissions.ACTIVITY_RECOGNITION',
       'android.permissions.RECORD_AUDIO',
       'android.permissions.MODIFY_AUDIO_SETTINGS',
       'android.permissions.VIBRATE',


### PR DESCRIPTION
## Description
Add ACTIVITY_RECOGNITION to blocked permissions. Expo is adding this and we don't need it.

Avoids Play Store request for additional details.