### PR TITLE
fix: Fix bad assumptions in Home screen callout selection and refactor for clarity.

### DIFF
--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -130,7 +130,7 @@ export const HomeScreen = memo(() => {
 
   const searchFunction = useCallback(
     (coords: Coords) => {
-      setCalloutState({kind: 'location', showCallout: false, coords});
+      setCalloutState({kind: 'location', coords});
       mapRef.current?.moveToPoint(coords);
     },
     [setCalloutState, mapRef],

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -48,7 +48,12 @@ import {selectSitesAndUserRoles} from 'terraso-client-shared/selectors';
 import {ListFilterProvider} from 'terraso-mobile-client/components/ListFilter';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
+import {
+  CalloutState,
+  noneCallout,
+  siteCallout,
+  locationCallout,
+} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 
 type HomeScreenRef = {
   showSiteOnMap: (site: Site) => void;
@@ -71,9 +76,7 @@ export const HomeScreen = memo(() => {
   const infoBottomSheetRef = useRef<BottomSheetModal>(null);
   const siteListBottomSheetRef = useRef<BottomSheet>(null);
   const [mapStyleURL, setMapStyleURL] = useState(Mapbox.StyleURL.Street);
-  const [calloutState, setCalloutState] = useState<CalloutState>({
-    kind: 'none',
-  });
+  const [calloutState, setCalloutState] = useState<CalloutState>(noneCallout());
   const currentUserID = useSelector(
     state => state.account.currentUser?.data?.id,
   );
@@ -87,7 +90,7 @@ export const HomeScreen = memo(() => {
   const showSiteOnMap = useCallback(
     (targetSite: Site) => {
       mapRef.current?.moveToPoint(targetSite);
-      setCalloutState({kind: 'site', siteId: targetSite.id});
+      setCalloutState(siteCallout(targetSite.id));
       siteListBottomSheetRef.current?.collapse();
     },
     [setCalloutState],
@@ -130,7 +133,7 @@ export const HomeScreen = memo(() => {
 
   const searchFunction = useCallback(
     (coords: Coords) => {
-      setCalloutState({kind: 'location', coords});
+      setCalloutState(locationCallout(coords));
       mapRef.current?.moveToPoint(coords);
     },
     [setCalloutState, mapRef],

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -48,23 +48,7 @@ import {selectSitesAndUserRoles} from 'terraso-client-shared/selectors';
 import {ListFilterProvider} from 'terraso-mobile-client/components/ListFilter';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
-
-export type CalloutState =
-  | {
-      kind: 'site';
-      siteId: string;
-    }
-  | {
-      kind: 'location';
-      showCallout: boolean;
-      coords: Coords;
-    }
-  | {
-      kind: 'site_cluster';
-      siteIds: string[];
-      coords: Coords;
-    }
-  | {kind: 'none'};
+import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 
 type HomeScreenRef = {
   showSiteOnMap: (site: Site) => void;

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -35,22 +35,18 @@ import Mapbox from '@rnmapbox/maps';
 import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {SiteListBottomSheet} from 'terraso-mobile-client/screens/HomeScreen/components/SiteListBottomSheet';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
-import MapSearch from 'terraso-mobile-client/screens/HomeScreen/components/MapSearch';
 import BottomSheet, {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {SiteListBottomSheet} from 'terraso-mobile-client/screens/HomeScreen/components/SiteListBottomSheet';
+import MapSearch from 'terraso-mobile-client/screens/HomeScreen/components/MapSearch';
 import {LandPKSInfoModal} from 'terraso-mobile-client/screens/HomeScreen/components/LandPKSInfoModal';
+import {getHomeScreenFilters} from 'terraso-mobile-client/screens/HomeScreen/utils/homeScreenFilters';
 import {fetchSoilDataForUser} from 'terraso-client-shared/soilId/soilIdSlice';
 import {selectSitesAndUserRoles} from 'terraso-client-shared/selectors';
-import {
-  ListFilterProvider,
-  SortingOption,
-} from 'terraso-mobile-client/components/ListFilter';
-import {equals, searchText} from 'terraso-mobile-client/util';
+import {ListFilterProvider} from 'terraso-mobile-client/components/ListFilter';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
-import {normalizeText} from 'terraso-client-shared/utils';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 
 export type CalloutState =
@@ -183,75 +179,9 @@ export const HomeScreen = memo(() => {
 
   const {siteDistances} = useGeospatialContext();
 
-  const distanceSorting: Record<string, SortingOption<Site>> | undefined =
-    useMemo(() => {
-      return siteDistances === null
-        ? undefined
-        : {
-            distanceAsc: {
-              record: siteDistances,
-              key: 'id',
-              order: 'ascending',
-            },
-            distanceDesc: {
-              record: siteDistances,
-              key: 'id',
-              order: 'descending',
-            },
-          };
-    }, [siteDistances]);
-
   const filters = useMemo(
-    () =>
-      ({
-        search: {
-          kind: 'filter',
-          f: searchText,
-          preprocess: normalizeText,
-          lookup: {
-            key: ['name', 'notes.content'],
-          },
-          hide: true,
-        },
-        role: {
-          kind: 'filter',
-          f: equals,
-          lookup: {
-            record: siteProjectRoles,
-            key: 'id',
-          },
-        },
-        project: {
-          kind: 'filter',
-          f: equals,
-          lookup: {
-            key: 'projectId',
-          },
-        },
-        sort: {
-          kind: 'sorting',
-          options: {
-            nameDesc: {
-              key: 'name',
-              order: 'descending',
-            },
-            nameAsc: {
-              key: 'name',
-              order: 'ascending',
-            },
-            lastModDesc: {
-              key: 'updatedAt',
-              order: 'descending',
-            },
-            lastModAsc: {
-              key: 'updatedAt',
-              order: 'ascending',
-            },
-            ...distanceSorting,
-          },
-        },
-      }) as const,
-    [distanceSorting, siteProjectRoles],
+    () => getHomeScreenFilters(siteDistances, siteProjectRoles),
+    [siteDistances, siteProjectRoles],
   );
 
   return (

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
@@ -1,34 +1,36 @@
 /*
  * Copyright © 2024 Technology Matters
  *
- * This program is free software: you can redistribute it and/or modify
+ * state program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * state program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see https://www.gnu.org/licenses/.
+ * along with state program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
+import { Coords } from 'terraso-mobile-client/model/map/mapSlice';
+
 
 export type CalloutState =
   | {
-      kind: 'site';
-      siteId: string;
-    }
+    kind: 'site';
+    siteId: string;
+  }
   | {
-      kind: 'location';
-      coords: Coords;
-    }
+    kind: 'location';
+    coords: Coords;
+  }
   | {
-      kind: 'site_cluster';
-      siteIds: string[];
-      coords: Coords;
-    }
-  | {kind: 'none'};
+    kind: 'site_cluster';
+    siteIds: string[];
+    coords: Coords;
+  }
+  | { kind: 'none' };
+

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
@@ -15,22 +15,83 @@
  * along with state program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { Coords } from 'terraso-mobile-client/model/map/mapSlice';
-
+import {Site} from 'terraso-client-shared/site/siteSlice';
+import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 
 export type CalloutState =
   | {
-    kind: 'site';
-    siteId: string;
-  }
+      kind: 'site';
+      siteId: string;
+    }
   | {
-    kind: 'location';
-    coords: Coords;
-  }
+      kind: 'location';
+      coords: Coords;
+    }
   | {
-    kind: 'site_cluster';
-    siteIds: string[];
-    coords: Coords;
-  }
-  | { kind: 'none' };
+      kind: 'site_cluster';
+      siteIds: string[];
+      coords: Coords;
+    }
+  | {kind: 'none'};
 
+export function siteCallout(siteId: string): CalloutState {
+  return {kind: 'site', siteId};
+}
+
+export function siteClusterCallout(
+  coords: Coords,
+  siteIds: Iterable<string>,
+): CalloutState {
+  return {kind: 'site_cluster', coords, siteIds: Array.from(siteIds)};
+}
+
+export function locationCallout(coords: Coords): CalloutState {
+  return {kind: 'location', coords};
+}
+
+export function noneCallout(): CalloutState {
+  return {kind: 'none'};
+}
+
+export function getCalloutCoords(
+  state: CalloutState,
+  sites: Record<string, Site>,
+): Coords | null {
+  switch (state.kind) {
+    case 'site':
+      return getCalloutSite(state, sites);
+    case 'location':
+      return state.coords;
+    case 'site_cluster':
+      return state.coords;
+    case 'none':
+      return null;
+  }
+}
+
+export function getCalloutSite(
+  state: CalloutState,
+  sites: Record<string, Site>,
+): Site | null {
+  return state.kind === 'site' && state.siteId in sites
+    ? sites[state.siteId]
+    : null;
+}
+
+export function getCalloutSites(
+  state: CalloutState,
+  sites: Record<string, Site>,
+): Record<string, Site> {
+  switch (state.kind) {
+    case 'site':
+      const site = getCalloutSite(state, sites);
+      return site == null ? {} : Object.fromEntries([[state.siteId, site]]);
+    case 'site_cluster':
+      const presentSiteIds = state.siteIds.filter(siteId => siteId in sites);
+      return Object.fromEntries(
+        presentSiteIds.map(siteId => [siteId, sites[siteId]]),
+      );
+    default:
+      return {};
+  }
+}

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
@@ -1,18 +1,18 @@
 /*
  * Copyright © 2024 Technology Matters
  *
- * state program is free software: you can redistribute it and/or modify
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * state program is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with state program. If not, see https://www.gnu.org/licenses/.
+ * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
 import {Site} from 'terraso-client-shared/site/siteSlice';

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
+
+export type CalloutState =
+  | {
+      kind: 'site';
+      siteId: string;
+    }
+  | {
+      kind: 'location';
+      showCallout: boolean;
+      coords: Coords;
+    }
+  | {
+      kind: 'site_cluster';
+      siteIds: string[];
+      coords: Coords;
+    }
+  | {kind: 'none'};

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.tsx
@@ -24,7 +24,6 @@ export type CalloutState =
     }
   | {
       kind: 'location';
-      showCallout: boolean;
       coords: Coords;
     }
   | {

--- a/dev-client/src/screens/HomeScreen/components/SiteClusterCalloutListItem.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteClusterCalloutListItem.tsx
@@ -18,7 +18,10 @@
 import {useCallback} from 'react';
 import {Pressable} from 'react-native';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
+import {
+  CalloutState,
+  siteCallout,
+} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 import {useSelector} from 'terraso-mobile-client/store';
 import {
   Column,
@@ -41,7 +44,7 @@ export const SiteClusterCalloutListItem = ({
       : state.project.projects[site.projectId],
   );
   const onPress = useCallback(() => {
-    setState({kind: 'site', siteId: site.id});
+    setState(siteCallout(site.id));
   }, [site.id, setState]);
 
   return (

--- a/dev-client/src/screens/HomeScreen/components/SiteClusterCalloutListItem.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteClusterCalloutListItem.tsx
@@ -18,7 +18,7 @@
 import {useCallback} from 'react';
 import {Pressable} from 'react-native';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
+import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 import {useSelector} from 'terraso-mobile-client/store';
 import {
   Column,

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -187,12 +187,7 @@ export const SiteMap = memo(
       );
 
       const onTempSitePress = useCallback(
-        () =>
-          setCalloutState(
-            calloutState.kind === 'location'
-              ? {...calloutState, showCallout: true}
-              : calloutState,
-          ),
+        () => setCalloutState(calloutState),
         [calloutState, setCalloutState],
       );
 
@@ -218,7 +213,6 @@ export const SiteMap = memo(
             setCalloutState({
               kind: 'location',
               coords: positionToCoords(feature.geometry.coordinates),
-              showCallout: true,
             });
           } else {
             Keyboard.dismiss();

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -28,7 +28,14 @@ import {
 import {useTheme} from 'native-base';
 import {Keyboard, PixelRatio, StyleSheet} from 'react-native';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
+import {
+  CalloutState,
+  noneCallout,
+  siteCallout,
+  locationCallout,
+  siteClusterCallout,
+  getCalloutSite,
+} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 import {
   coordsToPosition,
   positionToCoords,
@@ -82,13 +89,10 @@ export const SiteMap = memo(
       }));
 
       const {filteredItems: filteredSites} = useListFilter<Site>();
-
       const sites = Object.fromEntries(
         filteredSites.map(site => [site.id, site]),
       );
-
-      const selectedSite =
-        calloutState.kind === 'site' ? sites[calloutState.siteId] : null;
+      const selectedSite = getCalloutSite(calloutState, sites);
 
       const {colors} = useTheme();
 
@@ -145,13 +149,14 @@ export const SiteMap = memo(
               0,
             )) as GeoJSON.FeatureCollection;
 
-            setCalloutState({
-              kind: 'site_cluster',
-              coords: positionToCoords(
-                (feature.geometry as GeoJSON.Point).coordinates,
+            setCalloutState(
+              siteClusterCallout(
+                positionToCoords(
+                  (feature.geometry as GeoJSON.Point).coordinates,
+                ),
+                leafFeatures.features.map(feat => feat.id as string),
               ),
-              siteIds: leafFeatures.features.map(feat => feat.id as string),
-            });
+            );
           }
         },
         [shapeSourceRef, setCalloutState],
@@ -180,15 +185,10 @@ export const SiteMap = memo(
               paddingBottom: 0,
               cameraRef: cameraRef,
             });
-            setCalloutState({kind: 'site', siteId: feature.id as string});
+            setCalloutState(siteCallout(feature.id as string));
           }
         },
         [setCalloutState, handleClusterPress],
-      );
-
-      const onTempSitePress = useCallback(
-        () => setCalloutState(calloutState),
-        [calloutState, setCalloutState],
       );
 
       const onPress = useCallback(
@@ -210,13 +210,12 @@ export const SiteMap = memo(
               paddingBottom: 320,
               cameraRef: cameraRef,
             });
-            setCalloutState({
-              kind: 'location',
-              coords: positionToCoords(feature.geometry.coordinates),
-            });
+            setCalloutState(
+              locationCallout(positionToCoords(feature.geometry.coordinates)),
+            );
           } else {
             Keyboard.dismiss();
-            setCalloutState({kind: 'none'});
+            setCalloutState(noneCallout());
           }
         },
         [calloutState, setCalloutState],
@@ -313,8 +312,7 @@ export const SiteMap = memo(
           </Mapbox.ShapeSource>
           <Mapbox.ShapeSource
             id="temporarySitesSource"
-            shape={temporarySitesFeature}
-            onPress={onTempSitePress}>
+            shape={temporarySitesFeature}>
             <Mapbox.SymbolLayer
               id="temporarySitesLayer"
               style={mapStyles.temporarySiteLayer}

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -28,7 +28,7 @@ import {
 import {useTheme} from 'native-base';
 import {Keyboard, PixelRatio, StyleSheet} from 'react-native';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
+import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 import {
   coordsToPosition,
   positionToCoords,

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -19,7 +19,7 @@ import React, {useCallback} from 'react';
 import Mapbox from '@rnmapbox/maps';
 import {Divider, FlatList} from 'native-base';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
+import {CalloutState} from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
 import {coordsToPosition} from 'terraso-mobile-client/components/StaticMapView';
 import {Card} from 'terraso-mobile-client/components/Card';
 import {CardCloseButton} from 'terraso-mobile-client/components/CardCloseButton';

--- a/dev-client/src/screens/HomeScreen/utils/homeScreenFilters.ts
+++ b/dev-client/src/screens/HomeScreen/utils/homeScreenFilters.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {normalizeText} from 'terraso-client-shared/utils';
+import {equals, searchText} from 'terraso-mobile-client/util';
+import {SortingOption} from 'terraso-mobile-client/components/ListFilter';
+import {Site} from 'terraso-client-shared/site/siteSlice';
+import {ProjectMembershipProjectRoleChoices} from 'terraso-client-shared/graphqlSchema/graphql';
+
+export const getHomeScreenFilters = (
+  siteDistances: Record<string, number> | null,
+  siteProjectRoles: {
+    [k: string]: ProjectMembershipProjectRoleChoices | undefined;
+  },
+) => {
+  const distanceSorting: Record<string, SortingOption<Site>> | undefined =
+    siteDistances === null
+      ? undefined
+      : {
+          distanceAsc: {
+            record: siteDistances,
+            key: 'id',
+            order: 'ascending',
+          },
+          distanceDesc: {
+            record: siteDistances,
+            key: 'id',
+            order: 'descending',
+          },
+        };
+
+  return {
+    search: {
+      kind: 'filter',
+      f: searchText,
+      preprocess: normalizeText,
+      lookup: {
+        key: ['name', 'notes.content'],
+      },
+      hide: true,
+    },
+    role: {
+      kind: 'filter',
+      f: equals,
+      lookup: {
+        record: siteProjectRoles,
+        key: 'id',
+      },
+    },
+    project: {
+      kind: 'filter',
+      f: equals,
+      lookup: {
+        key: 'projectId',
+      },
+    },
+    sort: {
+      kind: 'sorting',
+      options: {
+        nameDesc: {
+          key: 'name',
+          order: 'descending',
+        },
+        nameAsc: {
+          key: 'name',
+          order: 'ascending',
+        },
+        lastModDesc: {
+          key: 'updatedAt',
+          order: 'descending',
+        },
+        lastModAsc: {
+          key: 'updatedAt',
+          order: 'ascending',
+        },
+        ...distanceSorting,
+      },
+    },
+  } as const;
+};


### PR DESCRIPTION
## Description

If the user's current callout selection is excluded by their site filters, the app gracefully hides the callout rather than crashing. To enable this fix, add helper functions to the home screen's callout system to make initializing state more concise and mapping state to logic more consistent, and further refactor SiteMapCallout for general clarity.

This PR will fix the three below tickets, but several other bugs are also fixed (similar issues would have affected site clusters and filtering.) The general problem was that components which rendered based on the callout state were not written to consider that the selected callout site(s) might be excluded by the filter.

Also do some general incremental cleanup to the Home screen for readability and clarity: relocate filters and callout state to their own files, and remove the unused `showCallout`state property.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #676, #953, #741 

### Verification steps

Select a site in the home screen. Enter any search or filter criteria which exclude the site, and observe that the application no longer crashes. Do the same for site clusters. Verify that location selections are unaffected.