### PR TITLE
fix: restore push notification entitlement

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -17,7 +17,7 @@
 
 import 'ts-node/register';
 import {ExpoConfig, ConfigContext} from 'expo/config';
-import {withEntitlementsPlist, withAppBuildGradle} from 'expo/config-plugins';
+import {withAppBuildGradle} from 'expo/config-plugins';
 import {fromEntries} from 'terraso-client-shared/utils';
 
 const VERSION_REGEX = /^v[0-9]+$/g;
@@ -139,11 +139,6 @@ export default ({config}: ConfigContext): ExpoConfig => ({
     ],
     [
       ((modConfig: ExpoConfig): ExpoConfig => {
-        // workaround to remove push notification entitlements: https://github.com/expo/expo/pull/25808#pullrequestreview-1772795646
-        withEntitlementsPlist(modConfig, entitlements => {
-          delete entitlements.modResults['aps-environment'];
-          return entitlements;
-        });
         // workaround to avoid double signing with debug keychain
         withAppBuildGradle(modConfig, gradle => {
           gradle.modResults.contents = gradle.modResults.contents.replace(


### PR DESCRIPTION
## Description
Enable push notification entitlement.

Fixes this warning (in emails from Apple):
>ITMS-90078: Missing Push Notification Entitlement - Your app appears to register with the Apple Push Notification service, but the app signature's entitlements do not include the 'aps-environment' entitlement. If your app uses the Apple Push Notification service, make sure your App ID is enabled for Push Notification in the Provisioning Portal, and resubmit after signing your app with a Distribution provisioning profile that includes the 'aps-environment' entitlement. Xcode does not automatically copy the aps-environment entitlement from provisioning profiles at build time. This behavior is intentional. To use this entitlement, either enable Push Notifications in the project editor's Capabilities pane, or manually add the entitlement to your entitlements file. For more information, see https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/HandlingRemoteNotifications.html#//apple_ref/doc/uid/TP40008194-CH6-SW1.

In addition to the code change, I got a new version of `Terraso_LandPKS_Beta_Profile.mobileprovision`, ran `openssl base64 < Terraso_LandPKS_Beta_Profile.mobileprovision | tr -d '\n' | tee Terraso_LandPKS_Beta_Profile.base64.txt` and updated `IOS_MOBILE_PROVISION_BASE64`.
