### PR TITLE
fix: prevent the removal of the only manager from projects

### DIFF
--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -98,7 +98,7 @@ export const ProjectTeamScreen = ({route}: Props) => {
       <UserList
         memberships={members}
         currentUserId={currentUser.data?.id}
-        userAction={removeMembership}
+        removeUser={removeMembership}
         memberAction={manageMember}
         currentUserRole={currentUserRole}
       />

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserInfo.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserInfo.tsx
@@ -37,12 +37,12 @@ type InfoProps = {
 export const UserInfo = ({membership, user, isCurrentUser}: InfoProps) => {
   const {t} = useTranslation();
   const userLabel = useMemo(() => {
-    let label = formatName(user.firstName, user.lastName);
-
+    let name = formatName(user.firstName, user.lastName);
     if (isCurrentUser) {
-      label += ` (${t('general.you')})`;
+      return t('general.you_name', {name: name});
+    } else {
+      return name;
     }
-    return label;
   }, [user, isCurrentUser, t]);
 
   return (

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserInfo.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserInfo.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Image} from 'native-base';
+import {User} from 'terraso-client-shared/account/accountSlice';
+import {useTranslation} from 'react-i18next';
+import {useMemo} from 'react';
+import {ProjectMembership} from 'terraso-client-shared/project/projectSlice';
+import {formatName} from 'terraso-mobile-client/util';
+import {
+  Box,
+  HStack,
+  Badge,
+  Text,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+
+type InfoProps = {
+  membership: ProjectMembership;
+  user: User;
+  isCurrentUser: boolean;
+};
+
+export const UserInfo = ({membership, user, isCurrentUser}: InfoProps) => {
+  const {t} = useTranslation();
+  const userLabel = useMemo(() => {
+    let label = formatName(user.firstName, user.lastName);
+
+    if (isCurrentUser) {
+      label += ` (${t('general.you')})`;
+    }
+    return label;
+  }, [user, isCurrentUser, t]);
+
+  return (
+    <HStack space={3} justifyContent="space-between" alignItems="center">
+      <Box>
+        <Image
+          variant="profilePic"
+          source={{uri: user.profileImage}}
+          alt="profile pic"
+        />
+      </Box>
+      <Text flex={3}>{userLabel}</Text>
+      <Box>
+        <Badge
+          variant="chip"
+          bg="primary.lighter"
+          py="5px"
+          px="10px"
+          _text={{color: 'text.primary'}}>
+          {t(`general.role.${membership.userRole}`)}
+        </Badge>
+      </Box>
+    </HStack>
+  );
+};

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -15,20 +15,13 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Button, Center, Image, Pressable} from 'native-base';
+import {Button, Center, Pressable} from 'native-base';
 import {User} from 'terraso-client-shared/account/accountSlice';
 import {useTranslation} from 'react-i18next';
-import {useMemo} from 'react';
 import {ProjectMembership} from 'terraso-client-shared/project/projectSlice';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
-import {formatName} from 'terraso-mobile-client/util';
-import {
-  Box,
-  HStack,
-  VStack,
-  Badge,
-  Text,
-} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {Box, VStack} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {UserInfo} from 'terraso-mobile-client/screens/ProjectTeamScreen/components/UserInfo';
 
 type TriggerProps = {
   onOpen: () => void;
@@ -50,47 +43,6 @@ function LeaveProjectTrigger({onOpen, message}: TriggerProps) {
     </Center>
   );
 }
-
-type InfoProps = {
-  membership: ProjectMembership;
-  user: User;
-  isCurrentUser: boolean;
-};
-
-const UserInfo = ({membership, user, isCurrentUser}: InfoProps) => {
-  const {t} = useTranslation();
-  const userLabel = useMemo(() => {
-    let label = formatName(user.firstName, user.lastName);
-
-    if (isCurrentUser) {
-      label += ` (${t('general.you')})`;
-    }
-    return label;
-  }, [user, isCurrentUser, t]);
-
-  return (
-    <HStack space={3} justifyContent="space-between" alignItems="center">
-      <Box>
-        <Image
-          variant="profilePic"
-          source={{uri: user.profileImage}}
-          alt="profile pic"
-        />
-      </Box>
-      <Text flex={3}>{userLabel}</Text>
-      <Box>
-        <Badge
-          variant="chip"
-          bg="primary.lighter"
-          py="5px"
-          px="10px"
-          _text={{color: 'text.primary'}}>
-          {t(`general.role.${membership.userRole}`)}
-        </Badge>
-      </Box>
-    </HStack>
-  );
-};
 
 type ItemProps = {
   membership: ProjectMembership;

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -85,7 +85,7 @@ const UserInfo = ({membership, user, isCurrentUser}: InfoProps) => {
           py="5px"
           px="10px"
           _text={{color: 'text.primary'}}>
-          {t('general.role.' + membership.userRole)}
+          {t(`general.role.${membership.userRole}`)}
         </Badge>
       </Box>
     </HStack>

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Technology Matters
+ * Copyright © 2024 Technology Matters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Button, Center, Image, Pressable} from 'native-base';
+import {User} from 'terraso-client-shared/account/accountSlice';
+import {useTranslation} from 'react-i18next';
+import {useMemo} from 'react';
+import {
+  ProjectMembership,
+  ProjectRole,
+} from 'terraso-client-shared/project/projectSlice';
+import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
+import {formatName} from 'terraso-mobile-client/util';
+import {
+  Box,
+  HStack,
+  VStack,
+  Badge,
+  Text,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+
+type ItemProps = {
+  membership: ProjectMembership;
+  user: User;
+  currentUserId?: string;
+  removeUser: () => void;
+  memberAction: () => void;
+  currentUserRole: ProjectRole;
+};
+
+type TriggerProps = {
+  onOpen: () => void;
+  message: string;
+};
+
+function LeaveProjectTrigger({onOpen, message}: TriggerProps) {
+  return (
+    <Center>
+      <Button
+        size="sm"
+        my={2}
+        w="50%"
+        _text={{color: 'error.main'}}
+        bgColor="grey.200"
+        onPress={onOpen}>
+        {message}
+      </Button>
+    </Center>
+  );
+}
+
+const UserWrapper = ({
+  isCurrentUser,
+  memberAction,
+  currentUserRole,
+  children,
+}: React.PropsWithChildren &
+  Pick<ItemProps, 'memberAction'> & {
+    isCurrentUser: boolean;
+    currentUserRole: ProjectRole;
+  }) =>
+  !isCurrentUser && currentUserRole === 'MANAGER' ? (
+    <Pressable onPress={memberAction}>{children}</Pressable>
+  ) : (
+    <>{children}</>
+  );
+
+export const UserItem = ({
+  membership,
+  user,
+  currentUserId,
+  removeUser,
+  memberAction,
+  currentUserRole,
+}: ItemProps) => {
+  const {t} = useTranslation();
+  const isCurrentUser = useMemo(() => {
+    return user.id === currentUserId;
+  }, [user, currentUserId]);
+
+  const userName = useMemo(() => {
+    let name = formatName(user.firstName, user.lastName);
+
+    if (isCurrentUser) {
+      name += ` (${t('general.you')})`;
+    }
+    return name;
+  }, [user, isCurrentUser, t]);
+
+  return (
+    <Box borderBottomWidth="1" width={275} py={2}>
+      <VStack>
+        <UserWrapper
+          currentUserRole={currentUserRole}
+          isCurrentUser={isCurrentUser}
+          memberAction={memberAction}>
+          <HStack space={3} justifyContent="space-between" alignItems="center">
+            <Box>
+              <Image
+                variant="profilePic"
+                source={{uri: user.profileImage}}
+                alt="profile pic"
+              />
+            </Box>
+            <Text flex={3}>{userName}</Text>
+            <Box>
+              <Badge
+                variant="chip"
+                bg="primary.lighter"
+                py="5px"
+                px="10px"
+                _text={{color: 'text.primary'}}>
+                {t('general.role.' + membership.userRole)}
+              </Badge>
+            </Box>
+          </HStack>
+        </UserWrapper>
+        {isCurrentUser && (
+          <ConfirmModal
+            trigger={onOpen => (
+              <LeaveProjectTrigger
+                onOpen={onOpen}
+                message={t('projects.team.leave_project_modal.trigger')}
+              />
+            )}
+            title={t('projects.team.leave_project_modal.title')}
+            body={t('projects.team.leave_project_modal.body')}
+            actionName={t('projects.team.leave_project_modal.action_name')}
+            handleConfirm={removeUser}
+          />
+        )}
+      </VStack>
+    </Box>
+  );
+};

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -97,6 +97,7 @@ type ItemProps = {
   user: User;
   isCurrentUser: boolean;
   isManager: boolean;
+  hasSingleManager: boolean;
   removeUser: () => void;
   memberAction: () => void;
 };
@@ -106,10 +107,14 @@ export const UserItem = ({
   user,
   isCurrentUser,
   isManager,
+  hasSingleManager,
   removeUser,
   memberAction,
 }: ItemProps) => {
   const {t} = useTranslation();
+
+  /* Any non-manager user can leave the project, but managers can only leave if they are not the only manager. */
+  const canLeaveProject = isCurrentUser && !(isManager && hasSingleManager);
 
   return (
     <Box borderBottomWidth="1" width={275} py={2}>
@@ -129,7 +134,7 @@ export const UserItem = ({
             isCurrentUser={isCurrentUser}
           />
         )}
-        {isCurrentUser && (
+        {canLeaveProject && (
           <ConfirmModal
             trigger={onOpen => (
               <LeaveProjectTrigger

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -47,9 +47,9 @@ function LeaveProjectTrigger({onOpen, message}: TriggerProps) {
 type ItemProps = {
   membership: ProjectMembership;
   user: User;
-  isCurrentUser: boolean;
-  isManager: boolean;
-  hasSingleManager: boolean;
+  isForCurrentUser: boolean;
+  isInManagerView: boolean;
+  isForSingleManagerProject: boolean;
   removeUser: () => void;
   memberAction: () => void;
 };
@@ -57,36 +57,40 @@ type ItemProps = {
 export const UserItem = ({
   membership,
   user,
-  isCurrentUser,
-  isManager,
-  hasSingleManager,
+  isForCurrentUser,
+  isInManagerView,
+  isForSingleManagerProject,
   removeUser,
   memberAction,
 }: ItemProps) => {
   const {t} = useTranslation();
 
-  /* Any non-manager user can leave the project, but managers can only leave if they are not the only manager. */
-  const canLeaveProject = isCurrentUser && !(isManager && hasSingleManager);
+  /*
+   * Any non-manager user can leave the project, but managers can only leave if they are not the
+   * only manager.
+   */
+  const userCanLeaveProject =
+    isForCurrentUser && !(isInManagerView && isForSingleManagerProject);
 
   return (
     <Box borderBottomWidth="1" width={275} py={2}>
       <VStack>
-        {!isCurrentUser && isManager ? (
+        {!isForCurrentUser && isInManagerView ? (
           <Pressable onPress={memberAction}>
             <UserInfo
               membership={membership}
               user={user}
-              isCurrentUser={isCurrentUser}
+              isCurrentUser={isForCurrentUser}
             />
           </Pressable>
         ) : (
           <UserInfo
             membership={membership}
             user={user}
-            isCurrentUser={isCurrentUser}
+            isCurrentUser={isForCurrentUser}
           />
         )}
-        {canLeaveProject && (
+        {userCanLeaveProject && (
           <ConfirmModal
             trigger={onOpen => (
               <LeaveProjectTrigger

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
@@ -15,23 +15,13 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Button, Center, Divider, FlatList, Image, Pressable} from 'native-base';
+import {Divider, FlatList} from 'native-base';
 import {User} from 'terraso-client-shared/account/accountSlice';
-import {useTranslation} from 'react-i18next';
-import {useMemo} from 'react';
 import {
   ProjectMembership,
   ProjectRole,
 } from 'terraso-client-shared/project/projectSlice';
-import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
-import {formatName} from 'terraso-mobile-client/util';
-import {
-  Box,
-  HStack,
-  VStack,
-  Badge,
-  Text,
-} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {UserItem} from 'terraso-mobile-client/screens/ProjectTeamScreen/components/UserItem';
 
 type ListProps = {
   memberships: [ProjectMembership, User][];
@@ -40,121 +30,6 @@ type ListProps = {
   memberAction: (userId: string, memberId: string) => () => void;
   currentUserRole: ProjectRole;
 };
-
-type ItemProps = {
-  membership: ProjectMembership;
-  user: User;
-  currentUserId?: string;
-  removeUser: () => void;
-  memberAction: () => void;
-  currentUserRole: ProjectRole;
-};
-
-type TriggerProps = {
-  onOpen: () => void;
-  message: string;
-};
-
-function LeaveProjectTrigger({onOpen, message}: TriggerProps) {
-  return (
-    <Center>
-      <Button
-        size="sm"
-        my={2}
-        w="50%"
-        _text={{color: 'error.main'}}
-        bgColor="grey.200"
-        onPress={onOpen}>
-        {message}
-      </Button>
-    </Center>
-  );
-}
-
-const UserWrapper = ({
-  isCurrentUser,
-  memberAction,
-  currentUserRole,
-  children,
-}: React.PropsWithChildren &
-  Pick<ItemProps, 'memberAction'> & {
-    isCurrentUser: boolean;
-    currentUserRole: ProjectRole;
-  }) =>
-  !isCurrentUser && currentUserRole === 'MANAGER' ? (
-    <Pressable onPress={memberAction}>{children}</Pressable>
-  ) : (
-    <>{children}</>
-  );
-
-function UserItem({
-  membership,
-  user,
-  currentUserId,
-  removeUser,
-  memberAction,
-  currentUserRole,
-}: ItemProps) {
-  const {t} = useTranslation();
-  const isCurrentUser = useMemo(() => {
-    return user.id === currentUserId;
-  }, [user, currentUserId]);
-
-  const userName = useMemo(() => {
-    let name = formatName(user.firstName, user.lastName);
-
-    if (isCurrentUser) {
-      name += ` (${t('general.you')})`;
-    }
-    return name;
-  }, [user, isCurrentUser, t]);
-
-  return (
-    <Box borderBottomWidth="1" width={275} py={2}>
-      <VStack>
-        <UserWrapper
-          currentUserRole={currentUserRole}
-          isCurrentUser={isCurrentUser}
-          memberAction={memberAction}>
-          <HStack space={3} justifyContent="space-between" alignItems="center">
-            <Box>
-              <Image
-                variant="profilePic"
-                source={{uri: user.profileImage}}
-                alt="profile pic"
-              />
-            </Box>
-            <Text flex={3}>{userName}</Text>
-            <Box>
-              <Badge
-                variant="chip"
-                bg="primary.lighter"
-                py="5px"
-                px="10px"
-                _text={{color: 'text.primary'}}>
-                {t('general.role.' + membership.userRole)}
-              </Badge>
-            </Box>
-          </HStack>
-        </UserWrapper>
-        {isCurrentUser && (
-          <ConfirmModal
-            trigger={onOpen => (
-              <LeaveProjectTrigger
-                onOpen={onOpen}
-                message={t('projects.team.leave_project_modal.trigger')}
-              />
-            )}
-            title={t('projects.team.leave_project_modal.title')}
-            body={t('projects.team.leave_project_modal.body')}
-            actionName={t('projects.team.leave_project_modal.action_name')}
-            handleConfirm={removeUser}
-          />
-        )}
-      </VStack>
-    </Box>
-  );
-}
 
 export const UserList = ({
   memberships,

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
@@ -16,6 +16,7 @@
  */
 
 import {Divider, FlatList} from 'native-base';
+import {useMemo} from 'react';
 import {User} from 'terraso-client-shared/account/accountSlice';
 import {
   ProjectMembership,
@@ -38,6 +39,11 @@ export const UserList = ({
   memberAction,
   currentUserRole,
 }: ListProps) => {
+  const hasSingleManager = useMemo(
+    () => memberships.filter(m => m[0].userRole === 'MANAGER').length === 1,
+    [memberships],
+  );
+
   return (
     <FlatList
       data={memberships}
@@ -47,6 +53,7 @@ export const UserList = ({
           user={user}
           isCurrentUser={user.id === currentUserId}
           isManager={currentUserRole === 'MANAGER'}
+          hasSingleManager={hasSingleManager}
           removeUser={removeUser(membership)}
           memberAction={memberAction(user.id, membership.id)}
         />

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
@@ -45,10 +45,10 @@ export const UserList = ({
         <UserItem
           membership={membership}
           user={user}
-          currentUserId={currentUserId}
+          isCurrentUser={user.id === currentUserId}
+          isManager={currentUserRole === 'MANAGER'}
           removeUser={removeUser(membership)}
           memberAction={memberAction(user.id, membership.id)}
-          currentUserRole={currentUserRole}
         />
       )}
       keyExtractor={([membership, _]) => membership.id}

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
@@ -39,7 +39,8 @@ export const UserList = ({
   memberAction,
   currentUserRole,
 }: ListProps) => {
-  const hasSingleManager = useMemo(
+  /* (The number of managers in a project affects whether certain screen controls are available) */
+  const projectHasSingleManager = useMemo(
     () => memberships.filter(m => m[0].userRole === 'MANAGER').length === 1,
     [memberships],
   );
@@ -51,9 +52,9 @@ export const UserList = ({
         <UserItem
           membership={membership}
           user={user}
-          isCurrentUser={user.id === currentUserId}
-          isManager={currentUserRole === 'MANAGER'}
-          hasSingleManager={hasSingleManager}
+          isForCurrentUser={user.id === currentUserId}
+          isInManagerView={currentUserRole === 'MANAGER'}
+          isForSingleManagerProject={projectHasSingleManager}
           removeUser={removeUser(membership)}
           memberAction={memberAction(user.id, membership.id)}
         />

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserList.tsx
@@ -26,14 +26,14 @@ import {UserItem} from 'terraso-mobile-client/screens/ProjectTeamScreen/componen
 type ListProps = {
   memberships: [ProjectMembership, User][];
   currentUserId?: string;
-  userAction: (membership: ProjectMembership) => () => void;
+  removeUser: (membership: ProjectMembership) => () => void;
   memberAction: (userId: string, memberId: string) => () => void;
   currentUserRole: ProjectRole;
 };
 
 export const UserList = ({
   memberships,
-  userAction,
+  removeUser,
   currentUserId,
   memberAction,
   currentUserRole,
@@ -46,7 +46,7 @@ export const UserList = ({
           membership={membership}
           user={user}
           currentUserId={currentUserId}
-          removeUser={userAction(membership)}
+          removeUser={removeUser(membership)}
           memberAction={memberAction(user.id, membership.id)}
           currentUserRole={currentUserRole}
         />

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -285,7 +285,7 @@
     "use": "Use",
     "last_modified_by": "last modified {{user}}, {{date}}",
     "select_all": "Select All",
-    "you": "you",
+    "you_name": "{{name}} (you)",
     "details": "Details",
     "apply": "Apply",
     "example_email": "name@domain.com",


### PR DESCRIPTION
## Description
Hide the "leave project" button on the project team view if the user in question is the only manager for the project. Also refactor the associated components for clarity.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #[496](https://github.com/techmatters/terraso-mobile-client/issues/496)

### Verification steps

Create a project and invite a single collaborator. Observe that the option to leave the project is not available. Change the collaborator's role and observe that the option is now available. Change the role back and observe that the option is no longer available.