### PR TITLE
feat: snapshot integration testing!

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
       - synchronize
 
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out git repository
@@ -34,11 +34,3 @@ jobs:
       - name: Test JavaScript
         working-directory: ./dev-client
         run: npm run test
-
-      - name: Typecheck TypeScript
-        working-directory: ./dev-client
-        run: npm run check-ts
-
-      - name: Check NPM module usage
-        working-directory: ./dev-client
-        run: npm run check-modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          cache: 'npm'
+          cache-dependency-path: |
+            dev-client/package-lock.json
+
+      - name: Install Node dependencies
+        working-directory: ./dev-client
+        run: npm ci
+
+      - name: Test JavaScript
+        working-directory: ./dev-client
+        run: npm run test
+
+      - name: Typecheck TypeScript
+        working-directory: ./dev-client
+        run: npm run check-ts
+
+      - name: Check NPM module usage
+        working-directory: ./dev-client
+        run: npm run check-modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing guide
+
+## Writing tests
+
+Right now, all of our tests are integration tests using [Jest's snapshot testing feature](https://jestjs.io/docs/snapshot-testing).
+They must pass in order to merge a PR.
+
+To run the tests locally, run `npm test`.
+
+If the snapshot tests fail, but the diff looks like what you wanted, run `npm test -- -u` to update them.

--- a/dev-client/__tests__/integration/CreateProjectScreen-test.tsx
+++ b/dev-client/__tests__/integration/CreateProjectScreen-test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {testState} from '@testing/data';
+import {render} from '@testing/utils';
+import {CreateProjectScreen} from 'terraso-mobile-client/screens/CreateProjectScreen/CreateProjectScreen';
+
+test('renders correctly', () => {
+  const screen = render(<CreateProjectScreen />, {
+    route: 'CREATE_PROJECT',
+    initialState: testState,
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/CreateSiteScreen-test.tsx
+++ b/dev-client/__tests__/integration/CreateSiteScreen-test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {render} from '@testing/utils';
+import {CreateSiteScreen} from 'terraso-mobile-client/screens/CreateSiteScreen/CreateSiteScreen';
+
+test('renders correctly', () => {
+  const screen = render(<CreateSiteScreen />, {
+    route: 'CREATE_SITE',
+    initialState: {},
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/LocationDashboardScreen-test.tsx
+++ b/dev-client/__tests__/integration/LocationDashboardScreen-test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {testState} from '@testing/data';
+import {render} from '@testing/utils';
+import {LocationDashboardScreen} from 'terraso-mobile-client/screens/LocationDashboardScreen';
+
+test('renders correctly', () => {
+  const screen = render(<LocationDashboardScreen siteId="1" />, {
+    route: 'LOCATION_DASHBOARD',
+    initialState: testState,
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/LoginScreen-test.tsx
+++ b/dev-client/__tests__/integration/LoginScreen-test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {LoginScreen} from 'terraso-mobile-client/screens/LoginScreen';
+import {render} from '@testing/utils';
+
+test('renders correctly', () => {
+  expect(
+    render(<LoginScreen />, {
+      initialState: {
+        account: {
+          currentUser: {
+            data: null,
+            fetching: false,
+          },
+        } as any,
+      },
+    }).toJSON(),
+  ).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/LoginScreen-test.tsx
+++ b/dev-client/__tests__/integration/LoginScreen-test.tsx
@@ -19,16 +19,16 @@ import {LoginScreen} from 'terraso-mobile-client/screens/LoginScreen';
 import {render} from '@testing/utils';
 
 test('renders correctly', () => {
-  expect(
-    render(<LoginScreen />, {
-      initialState: {
-        account: {
-          currentUser: {
-            data: null,
-            fetching: false,
-          },
-        } as any,
-      },
-    }).toJSON(),
-  ).toMatchSnapshot();
+  const screen = render(<LoginScreen />, {
+    initialState: {
+      account: {
+        currentUser: {
+          data: null,
+          fetching: false,
+        },
+      } as any,
+    },
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
 });

--- a/dev-client/__tests__/integration/ProjectViewScreen-test.tsx
+++ b/dev-client/__tests__/integration/ProjectViewScreen-test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {testState} from '@testing/data';
+import {render} from '@testing/utils';
+import {ProjectViewScreen} from 'terraso-mobile-client/screens/ProjectViewScreen';
+
+test('renders correctly', () => {
+  const screen = render(<ProjectViewScreen projectId="1" />, {
+    route: 'PROJECT_VIEW',
+    initialState: testState,
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/SlopeScreen-test.tsx
+++ b/dev-client/__tests__/integration/SlopeScreen-test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {testState} from '@testing/data';
+import {render} from '@testing/utils';
+import {methodRequired} from 'terraso-client-shared/soilId/soilIdSlice';
+import {collectionMethods} from 'terraso-client-shared/soilId/soilIdTypes';
+import {fromEntries} from 'terraso-client-shared/utils';
+import {SlopeScreen} from 'terraso-mobile-client/screens/SlopeScreen/SlopeScreen';
+
+test('renders correctly', () => {
+  const screen = render(<SlopeScreen siteId="1" />, {
+    route: 'LOCATION_DASHBOARD',
+    initialState: {
+      ...testState,
+      soilId: {
+        status: 'ready',
+        soilData: {
+          '1': {
+            depthIntervalPreset: 'LANDPKS',
+            depthIntervals: [],
+            depthDependentData: [],
+            slopeSteepnessSelect: 'FLAT',
+          },
+        },
+        projectSettings: {
+          '1': {
+            ...fromEntries(
+              collectionMethods.map(method => [methodRequired(method), false]),
+            ),
+            soilPitRequired: false,
+            depthIntervalPreset: 'LANDPKS',
+            depthIntervals: [],
+            slopeRequired: true,
+          },
+        },
+      },
+    },
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/SoilScreen-test.tsx
+++ b/dev-client/__tests__/integration/SoilScreen-test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {testState} from '@testing/data';
+import {render} from '@testing/utils';
+import {SoilScreen} from 'terraso-mobile-client/screens/SoilScreen/SoilScreen';
+
+test('renders correctly', () => {
+  const screen = render(<SoilScreen siteId="1" />, {
+    route: 'LOCATION_DASHBOARD',
+    initialState: testState,
+  }).toJSON();
+
+  expect(screen).toMatchSnapshot();
+});

--- a/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -1,0 +1,1728 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenStack
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          nativeBackButtonDismissalEnabled={false}
+          onAppear={[Function]}
+          onDisappear={[Function]}
+          onDismissed={[Function]}
+          onGestureCancel={[Function]}
+          onHeaderBackButtonClicked={[Function]}
+          onNativeDismissCancelled={[Function]}
+          onTransitionProgress={[Function]}
+          onWillDisappear={[Function]}
+          replaceAnimation="push"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          stackPresentation="push"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          swipeDirection="horizontal"
+        >
+          <View
+            accessibilityElementsHidden={false}
+            importantForAccessibility="auto"
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "column-reverse",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <RNCSafeAreaView
+                edges={
+                  {
+                    "bottom": "additive",
+                    "left": "additive",
+                    "right": "additive",
+                    "top": "additive",
+                  }
+                }
+                style={
+                  [
+                    {
+                      "flex": 1,
+                    },
+                    {
+                      "backgroundColor": "#00582B",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "column",
+                      },
+                      {
+                        "backgroundColor": "#FFFFFF",
+                        "flex": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    onLayout={[Function]}
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "column",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "paddingHorizontal": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "minHeight": 56,
+                              "paddingVertical": 4,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "row",
+                              },
+                              {
+                                "alignItems": "center",
+                                "columnGap": 24,
+                                "flex": 1,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityRole="button"
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": undefined,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            colorScheme="primary"
+                            dataSet={{}}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "borderRadius": 4,
+                                "flexDirection": "row",
+                                "justifyContent": "center",
+                                "paddingBottom": 12,
+                                "paddingLeft": 12,
+                                "paddingRight": 12,
+                                "paddingTop": 12,
+                              }
+                            }
+                          >
+                            <Icon
+                              color="#FFFFFF"
+                              name="close"
+                              size={24}
+                              style={{}}
+                            />
+                          </View>
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#FFFFFF",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                              }
+                            }
+                          >
+                            Create Project
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      dataSet={{}}
+                      onLayout={[Function]}
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <RCTScrollView
+                        contentContainerStyle={
+                          [
+                            {},
+                            {
+                              "dataSet": {},
+                            },
+                            {},
+                          ]
+                        }
+                        dataSet={{}}
+                        style={
+                          {
+                            "backgroundColor": "#FFFFFF",
+                          }
+                        }
+                      >
+                        <View>
+                          <View
+                            style={
+                              {
+                                "marginHorizontal": 20,
+                                "paddingTop": "20%",
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "rowGap": 12,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                dataSet={{}}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Project Name
+                                </Text>
+                              </View>
+                              <View
+                                dataSet={{}}
+                                isFocused={false}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "borderColor": "#d4d4d4",
+                                    "borderRadius": 4,
+                                    "borderWidth": 1,
+                                    "flexDirection": "row",
+                                    "overflow": "hidden",
+                                  }
+                                }
+                              >
+                                <TextInput
+                                  accessible={true}
+                                  autoCorrect={false}
+                                  dataSet={{}}
+                                  defaultValue=""
+                                  editable={true}
+                                  onBlur={[Function]}
+                                  onChangeText={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyPress={[Function]}
+                                  placeholder="Project Name"
+                                  placeholderTextColor="#a3a3a3"
+                                  scrollEnabled={false}
+                                  secureTextEntry={false}
+                                  style={
+                                    {
+                                      "backgroundColor": "#00000000",
+                                      "color": "#171717",
+                                      "flex": 1,
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "height": "100%",
+                                      "paddingBottom": 8,
+                                      "paddingLeft": 12,
+                                      "paddingRight": 12,
+                                      "paddingTop": 8,
+                                      "width": "100%",
+                                    }
+                                  }
+                                />
+                              </View>
+                              <View
+                                dataSet={{}}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Project Description
+                                </Text>
+                              </View>
+                              <View
+                                dataSet={{}}
+                                isFocused={false}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "borderColor": "#d4d4d4",
+                                    "borderRadius": 4,
+                                    "borderWidth": 1,
+                                    "flexDirection": "row",
+                                    "height": 80,
+                                    "overflow": "hidden",
+                                  }
+                                }
+                              >
+                                <TextInput
+                                  accessible={true}
+                                  autoCompleteType="off"
+                                  autoCorrect={false}
+                                  dataSet={{}}
+                                  editable={true}
+                                  multiline={true}
+                                  onBlur={[Function]}
+                                  onChangeText={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyPress={[Function]}
+                                  placeholder="Project Description"
+                                  placeholderTextColor="#a3a3a3"
+                                  secureTextEntry={false}
+                                  style={
+                                    {
+                                      "backgroundColor": "#00000000",
+                                      "color": "#171717",
+                                      "flex": 1,
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "height": "100%",
+                                      "paddingBottom": 8,
+                                      "paddingLeft": 12,
+                                      "paddingRight": 12,
+                                      "paddingTop": 8,
+                                      "width": "100%",
+                                    }
+                                  }
+                                  textAlignVertical="top"
+                                />
+                              </View>
+                              <View
+                                dataSet={{}}
+                                style={
+                                  {
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <View
+                                  dataSet={{}}
+                                  feedbackId="field-1-feedback"
+                                  hasFeedbackText={false}
+                                  hasHelpText={false}
+                                  helpTextId="field-1-helptext"
+                                  isDisabled={false}
+                                  isInvalid={false}
+                                  isReadOnly={false}
+                                  isRequired={false}
+                                  labelId="field-1-label"
+                                  nativeID="field-1-label"
+                                  setHasFeedbackText={[Function]}
+                                  setHasHelpText={[Function]}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "row",
+                                        },
+                                        {
+                                          "alignItems": "center",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      lineHeight="32px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 14,
+                                          "fontWeight": "500",
+                                        }
+                                      }
+                                    >
+                                      Data Privacy
+                                    </Text>
+                                    <View
+                                      accessibilityRole="button"
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      colorScheme="primary"
+                                      dataSet={{}}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 4,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
+                                        }
+                                      }
+                                    >
+                                      <Icon
+                                        color="#1A202C"
+                                        name="info"
+                                        size={24}
+                                        style={{}}
+                                      />
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  aria-disabled={false}
+                                  colorScheme="primary"
+                                  dataSet={{}}
+                                  name="data-privacy"
+                                  onChange={[Function]}
+                                  role="radiogroup"
+                                  style={
+                                    {
+                                      "alignItems": "flex-start",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                  value="PRIVATE"
+                                >
+                                  <View
+                                    accessibilityRole="radio"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": false,
+                                        "disabled": false,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    checked={false}
+                                    collapsable={false}
+                                    dataSet={{}}
+                                    feedbackId="field-1-feedback"
+                                    focusable={true}
+                                    formControlContext={
+                                      {
+                                        "feedbackId": "field-1-feedback",
+                                        "hasFeedbackText": false,
+                                        "hasHelpText": false,
+                                        "helpTextId": "field-1-helptext",
+                                        "isDisabled": false,
+                                        "isInvalid": false,
+                                        "isReadOnly": false,
+                                        "isRequired": false,
+                                        "labelId": "field-1-label",
+                                        "nativeID": "field-1",
+                                        "setHasFeedbackText": [Function],
+                                        "setHasHelpText": [Function],
+                                      }
+                                    }
+                                    hasFeedbackText={false}
+                                    hasHelpText={false}
+                                    helpTextId="field-1-helptext"
+                                    isInvalid={false}
+                                    isReadOnly={false}
+                                    isRequired={false}
+                                    labelId="field-1-label"
+                                    nativeID="field-1"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    role="radio"
+                                    setHasFeedbackText={[Function]}
+                                    setHasHelpText={[Function]}
+                                    state={
+                                      {
+                                        "lastFocusedValue": null,
+                                        "name": "data-privacy",
+                                        "selectedValue": "PRIVATE",
+                                        "setLastFocusedValue": [Function],
+                                        "setSelectedValue": [Function],
+                                      }
+                                    }
+                                    style={{}}
+                                    value="PUBLIC"
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "display": "flex",
+                                            "justifyContent": "center",
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          dataSet={{}}
+                                          style={{}}
+                                        />
+                                        <View
+                                          colorScheme="primary"
+                                          dataSet={{}}
+                                          defaultIsChecked={false}
+                                          feedbackId="field-1-feedback"
+                                          formControlContext={
+                                            {
+                                              "feedbackId": "field-1-feedback",
+                                              "hasFeedbackText": false,
+                                              "hasHelpText": false,
+                                              "helpTextId": "field-1-helptext",
+                                              "isDisabled": false,
+                                              "isInvalid": false,
+                                              "isReadOnly": false,
+                                              "isRequired": false,
+                                              "labelId": "field-1-label",
+                                              "nativeID": "field-1",
+                                              "setHasFeedbackText": [Function],
+                                              "setHasHelpText": [Function],
+                                            }
+                                          }
+                                          hasFeedbackText={false}
+                                          hasHelpText={false}
+                                          helpTextId="field-1-helptext"
+                                          isDisabled={false}
+                                          isInvalid={false}
+                                          isReadOnly={false}
+                                          isRequired={false}
+                                          labelId="field-1-label"
+                                          nativeID="field-1"
+                                          setHasFeedbackText={[Function]}
+                                          setHasHelpText={[Function]}
+                                          state={
+                                            {
+                                              "lastFocusedValue": null,
+                                              "name": "data-privacy",
+                                              "selectedValue": "PRIVATE",
+                                              "setLastFocusedValue": [Function],
+                                              "setSelectedValue": [Function],
+                                            }
+                                          }
+                                          style={
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#fafafa",
+                                              "borderColor": "#a3a3a3",
+                                              "borderRadius": 9999,
+                                              "borderWidth": 2,
+                                              "display": "flex",
+                                              "fontSize": 16,
+                                              "fontWeight": "400",
+                                              "justifyContent": "center",
+                                              "letterSpacing": 0.15,
+                                              "lineHeight": 24,
+                                              "marginBottom": 8,
+                                              "marginLeft": 8,
+                                              "marginRight": 0,
+                                              "marginTop": 8,
+                                              "paddingBottom": 4,
+                                              "paddingLeft": 4,
+                                              "paddingRight": 4,
+                                              "paddingTop": 4,
+                                            }
+                                          }
+                                          value="PUBLIC"
+                                        >
+                                          <RNSVGSvgView
+                                            accessibilityRole="image"
+                                            align="xMidYMid"
+                                            bbHeight={12}
+                                            bbWidth={12}
+                                            dataSet={{}}
+                                            focusable={false}
+                                            meetOrSlice={0}
+                                            minX={0}
+                                            minY={0}
+                                            stroke=""
+                                            style={
+                                              [
+                                                {
+                                                  "backgroundColor": "transparent",
+                                                  "borderWidth": 0,
+                                                },
+                                                {
+                                                  "color": "#737373",
+                                                  "height": 12,
+                                                  "opacity": 0,
+                                                  "width": 12,
+                                                },
+                                                {
+                                                  "flex": 0,
+                                                  "height": 12,
+                                                  "width": 12,
+                                                },
+                                              ]
+                                            }
+                                            tintColor="#737373"
+                                            vbHeight={24}
+                                            vbWidth={24}
+                                          >
+                                            <RNSVGGroup
+                                              fill={
+                                                {
+                                                  "payload": 4278190080,
+                                                  "type": 0,
+                                                }
+                                              }
+                                              opacity={0}
+                                              propList={
+                                                [
+                                                  "stroke",
+                                                ]
+                                              }
+                                              stroke={null}
+                                            >
+                                              <RNSVGGroup
+                                                fill={
+                                                  {
+                                                    "payload": 4278190080,
+                                                    "type": 0,
+                                                  }
+                                                }
+                                              >
+                                                <RNSVGPath
+                                                  d="M0 12C-2.34822e-08 13.5759 0.310389 15.1363 0.913445 16.5922C1.5165 18.0481 2.40042 19.371 3.51472 20.4853C4.62902 21.5996 5.95189 22.4835 7.4078 23.0866C8.86371 23.6896 10.4241 24 12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12C24 10.4241 23.6896 8.86371 23.0866 7.4078C22.4835 5.95189 21.5996 4.62902 20.4853 3.51472C19.371 2.40042 18.0481 1.5165 16.5922 0.913446C15.1363 0.310389 13.5759 0 12 0C10.4241 0 8.86371 0.310389 7.4078 0.913446C5.95189 1.5165 4.62902 2.40042 3.51472 3.51472C2.40042 4.62902 1.5165 5.95189 0.913445 7.4078C0.310389 8.86371 -2.34822e-08 10.4241 0 12Z"
+                                                  fill={
+                                                    {
+                                                      "type": 2,
+                                                    }
+                                                  }
+                                                  propList={
+                                                    [
+                                                      "fill",
+                                                      "stroke",
+                                                    ]
+                                                  }
+                                                  stroke={null}
+                                                />
+                                              </RNSVGGroup>
+                                            </RNSVGGroup>
+                                          </RNSVGSvgView>
+                                        </View>
+                                      </View>
+                                      <View
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "width": 8,
+                                          }
+                                        }
+                                      />
+                                      <Text
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "backgroundColor": undefined,
+                                            "color": "#171717",
+                                            "fontFamily": undefined,
+                                            "fontSize": 16,
+                                            "fontStyle": "normal",
+                                            "fontWeight": "400",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textDecorationLine": undefined,
+                                          }
+                                        }
+                                      >
+                                        Public
+                                      </Text>
+                                    </View>
+                                  </View>
+                                  <View
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "width": 26,
+                                      }
+                                    }
+                                  />
+                                  <View
+                                    accessibilityRole="radio"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": true,
+                                        "disabled": false,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    checked={true}
+                                    collapsable={false}
+                                    dataSet={{}}
+                                    feedbackId="field-1-feedback"
+                                    focusable={true}
+                                    formControlContext={
+                                      {
+                                        "feedbackId": "field-1-feedback",
+                                        "hasFeedbackText": false,
+                                        "hasHelpText": false,
+                                        "helpTextId": "field-1-helptext",
+                                        "isDisabled": false,
+                                        "isInvalid": false,
+                                        "isReadOnly": false,
+                                        "isRequired": false,
+                                        "labelId": "field-1-label",
+                                        "nativeID": "field-1",
+                                        "setHasFeedbackText": [Function],
+                                        "setHasHelpText": [Function],
+                                      }
+                                    }
+                                    hasFeedbackText={false}
+                                    hasHelpText={false}
+                                    helpTextId="field-1-helptext"
+                                    isInvalid={false}
+                                    isReadOnly={false}
+                                    isRequired={false}
+                                    labelId="field-1-label"
+                                    nativeID="field-1"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    role="radio"
+                                    setHasFeedbackText={[Function]}
+                                    setHasHelpText={[Function]}
+                                    state={
+                                      {
+                                        "lastFocusedValue": null,
+                                        "name": "data-privacy",
+                                        "selectedValue": "PRIVATE",
+                                        "setLastFocusedValue": [Function],
+                                        "setSelectedValue": [Function],
+                                      }
+                                    }
+                                    style={{}}
+                                    value="PRIVATE"
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "display": "flex",
+                                            "justifyContent": "center",
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          dataSet={{}}
+                                          style={{}}
+                                        />
+                                        <View
+                                          colorScheme="primary"
+                                          dataSet={{}}
+                                          defaultIsChecked={false}
+                                          feedbackId="field-1-feedback"
+                                          formControlContext={
+                                            {
+                                              "feedbackId": "field-1-feedback",
+                                              "hasFeedbackText": false,
+                                              "hasHelpText": false,
+                                              "helpTextId": "field-1-helptext",
+                                              "isDisabled": false,
+                                              "isInvalid": false,
+                                              "isReadOnly": false,
+                                              "isRequired": false,
+                                              "labelId": "field-1-label",
+                                              "nativeID": "field-1",
+                                              "setHasFeedbackText": [Function],
+                                              "setHasHelpText": [Function],
+                                            }
+                                          }
+                                          hasFeedbackText={false}
+                                          hasHelpText={false}
+                                          helpTextId="field-1-helptext"
+                                          isDisabled={false}
+                                          isInvalid={false}
+                                          isReadOnly={false}
+                                          isRequired={false}
+                                          labelId="field-1-label"
+                                          nativeID="field-1"
+                                          setHasFeedbackText={[Function]}
+                                          setHasHelpText={[Function]}
+                                          state={
+                                            {
+                                              "lastFocusedValue": null,
+                                              "name": "data-privacy",
+                                              "selectedValue": "PRIVATE",
+                                              "setLastFocusedValue": [Function],
+                                              "setSelectedValue": [Function],
+                                            }
+                                          }
+                                          style={
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#fafafa",
+                                              "borderColor": "#028843",
+                                              "borderRadius": 9999,
+                                              "borderWidth": 2,
+                                              "display": "flex",
+                                              "fontSize": 16,
+                                              "fontWeight": "400",
+                                              "justifyContent": "center",
+                                              "letterSpacing": 0.15,
+                                              "lineHeight": 24,
+                                              "marginBottom": 8,
+                                              "marginLeft": 8,
+                                              "marginRight": 0,
+                                              "marginTop": 8,
+                                              "paddingBottom": 4,
+                                              "paddingLeft": 4,
+                                              "paddingRight": 4,
+                                              "paddingTop": 4,
+                                            }
+                                          }
+                                          value="PRIVATE"
+                                        >
+                                          <RNSVGSvgView
+                                            accessibilityRole="image"
+                                            align="xMidYMid"
+                                            bbHeight={12}
+                                            bbWidth={12}
+                                            dataSet={{}}
+                                            focusable={false}
+                                            meetOrSlice={0}
+                                            minX={0}
+                                            minY={0}
+                                            stroke=""
+                                            style={
+                                              [
+                                                {
+                                                  "backgroundColor": "transparent",
+                                                  "borderWidth": 0,
+                                                },
+                                                {
+                                                  "color": "#028843",
+                                                  "height": 12,
+                                                  "opacity": 1,
+                                                  "width": 12,
+                                                },
+                                                {
+                                                  "flex": 0,
+                                                  "height": 12,
+                                                  "width": 12,
+                                                },
+                                              ]
+                                            }
+                                            tintColor="#028843"
+                                            vbHeight={24}
+                                            vbWidth={24}
+                                          >
+                                            <RNSVGGroup
+                                              fill={
+                                                {
+                                                  "payload": 4278190080,
+                                                  "type": 0,
+                                                }
+                                              }
+                                              opacity={1}
+                                              propList={
+                                                [
+                                                  "stroke",
+                                                ]
+                                              }
+                                              stroke={null}
+                                            >
+                                              <RNSVGGroup
+                                                fill={
+                                                  {
+                                                    "payload": 4278190080,
+                                                    "type": 0,
+                                                  }
+                                                }
+                                              >
+                                                <RNSVGPath
+                                                  d="M0 12C-2.34822e-08 13.5759 0.310389 15.1363 0.913445 16.5922C1.5165 18.0481 2.40042 19.371 3.51472 20.4853C4.62902 21.5996 5.95189 22.4835 7.4078 23.0866C8.86371 23.6896 10.4241 24 12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12C24 10.4241 23.6896 8.86371 23.0866 7.4078C22.4835 5.95189 21.5996 4.62902 20.4853 3.51472C19.371 2.40042 18.0481 1.5165 16.5922 0.913446C15.1363 0.310389 13.5759 0 12 0C10.4241 0 8.86371 0.310389 7.4078 0.913446C5.95189 1.5165 4.62902 2.40042 3.51472 3.51472C2.40042 4.62902 1.5165 5.95189 0.913445 7.4078C0.310389 8.86371 -2.34822e-08 10.4241 0 12Z"
+                                                  fill={
+                                                    {
+                                                      "type": 2,
+                                                    }
+                                                  }
+                                                  propList={
+                                                    [
+                                                      "fill",
+                                                      "stroke",
+                                                    ]
+                                                  }
+                                                  stroke={null}
+                                                />
+                                              </RNSVGGroup>
+                                            </RNSVGGroup>
+                                          </RNSVGSvgView>
+                                        </View>
+                                      </View>
+                                      <View
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "width": 8,
+                                          }
+                                        }
+                                      />
+                                      <Text
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "backgroundColor": undefined,
+                                            "color": "#171717",
+                                            "fontFamily": undefined,
+                                            "fontSize": 16,
+                                            "fontStyle": "normal",
+                                            "fontWeight": "400",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textDecorationLine": undefined,
+                                          }
+                                        }
+                                      >
+                                        Private
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                      <View
+                        style={
+                          {
+                            "bottom": 32,
+                            "padding": 12,
+                            "position": "absolute",
+                            "right": 12,
+                          }
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#028843",
+                              "borderRadius": 4,
+                              "elevation": 6,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 8,
+                              "paddingLeft": 22,
+                              "paddingRight": 22,
+                              "paddingTop": 8,
+                              "shadowColor": "#000000",
+                              "shadowOffset": {
+                                "height": 3,
+                                "width": 0,
+                              },
+                              "shadowOpacity": 0.27,
+                              "shadowRadius": 4.65,
+                            }
+                          }
+                        >
+                          <View
+                            dataSet={{}}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                              }
+                            }
+                            test={true}
+                          >
+                            <View
+                              dataSet={{}}
+                              style={{}}
+                            >
+                              <Text
+                                dataSet={{}}
+                                style={
+                                  {
+                                    "backgroundColor": undefined,
+                                    "color": "#fafafa",
+                                    "fontFamily": undefined,
+                                    "fontSize": 15,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "500",
+                                    "letterSpacing": 0.46,
+                                    "lineHeight": 26,
+                                    "textDecorationLine": undefined,
+                                    "textTransform": "uppercase",
+                                  }
+                                }
+                              >
+                                SAVE
+                              </Text>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RNCSafeAreaView>
+              <RCTScrollView>
+                <View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "marginTop": 48,
+                          "paddingBottom": "65%",
+                          "paddingHorizontal": 20,
+                          "paddingTop": 20,
+                          "rowGap": 12,
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      lineHeight="32px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 20,
+                          "fontWeight": "500",
+                          "textAlign": "left",
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      LandPKS Data Privacy
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        The data visible in public sites
+                      </Text>
+                       includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        Public sites
+                      </Text>
+                       are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          style={{}}
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              colorScheme="primary"
+                              dataSet={{}}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "borderRadius": 4,
+                                  "flexDirection": "row",
+                                  "justifyContent": "center",
+                                  "paddingBottom": 0,
+                                  "paddingLeft": 0,
+                                  "paddingRight": 0,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            >
+                              <Icon
+                                color="#028843"
+                                name="open-in-new"
+                                size={24}
+                                style={{}}
+                              />
+                            </View>
+                            <Text
+                              letterSpacing="0.15px"
+                              lineHeight="24px"
+                              style={
+                                {
+                                  "color": "#028843",
+                                  "fontSize": 16,
+                                  "fontWeight": "400",
+                                  "paddingLeft": 4,
+                                  "textTransform": "uppercase",
+                                }
+                              }
+                            >
+                              LandPKS Data Portal
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        Unaffiliated private sites
+                      </Text>
+                       are only visible to you. You can change the privacy of the site at any time.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        A project’s privacy setting determines the privacy of its affiliated sites.
+                      </Text>
+                       Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        When a site is transferred to a project,
+                      </Text>
+                       the project will determine the site’s privacy setting.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      Read more about our data privacy policy:
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          style={{}}
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              colorScheme="primary"
+                              dataSet={{}}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "borderRadius": 4,
+                                  "flexDirection": "row",
+                                  "justifyContent": "center",
+                                  "paddingBottom": 0,
+                                  "paddingLeft": 0,
+                                  "paddingRight": 0,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            >
+                              <Icon
+                                color="#028843"
+                                name="open-in-new"
+                                size={24}
+                                style={{}}
+                              />
+                            </View>
+                            <Text
+                              letterSpacing="0.15px"
+                              lineHeight="24px"
+                              style={
+                                {
+                                  "color": "#028843",
+                                  "fontSize": 16,
+                                  "fontWeight": "400",
+                                  "paddingLeft": 4,
+                                  "textTransform": "uppercase",
+                                }
+                              }
+                            >
+                              LandPKS Privacy Policy
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RCTScrollView>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 23,
+                    "top": 18,
+                  }
+                }
+              >
+                <View
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  colorScheme="primary"
+                  dataSet={{}}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "#EEEEEE",
+                      "borderRadius": 9999,
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "paddingBottom": 4,
+                      "paddingLeft": 4,
+                      "paddingRight": 4,
+                      "paddingTop": 4,
+                    }
+                  }
+                >
+                  <Icon
+                    color="#1A202C"
+                    name="close"
+                    size={24}
+                    style={{}}
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <RNSScreenStackHeaderConfig
+            backButtonInCustomView={false}
+            backTitleVisible={true}
+            backgroundColor="rgb(255, 255, 255)"
+            color="rgb(0, 122, 255)"
+            direction="ltr"
+            disableBackButtonMenu={false}
+            hidden={false}
+            hideBackButton={false}
+            largeTitleHideShadow={false}
+            title="CREATE_PROJECT"
+            titleColor="rgb(28, 28, 30)"
+            topInsetEnabled={false}
+            translucent={false}
+          />
+        </RNSScreen>
+      </RNSScreenStack>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -1,0 +1,2421 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenStack
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          nativeBackButtonDismissalEnabled={false}
+          onAppear={[Function]}
+          onDisappear={[Function]}
+          onDismissed={[Function]}
+          onGestureCancel={[Function]}
+          onHeaderBackButtonClicked={[Function]}
+          onNativeDismissCancelled={[Function]}
+          onTransitionProgress={[Function]}
+          onWillDisappear={[Function]}
+          replaceAnimation="push"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          stackPresentation="push"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          swipeDirection="horizontal"
+        >
+          <View
+            accessibilityElementsHidden={false}
+            importantForAccessibility="auto"
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "column-reverse",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <RNCSafeAreaView
+                edges={
+                  {
+                    "bottom": "additive",
+                    "left": "additive",
+                    "right": "additive",
+                    "top": "additive",
+                  }
+                }
+                style={
+                  [
+                    {
+                      "flex": 1,
+                    },
+                    {
+                      "backgroundColor": "#00582B",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "column",
+                      },
+                      {
+                        "backgroundColor": "#FFFFFF",
+                        "flex": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    onLayout={[Function]}
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "column",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "paddingHorizontal": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "minHeight": 56,
+                              "paddingVertical": 4,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "row",
+                              },
+                              {
+                                "alignItems": "center",
+                                "columnGap": 24,
+                                "flex": 1,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityRole="button"
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": undefined,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            colorScheme="primary"
+                            dataSet={{}}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "borderRadius": 4,
+                                "flexDirection": "row",
+                                "justifyContent": "center",
+                                "paddingBottom": 12,
+                                "paddingLeft": 12,
+                                "paddingRight": 12,
+                                "paddingTop": 12,
+                              }
+                            }
+                          >
+                            <Icon
+                              color="#FFFFFF"
+                              name="close"
+                              size={24}
+                              style={{}}
+                            />
+                          </View>
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#FFFFFF",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                              }
+                            }
+                          >
+                            Create Site
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      dataSet={{}}
+                      onLayout={[Function]}
+                      style={
+                        [
+                          {
+                            "flex": 1,
+                          },
+                          {
+                            "paddingBottom": 0,
+                          },
+                        ]
+                      }
+                    >
+                      <RCTScrollView
+                        contentContainerStyle={
+                          [
+                            {},
+                            {
+                              "dataSet": {},
+                            },
+                            {},
+                          ]
+                        }
+                        dataSet={{}}
+                        style={{}}
+                      >
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                  "paddingTop": 30,
+                                  "rowGap": 18,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              dataSet={{}}
+                              style={
+                                {
+                                  "width": "100%",
+                                }
+                              }
+                            >
+                              <View
+                                dataSet={{}}
+                                feedbackId="field-1-feedback"
+                                hasFeedbackText={false}
+                                hasHelpText={false}
+                                helpTextId="field-1-helptext"
+                                isDisabled={false}
+                                isInvalid={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                labelId="field-1-label"
+                                nativeID="field-1-label"
+                                setHasFeedbackText={[Function]}
+                                setHasHelpText={[Function]}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Site Name
+                                </Text>
+                              </View>
+                              <View
+                                dataSet={{}}
+                                isFocused={false}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "borderColor": "#d4d4d4",
+                                    "borderRadius": 4,
+                                    "borderWidth": 1,
+                                    "flexDirection": "row",
+                                    "overflow": "hidden",
+                                  }
+                                }
+                              >
+                                <TextInput
+                                  accessible={true}
+                                  dataSet={{}}
+                                  disabled={false}
+                                  editable={true}
+                                  isRequired={false}
+                                  nativeID="field-1-input"
+                                  onBlur={[Function]}
+                                  onChangeText={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyPress={[Function]}
+                                  placeholder="Site name"
+                                  placeholderTextColor="#a3a3a3"
+                                  readOnly={false}
+                                  required={false}
+                                  secureTextEntry={false}
+                                  style={
+                                    {
+                                      "backgroundColor": "#00000000",
+                                      "color": "#171717",
+                                      "flex": 1,
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "height": "100%",
+                                      "paddingBottom": 8,
+                                      "paddingLeft": 12,
+                                      "paddingRight": 12,
+                                      "paddingTop": 8,
+                                      "width": "100%",
+                                    }
+                                  }
+                                  value=""
+                                />
+                              </View>
+                            </View>
+                            <View
+                              dataSet={{}}
+                              style={
+                                {
+                                  "width": "100%",
+                                }
+                              }
+                            >
+                              <View
+                                dataSet={{}}
+                                feedbackId="field-2-feedback"
+                                hasFeedbackText={false}
+                                hasHelpText={false}
+                                helpTextId="field-2-helptext"
+                                isDisabled={false}
+                                isInvalid={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                labelId="field-2-label"
+                                nativeID="field-2-label"
+                                setHasFeedbackText={[Function]}
+                                setHasHelpText={[Function]}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Site Location
+                                </Text>
+                              </View>
+                              <Text
+                                letterSpacing="0.15px"
+                                lineHeight="24px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 16,
+                                    "fontWeight": "400",
+                                  }
+                                }
+                              >
+                                GPS accuracy: m
+                              </Text>
+                              <View
+                                dataSet={{}}
+                                isFocused={false}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "borderColor": "#d4d4d4",
+                                    "borderRadius": 4,
+                                    "borderWidth": 1,
+                                    "flexDirection": "row",
+                                    "overflow": "hidden",
+                                  }
+                                }
+                              >
+                                <TextInput
+                                  accessible={true}
+                                  dataSet={{}}
+                                  disabled={false}
+                                  editable={true}
+                                  isRequired={false}
+                                  keyboardType="decimal-pad"
+                                  nativeID="field-2-input"
+                                  onBlur={[Function]}
+                                  onChangeText={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyPress={[Function]}
+                                  placeholderTextColor="#a3a3a3"
+                                  readOnly={false}
+                                  required={false}
+                                  secureTextEntry={false}
+                                  style={
+                                    {
+                                      "backgroundColor": "#00000000",
+                                      "color": "#171717",
+                                      "flex": 1,
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "height": "100%",
+                                      "paddingBottom": 8,
+                                      "paddingLeft": 12,
+                                      "paddingRight": 12,
+                                      "paddingTop": 8,
+                                      "width": "100%",
+                                    }
+                                  }
+                                  value=""
+                                />
+                              </View>
+                              <View
+                                dataSet={{}}
+                                feedbackId="field-2-feedback"
+                                hasFeedbackText={false}
+                                hasHelpText={false}
+                                helpTextId="field-2-helptext"
+                                isDisabled={false}
+                                isInvalid={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                labelId="field-2-label"
+                                nativeID="field-2-label"
+                                setHasFeedbackText={[Function]}
+                                setHasHelpText={[Function]}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#33474F",
+                                      "fontFamily": undefined,
+                                      "fontSize": 12,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 12,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Latitude, Longitude
+                                </Text>
+                              </View>
+                            </View>
+                            <View
+                              dataSet={{}}
+                              style={
+                                {
+                                  "width": "100%",
+                                }
+                              }
+                            >
+                              <View
+                                dataSet={{}}
+                                feedbackId="field-3-feedback"
+                                hasFeedbackText={false}
+                                hasHelpText={false}
+                                helpTextId="field-3-helptext"
+                                isDisabled={false}
+                                isInvalid={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                labelId="field-3-label"
+                                nativeID="field-3-label"
+                                setHasFeedbackText={[Function]}
+                                setHasHelpText={[Function]}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Add to Project
+                                </Text>
+                                <View
+                                  dataSet={{}}
+                                  style={{}}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": 6,
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#1A202CB2"
+                                      name="help"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "#0000000F",
+                                          "borderTopLeftRadius": 4,
+                                          "borderTopRightRadius": 4,
+                                        },
+                                        {},
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      collapsable={false}
+                                      style={
+                                        {
+                                          "backgroundColor": "#0000006B",
+                                          "bottom": 0,
+                                          "height": 1,
+                                          "left": 0,
+                                          "position": "absolute",
+                                          "right": 0,
+                                          "transform": [
+                                            {
+                                              "scaleY": 0.5,
+                                            },
+                                          ],
+                                          "zIndex": 1,
+                                        }
+                                      }
+                                      testID="text-input-underline"
+                                    />
+                                    <View
+                                      onLayout={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "paddingBottom": 0,
+                                            "paddingTop": 0,
+                                          },
+                                          {
+                                            "minHeight": 56,
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <TextInput
+                                        cursorColor="rgba(103, 80, 164, 1)"
+                                        editable={false}
+                                        maxFontSizeMultiplier={1.5}
+                                        multiline={false}
+                                        onBlur={[Function]}
+                                        onChangeText={[Function]}
+                                        onFocus={[Function]}
+                                        placeholderTextColor="rgba(73, 69, 79, 1)"
+                                        selectionColor="rgba(103, 80, 164, 1)"
+                                        style={
+                                          [
+                                            {
+                                              "margin": 0,
+                                            },
+                                            {
+                                              "height": 56,
+                                            },
+                                            {
+                                              "paddingBottom": 0,
+                                              "paddingTop": 0,
+                                            },
+                                            {
+                                              "color": "rgba(28, 27, 31, 1)",
+                                              "fontFamily": "System",
+                                              "fontSize": 16,
+                                              "fontWeight": undefined,
+                                              "letterSpacing": 0.15,
+                                              "lineHeight": undefined,
+                                              "minWidth": 65,
+                                              "paddingLeft": 16,
+                                              "paddingRight": 56,
+                                              "textAlign": "left",
+                                              "textAlignVertical": "center",
+                                            },
+                                            false,
+                                            {
+                                              "marginRight": 40,
+                                              "paddingRight": 16,
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                        testID="text-input-flat"
+                                        underlineColorAndroid="transparent"
+                                        value=""
+                                      />
+                                    </View>
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "height": 24,
+                                            "justifyContent": "center",
+                                            "position": "absolute",
+                                            "width": 24,
+                                          },
+                                          {
+                                            "right": 16,
+                                            "top": 16,
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "backgroundColor": "transparent",
+                                            "borderRadius": 20,
+                                            "height": 40,
+                                            "margin": 0,
+                                            "shadowColor": "#000",
+                                            "shadowOffset": {
+                                              "height": 0,
+                                              "width": 0,
+                                            },
+                                            "shadowOpacity": 0,
+                                            "shadowRadius": 0,
+                                            "width": 40,
+                                          }
+                                        }
+                                        testID="right-icon-adornment-container-outer-layer"
+                                      >
+                                        <View
+                                          collapsable={false}
+                                          style={
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderColor": "rgba(28, 27, 31, 0.12)",
+                                              "borderRadius": 20,
+                                              "borderWidth": 0,
+                                              "elevation": 0,
+                                              "flex": 1,
+                                              "overflow": "hidden",
+                                              "shadowColor": "#000",
+                                              "shadowOffset": {
+                                                "height": 0,
+                                                "width": 0,
+                                              },
+                                              "shadowOpacity": 0,
+                                              "shadowRadius": 0,
+                                            }
+                                          }
+                                          testID="right-icon-adornment-container"
+                                        >
+                                          <View
+                                            accessibilityComponentType="button"
+                                            accessibilityRole="button"
+                                            accessibilityState={
+                                              {
+                                                "busy": undefined,
+                                                "checked": undefined,
+                                                "disabled": true,
+                                                "expanded": undefined,
+                                                "selected": undefined,
+                                              }
+                                            }
+                                            accessibilityTraits={
+                                              [
+                                                "button",
+                                                "disabled",
+                                              ]
+                                            }
+                                            accessibilityValue={
+                                              {
+                                                "max": undefined,
+                                                "min": undefined,
+                                                "now": undefined,
+                                                "text": undefined,
+                                              }
+                                            }
+                                            accessible={true}
+                                            centered={true}
+                                            collapsable={false}
+                                            focusable={true}
+                                            hitSlop={
+                                              {
+                                                "bottom": 6,
+                                                "left": 6,
+                                                "right": 6,
+                                                "top": 6,
+                                              }
+                                            }
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onResponderGrant={[Function]}
+                                            onResponderMove={[Function]}
+                                            onResponderRelease={[Function]}
+                                            onResponderTerminate={[Function]}
+                                            onResponderTerminationRequest={[Function]}
+                                            onStartShouldSetResponder={[Function]}
+                                            style={
+                                              [
+                                                {
+                                                  "overflow": "hidden",
+                                                },
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "flexGrow": 1,
+                                                    "justifyContent": "center",
+                                                  },
+                                                  {
+                                                    "borderRadius": 20,
+                                                  },
+                                                ],
+                                              ]
+                                            }
+                                            testID="right-icon-adornment"
+                                          >
+                                            <Icon
+                                              color="#1A202C"
+                                              name="arrow-drop-down"
+                                              size={24}
+                                              style={{}}
+                                            />
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <RCTScrollView
+                                ListHeaderComponent={
+                                  <Memo(Pressable)
+                                    onPress={[Function]}
+                                  >
+                                    <Row
+                                      alignItems="center"
+                                      backgroundColor="primary.main"
+                                      justifyContent="flex-end"
+                                      padding="md"
+                                    >
+                                      <Text
+                                        color="primary.contrast"
+                                        textTransform="uppercase"
+                                        variant="body1-strong"
+                                      >
+                                        Done
+                                      </Text>
+                                    </Row>
+                                  </Memo(Pressable)>
+                                }
+                                data={
+                                  [
+                                    null,
+                                  ]
+                                }
+                                getItem={[Function]}
+                                getItemCount={[Function]}
+                                keyExtractor={[Function]}
+                                onContentSizeChange={[Function]}
+                                onLayout={[Function]}
+                                onMomentumScrollBegin={[Function]}
+                                onMomentumScrollEnd={[Function]}
+                                onScroll={[Function]}
+                                onScrollBeginDrag={[Function]}
+                                onScrollEndDrag={[Function]}
+                                removeClippedSubviews={false}
+                                renderItem={[Function]}
+                                scrollEventThrottle={0.0001}
+                                stickyHeaderIndices={[]}
+                                viewabilityConfigCallbackPairs={[]}
+                              >
+                                <View>
+                                  <View
+                                    collapsable={false}
+                                    onLayout={[Function]}
+                                  >
+                                    <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "flexDirection": "row",
+                                            },
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#028843",
+                                              "justifyContent": "flex-end",
+                                              "padding": 16,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <Text
+                                          lineHeight="24px"
+                                          style={
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontSize": 16,
+                                              "fontWeight": "700",
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Done
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <View
+                                    onFocusCapture={[Function]}
+                                    onLayout={[Function]}
+                                    style={null}
+                                  >
+                                    <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": true,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "flexDirection": "row",
+                                            },
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#0000000F",
+                                              "justifyContent": "flex-start",
+                                              "paddingHorizontal": 8,
+                                              "paddingVertical": 8,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <Icon
+                                          color="#1A202C"
+                                          name="check"
+                                          size={20}
+                                          style={{}}
+                                        />
+                                        <View
+                                          style={
+                                            {
+                                              "width": 8,
+                                            }
+                                          }
+                                        />
+                                        <Text
+                                          letterSpacing="0.15px"
+                                          lineHeight="24px"
+                                          style={
+                                            {
+                                              "color": "#1A202C",
+                                              "fontSize": 16,
+                                              "fontWeight": "400",
+                                            }
+                                          }
+                                        >
+                                          None
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </RCTScrollView>
+                            </View>
+                            <View
+                              dataSet={{}}
+                              style={
+                                {
+                                  "width": "100%",
+                                }
+                              }
+                            >
+                              <View
+                                dataSet={{}}
+                                feedbackId="field-5-feedback"
+                                hasFeedbackText={false}
+                                hasHelpText={false}
+                                helpTextId="field-5-helptext"
+                                isDisabled={false}
+                                isInvalid={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                labelId="field-5-label"
+                                nativeID="field-5-label"
+                                setHasFeedbackText={[Function]}
+                                setHasHelpText={[Function]}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+                                  Data Privacy
+                                </Text>
+                                <View
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  colorScheme="primary"
+                                  dataSet={{}}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "borderRadius": 4,
+                                      "flexDirection": "row",
+                                      "justifyContent": "center",
+                                      "paddingBottom": 0,
+                                      "paddingLeft": 8,
+                                      "paddingRight": 12,
+                                      "paddingTop": 0,
+                                    }
+                                  }
+                                >
+                                  <Icon
+                                    color="#1A202CB2"
+                                    name="info"
+                                    size={24}
+                                    style={{}}
+                                  />
+                                </View>
+                              </View>
+                              <View
+                                aria-disabled={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                name="privacy"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                role="radiogroup"
+                                style={
+                                  {
+                                    "alignItems": "flex-start",
+                                    "flexDirection": "row",
+                                  }
+                                }
+                                value="PUBLIC"
+                              >
+                                <View
+                                  accessibilityRole="radio"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": true,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  checked={true}
+                                  collapsable={false}
+                                  dataSet={{}}
+                                  feedbackId="field-5-feedback"
+                                  focusable={true}
+                                  formControlContext={
+                                    {
+                                      "feedbackId": "field-5-feedback",
+                                      "hasFeedbackText": false,
+                                      "hasHelpText": false,
+                                      "helpTextId": "field-5-helptext",
+                                      "isDisabled": false,
+                                      "isInvalid": false,
+                                      "isReadOnly": false,
+                                      "isRequired": false,
+                                      "labelId": "field-5-label",
+                                      "nativeID": "field-5",
+                                      "setHasFeedbackText": [Function],
+                                      "setHasHelpText": [Function],
+                                    }
+                                  }
+                                  hasFeedbackText={false}
+                                  hasHelpText={false}
+                                  helpTextId="field-5-helptext"
+                                  isInvalid={false}
+                                  isReadOnly={false}
+                                  isRequired={false}
+                                  labelId="field-5-label"
+                                  nativeID="field-5"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  role="radio"
+                                  setHasFeedbackText={[Function]}
+                                  setHasHelpText={[Function]}
+                                  state={
+                                    {
+                                      "lastFocusedValue": null,
+                                      "name": "privacy",
+                                      "selectedValue": "PUBLIC",
+                                      "setLastFocusedValue": [Function],
+                                      "setSelectedValue": [Function],
+                                    }
+                                  }
+                                  style={{}}
+                                  value="PUBLIC"
+                                >
+                                  <View
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "flexDirection": "row",
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "display": "flex",
+                                          "justifyContent": "center",
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      />
+                                      <View
+                                        colorScheme="primary"
+                                        dataSet={{}}
+                                        defaultIsChecked={false}
+                                        feedbackId="field-5-feedback"
+                                        formControlContext={
+                                          {
+                                            "feedbackId": "field-5-feedback",
+                                            "hasFeedbackText": false,
+                                            "hasHelpText": false,
+                                            "helpTextId": "field-5-helptext",
+                                            "isDisabled": false,
+                                            "isInvalid": false,
+                                            "isReadOnly": false,
+                                            "isRequired": false,
+                                            "labelId": "field-5-label",
+                                            "nativeID": "field-5",
+                                            "setHasFeedbackText": [Function],
+                                            "setHasHelpText": [Function],
+                                          }
+                                        }
+                                        hasFeedbackText={false}
+                                        hasHelpText={false}
+                                        helpTextId="field-5-helptext"
+                                        isDisabled={false}
+                                        isInvalid={false}
+                                        isReadOnly={false}
+                                        isRequired={false}
+                                        labelId="field-5-label"
+                                        nativeID="field-5"
+                                        setHasFeedbackText={[Function]}
+                                        setHasHelpText={[Function]}
+                                        state={
+                                          {
+                                            "lastFocusedValue": null,
+                                            "name": "privacy",
+                                            "selectedValue": "PUBLIC",
+                                            "setLastFocusedValue": [Function],
+                                            "setSelectedValue": [Function],
+                                          }
+                                        }
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#fafafa",
+                                            "borderColor": "#028843",
+                                            "borderRadius": 9999,
+                                            "borderWidth": 2,
+                                            "display": "flex",
+                                            "fontSize": 16,
+                                            "fontWeight": "400",
+                                            "justifyContent": "center",
+                                            "letterSpacing": 0.15,
+                                            "lineHeight": 24,
+                                            "marginBottom": 8,
+                                            "marginLeft": 8,
+                                            "marginRight": 0,
+                                            "marginTop": 8,
+                                            "paddingBottom": 4,
+                                            "paddingLeft": 4,
+                                            "paddingRight": 4,
+                                            "paddingTop": 4,
+                                          }
+                                        }
+                                        value="PUBLIC"
+                                      >
+                                        <RNSVGSvgView
+                                          accessibilityRole="image"
+                                          align="xMidYMid"
+                                          bbHeight={12}
+                                          bbWidth={12}
+                                          dataSet={{}}
+                                          focusable={false}
+                                          meetOrSlice={0}
+                                          minX={0}
+                                          minY={0}
+                                          stroke=""
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "borderWidth": 0,
+                                              },
+                                              {
+                                                "color": "#028843",
+                                                "height": 12,
+                                                "opacity": 1,
+                                                "width": 12,
+                                              },
+                                              {
+                                                "flex": 0,
+                                                "height": 12,
+                                                "width": 12,
+                                              },
+                                            ]
+                                          }
+                                          tintColor="#028843"
+                                          vbHeight={24}
+                                          vbWidth={24}
+                                        >
+                                          <RNSVGGroup
+                                            fill={
+                                              {
+                                                "payload": 4278190080,
+                                                "type": 0,
+                                              }
+                                            }
+                                            opacity={1}
+                                            propList={
+                                              [
+                                                "stroke",
+                                              ]
+                                            }
+                                            stroke={null}
+                                          >
+                                            <RNSVGGroup
+                                              fill={
+                                                {
+                                                  "payload": 4278190080,
+                                                  "type": 0,
+                                                }
+                                              }
+                                            >
+                                              <RNSVGPath
+                                                d="M0 12C-2.34822e-08 13.5759 0.310389 15.1363 0.913445 16.5922C1.5165 18.0481 2.40042 19.371 3.51472 20.4853C4.62902 21.5996 5.95189 22.4835 7.4078 23.0866C8.86371 23.6896 10.4241 24 12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12C24 10.4241 23.6896 8.86371 23.0866 7.4078C22.4835 5.95189 21.5996 4.62902 20.4853 3.51472C19.371 2.40042 18.0481 1.5165 16.5922 0.913446C15.1363 0.310389 13.5759 0 12 0C10.4241 0 8.86371 0.310389 7.4078 0.913446C5.95189 1.5165 4.62902 2.40042 3.51472 3.51472C2.40042 4.62902 1.5165 5.95189 0.913445 7.4078C0.310389 8.86371 -2.34822e-08 10.4241 0 12Z"
+                                                fill={
+                                                  {
+                                                    "type": 2,
+                                                  }
+                                                }
+                                                propList={
+                                                  [
+                                                    "fill",
+                                                    "stroke",
+                                                  ]
+                                                }
+                                                stroke={null}
+                                              />
+                                            </RNSVGGroup>
+                                          </RNSVGGroup>
+                                        </RNSVGSvgView>
+                                      </View>
+                                    </View>
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "width": 8,
+                                        }
+                                      }
+                                    />
+                                    <Text
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "backgroundColor": undefined,
+                                          "color": "#171717",
+                                          "fontFamily": undefined,
+                                          "fontSize": 16,
+                                          "fontStyle": "normal",
+                                          "fontWeight": "400",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textDecorationLine": undefined,
+                                        }
+                                      }
+                                    >
+                                      Public
+                                    </Text>
+                                  </View>
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "width": 26,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityRole="radio"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": false,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  checked={false}
+                                  collapsable={false}
+                                  dataSet={{}}
+                                  feedbackId="field-5-feedback"
+                                  focusable={true}
+                                  formControlContext={
+                                    {
+                                      "feedbackId": "field-5-feedback",
+                                      "hasFeedbackText": false,
+                                      "hasHelpText": false,
+                                      "helpTextId": "field-5-helptext",
+                                      "isDisabled": false,
+                                      "isInvalid": false,
+                                      "isReadOnly": false,
+                                      "isRequired": false,
+                                      "labelId": "field-5-label",
+                                      "nativeID": "field-5",
+                                      "setHasFeedbackText": [Function],
+                                      "setHasHelpText": [Function],
+                                    }
+                                  }
+                                  hasFeedbackText={false}
+                                  hasHelpText={false}
+                                  helpTextId="field-5-helptext"
+                                  isInvalid={false}
+                                  isReadOnly={false}
+                                  isRequired={false}
+                                  labelId="field-5-label"
+                                  nativeID="field-5"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  role="radio"
+                                  setHasFeedbackText={[Function]}
+                                  setHasHelpText={[Function]}
+                                  state={
+                                    {
+                                      "lastFocusedValue": null,
+                                      "name": "privacy",
+                                      "selectedValue": "PUBLIC",
+                                      "setLastFocusedValue": [Function],
+                                      "setSelectedValue": [Function],
+                                    }
+                                  }
+                                  style={{}}
+                                  value="PRIVATE"
+                                >
+                                  <View
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "flexDirection": "row",
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "display": "flex",
+                                          "justifyContent": "center",
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      />
+                                      <View
+                                        colorScheme="primary"
+                                        dataSet={{}}
+                                        defaultIsChecked={false}
+                                        feedbackId="field-5-feedback"
+                                        formControlContext={
+                                          {
+                                            "feedbackId": "field-5-feedback",
+                                            "hasFeedbackText": false,
+                                            "hasHelpText": false,
+                                            "helpTextId": "field-5-helptext",
+                                            "isDisabled": false,
+                                            "isInvalid": false,
+                                            "isReadOnly": false,
+                                            "isRequired": false,
+                                            "labelId": "field-5-label",
+                                            "nativeID": "field-5",
+                                            "setHasFeedbackText": [Function],
+                                            "setHasHelpText": [Function],
+                                          }
+                                        }
+                                        hasFeedbackText={false}
+                                        hasHelpText={false}
+                                        helpTextId="field-5-helptext"
+                                        isDisabled={false}
+                                        isInvalid={false}
+                                        isReadOnly={false}
+                                        isRequired={false}
+                                        labelId="field-5-label"
+                                        nativeID="field-5"
+                                        setHasFeedbackText={[Function]}
+                                        setHasHelpText={[Function]}
+                                        state={
+                                          {
+                                            "lastFocusedValue": null,
+                                            "name": "privacy",
+                                            "selectedValue": "PUBLIC",
+                                            "setLastFocusedValue": [Function],
+                                            "setSelectedValue": [Function],
+                                          }
+                                        }
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#fafafa",
+                                            "borderColor": "#a3a3a3",
+                                            "borderRadius": 9999,
+                                            "borderWidth": 2,
+                                            "display": "flex",
+                                            "fontSize": 16,
+                                            "fontWeight": "400",
+                                            "justifyContent": "center",
+                                            "letterSpacing": 0.15,
+                                            "lineHeight": 24,
+                                            "marginBottom": 8,
+                                            "marginLeft": 8,
+                                            "marginRight": 0,
+                                            "marginTop": 8,
+                                            "paddingBottom": 4,
+                                            "paddingLeft": 4,
+                                            "paddingRight": 4,
+                                            "paddingTop": 4,
+                                          }
+                                        }
+                                        value="PRIVATE"
+                                      >
+                                        <RNSVGSvgView
+                                          accessibilityRole="image"
+                                          align="xMidYMid"
+                                          bbHeight={12}
+                                          bbWidth={12}
+                                          dataSet={{}}
+                                          focusable={false}
+                                          meetOrSlice={0}
+                                          minX={0}
+                                          minY={0}
+                                          stroke=""
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "borderWidth": 0,
+                                              },
+                                              {
+                                                "color": "#737373",
+                                                "height": 12,
+                                                "opacity": 0,
+                                                "width": 12,
+                                              },
+                                              {
+                                                "flex": 0,
+                                                "height": 12,
+                                                "width": 12,
+                                              },
+                                            ]
+                                          }
+                                          tintColor="#737373"
+                                          vbHeight={24}
+                                          vbWidth={24}
+                                        >
+                                          <RNSVGGroup
+                                            fill={
+                                              {
+                                                "payload": 4278190080,
+                                                "type": 0,
+                                              }
+                                            }
+                                            opacity={0}
+                                            propList={
+                                              [
+                                                "stroke",
+                                              ]
+                                            }
+                                            stroke={null}
+                                          >
+                                            <RNSVGGroup
+                                              fill={
+                                                {
+                                                  "payload": 4278190080,
+                                                  "type": 0,
+                                                }
+                                              }
+                                            >
+                                              <RNSVGPath
+                                                d="M0 12C-2.34822e-08 13.5759 0.310389 15.1363 0.913445 16.5922C1.5165 18.0481 2.40042 19.371 3.51472 20.4853C4.62902 21.5996 5.95189 22.4835 7.4078 23.0866C8.86371 23.6896 10.4241 24 12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12C24 10.4241 23.6896 8.86371 23.0866 7.4078C22.4835 5.95189 21.5996 4.62902 20.4853 3.51472C19.371 2.40042 18.0481 1.5165 16.5922 0.913446C15.1363 0.310389 13.5759 0 12 0C10.4241 0 8.86371 0.310389 7.4078 0.913446C5.95189 1.5165 4.62902 2.40042 3.51472 3.51472C2.40042 4.62902 1.5165 5.95189 0.913445 7.4078C0.310389 8.86371 -2.34822e-08 10.4241 0 12Z"
+                                                fill={
+                                                  {
+                                                    "type": 2,
+                                                  }
+                                                }
+                                                propList={
+                                                  [
+                                                    "fill",
+                                                    "stroke",
+                                                  ]
+                                                }
+                                                stroke={null}
+                                              />
+                                            </RNSVGGroup>
+                                          </RNSVGGroup>
+                                        </RNSVGSvgView>
+                                      </View>
+                                    </View>
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "width": 8,
+                                        }
+                                      }
+                                    />
+                                    <Text
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "backgroundColor": undefined,
+                                          "color": "#171717",
+                                          "fontFamily": undefined,
+                                          "fontSize": 16,
+                                          "fontStyle": "normal",
+                                          "fontWeight": "400",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textDecorationLine": undefined,
+                                        }
+                                      }
+                                    >
+                                      Private
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              dataSet={{}}
+                              style={
+                                {
+                                  "flexGrow": 1,
+                                }
+                              }
+                            />
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                      <View
+                        style={
+                          {
+                            "bottom": 40,
+                            "padding": 12,
+                            "position": "absolute",
+                            "right": 12,
+                          }
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#028843",
+                              "borderRadius": 4,
+                              "elevation": 6,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 8,
+                              "paddingLeft": 22,
+                              "paddingRight": 22,
+                              "paddingTop": 8,
+                              "shadowColor": "#000000",
+                              "shadowOffset": {
+                                "height": 3,
+                                "width": 0,
+                              },
+                              "shadowOpacity": 0.27,
+                              "shadowRadius": 4.65,
+                            }
+                          }
+                        >
+                          <View
+                            dataSet={{}}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                              }
+                            }
+                            test={true}
+                          >
+                            <View
+                              dataSet={{}}
+                              style={{}}
+                            >
+                              <Text
+                                dataSet={{}}
+                                style={
+                                  {
+                                    "backgroundColor": undefined,
+                                    "color": "#fafafa",
+                                    "fontFamily": undefined,
+                                    "fontSize": 15,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "500",
+                                    "letterSpacing": 0.46,
+                                    "lineHeight": 26,
+                                    "textDecorationLine": undefined,
+                                    "textTransform": "uppercase",
+                                  }
+                                }
+                              >
+                                SAVE
+                              </Text>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RNCSafeAreaView>
+              <RCTScrollView>
+                <View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "marginTop": 48,
+                          "paddingBottom": "65%",
+                          "paddingHorizontal": 20,
+                          "paddingTop": 20,
+                          "rowGap": 12,
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      lineHeight="32px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 20,
+                          "fontWeight": "500",
+                          "textAlign": "left",
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      LandPKS Data Privacy
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        The data visible in public sites
+                      </Text>
+                       includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        Public sites
+                      </Text>
+                       are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          style={{}}
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              colorScheme="primary"
+                              dataSet={{}}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "borderRadius": 4,
+                                  "flexDirection": "row",
+                                  "justifyContent": "center",
+                                  "paddingBottom": 0,
+                                  "paddingLeft": 0,
+                                  "paddingRight": 0,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            >
+                              <Icon
+                                color="#028843"
+                                name="open-in-new"
+                                size={24}
+                                style={{}}
+                              />
+                            </View>
+                            <Text
+                              letterSpacing="0.15px"
+                              lineHeight="24px"
+                              style={
+                                {
+                                  "color": "#028843",
+                                  "fontSize": 16,
+                                  "fontWeight": "400",
+                                  "paddingLeft": 4,
+                                  "textTransform": "uppercase",
+                                }
+                              }
+                            >
+                              LandPKS Data Portal
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        Unaffiliated private sites
+                      </Text>
+                       are only visible to you. You can change the privacy of the site at any time.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        A project’s privacy setting determines the privacy of its affiliated sites.
+                      </Text>
+                       Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        When a site is transferred to a project,
+                      </Text>
+                       the project will determine the site’s privacy setting.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      Read more about our data privacy policy:
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          style={{}}
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              colorScheme="primary"
+                              dataSet={{}}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "borderRadius": 4,
+                                  "flexDirection": "row",
+                                  "justifyContent": "center",
+                                  "paddingBottom": 0,
+                                  "paddingLeft": 0,
+                                  "paddingRight": 0,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            >
+                              <Icon
+                                color="#028843"
+                                name="open-in-new"
+                                size={24}
+                                style={{}}
+                              />
+                            </View>
+                            <Text
+                              letterSpacing="0.15px"
+                              lineHeight="24px"
+                              style={
+                                {
+                                  "color": "#028843",
+                                  "fontSize": 16,
+                                  "fontWeight": "400",
+                                  "paddingLeft": 4,
+                                  "textTransform": "uppercase",
+                                }
+                              }
+                            >
+                              LandPKS Privacy Policy
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RCTScrollView>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 23,
+                    "top": 18,
+                  }
+                }
+              >
+                <View
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  colorScheme="primary"
+                  dataSet={{}}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "#EEEEEE",
+                      "borderRadius": 9999,
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "paddingBottom": 4,
+                      "paddingLeft": 4,
+                      "paddingRight": 4,
+                      "paddingTop": 4,
+                    }
+                  }
+                >
+                  <Icon
+                    color="#1A202C"
+                    name="close"
+                    size={24}
+                    style={{}}
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <RNSScreenStackHeaderConfig
+            backButtonInCustomView={false}
+            backTitleVisible={true}
+            backgroundColor="rgb(255, 255, 255)"
+            color="rgb(0, 122, 255)"
+            direction="ltr"
+            disableBackButtonMenu={false}
+            hidden={false}
+            hideBackButton={false}
+            largeTitleHideShadow={false}
+            title="CREATE_SITE"
+            titleColor="rgb(28, 28, 30)"
+            topInsetEnabled={false}
+            translucent={false}
+          />
+        </RNSScreen>
+      </RNSScreenStack>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -1471,30 +1471,53 @@ exports[`renders correctly 1`] = `
                                           "flexDirection": "column",
                                         },
                                         {
-                                          "alignItems": "center",
-                                          "backgroundColor": "#028843",
+                                          "alignItems": "flex-start",
+                                          "backgroundColor": "#00344D",
+                                          "paddingLeft": 16,
                                           "paddingVertical": 18,
                                         },
                                       ]
                                     }
                                   >
-                                    <Text
-                                      letterSpacing="0.15px"
-                                      lineHeight="24px"
+                                    <View
                                       style={
-                                        {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 16,
-                                          "fontWeight": "bold",
-                                        }
+                                        [
+                                          {
+                                            "flexDirection": "row",
+                                          },
+                                          {
+                                            "alignItems": "center",
+                                          },
+                                        ]
                                       }
                                     >
-                                      SOIL ID
-                                    </Text>
+                                      <View
+                                        style={
+                                          {
+                                            "marginRight": 15,
+                                          }
+                                        }
+                                      >
+                                        < />
+                                      </View>
+                                      <Text
+                                        letterSpacing="0.15px"
+                                        lineHeight="24px"
+                                        style={
+                                          {
+                                            "color": "#93E39B",
+                                            "fontSize": 16,
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        SOIL ID
+                                      </Text>
+                                    </View>
                                     <View
                                       style={
                                         {
-                                          "height": 5,
+                                          "height": 15,
                                         }
                                       }
                                     />
@@ -1506,6 +1529,7 @@ exports[`renders correctly 1`] = `
                                           "color": "#FFFFFF",
                                           "fontSize": 14,
                                           "fontWeight": "400",
+                                          "marginBottom": 5,
                                         }
                                       }
                                     >
@@ -1516,7 +1540,7 @@ exports[`renders correctly 1`] = `
                                           }
                                         }
                                       >
-                                        Prediction
+                                        Top Match
                                         : 
                                       </Text>
                                       <Text
@@ -1533,6 +1557,7 @@ exports[`renders correctly 1`] = `
                                           "color": "#FFFFFF",
                                           "fontSize": 14,
                                           "fontWeight": "400",
+                                          "marginBottom": 25,
                                         }
                                       }
                                     >
@@ -1543,69 +1568,7 @@ exports[`renders correctly 1`] = `
                                           }
                                         }
                                       >
-                                        Confidence
-                                        : 
-                                      </Text>
-                                      <Text
-                                        style={{}}
-                                      >
-                                        80%
-                                      </Text>
-                                    </Text>
-                                  </View>
-                                  <View
-                                    style={
-                                      [
-                                        {
-                                          "flexDirection": "column",
-                                        },
-                                        {
-                                          "alignItems": "center",
-                                          "backgroundColor": "#028843",
-                                          "paddingVertical": 18,
-                                        },
-                                      ]
-                                    }
-                                  >
-                                    <Text
-                                      letterSpacing="0.15px"
-                                      lineHeight="24px"
-                                      style={
-                                        {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 16,
-                                          "fontWeight": "bold",
-                                        }
-                                      }
-                                    >
-                                      ECOLOGICAL SITE ID
-                                    </Text>
-                                    <View
-                                      style={
-                                        {
-                                          "height": 5,
-                                        }
-                                      }
-                                    />
-                                    <Text
-                                      letterSpacing="0.17px"
-                                      lineHeight="20px"
-                                      style={
-                                        {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 14,
-                                          "fontWeight": "400",
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        style={
-                                          {
-                                            "fontWeight": "bold",
-                                          }
-                                        }
-                                      >
-                                        Prediction
+                                        Ecological Site Name
                                         : 
                                       </Text>
                                       <Text
@@ -1614,122 +1577,103 @@ exports[`renders correctly 1`] = `
                                         Loamy Upland
                                       </Text>
                                     </Text>
-                                    <Text
-                                      letterSpacing="0.17px"
-                                      lineHeight="20px"
-                                      style={
+                                    <View
+                                      accessibilityRole="button"
+                                      accessibilityState={
                                         {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 14,
-                                          "fontWeight": "400",
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
                                         }
                                       }
-                                    >
-                                      <Text
-                                        style={
-                                          {
-                                            "fontWeight": "bold",
-                                          }
-                                        }
-                                      >
-                                        Confidence
-                                        : 
-                                      </Text>
-                                      <Text
-                                        style={{}}
-                                      >
-                                        80%
-                                      </Text>
-                                    </Text>
-                                  </View>
-                                  <View
-                                    style={
-                                      [
+                                      accessibilityValue={
                                         {
-                                          "flexDirection": "column",
-                                        },
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      colorScheme="primary"
+                                      dataSet={{}}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                      style={
                                         {
                                           "alignItems": "center",
                                           "backgroundColor": "#028843",
-                                          "paddingVertical": 18,
-                                        },
-                                      ]
-                                    }
-                                  >
-                                    <Text
-                                      letterSpacing="0.15px"
-                                      lineHeight="24px"
-                                      style={
-                                        {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 16,
-                                          "fontWeight": "bold",
+                                          "borderRadius": 4,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingBottom": 6,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "paddingTop": 6,
+                                          "width": "95%",
                                         }
                                       }
                                     >
-                                      LAND CAPABILITY CLASSIFICATION
-                                    </Text>
-                                    <View
-                                      style={
-                                        {
-                                          "height": 5,
-                                        }
-                                      }
-                                    />
-                                    <Text
-                                      letterSpacing="0.17px"
-                                      lineHeight="20px"
-                                      style={
-                                        {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 14,
-                                          "fontWeight": "400",
-                                        }
-                                      }
-                                    >
-                                      <Text
+                                      <View
+                                        dataSet={{}}
                                         style={
                                           {
-                                            "fontWeight": "bold",
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
                                           }
                                         }
+                                        test={true}
                                       >
-                                        Prediction
-                                        : 
-                                      </Text>
-                                      <Text
-                                        style={{}}
-                                      >
-                                        Class 1
-                                      </Text>
-                                    </Text>
-                                    <Text
-                                      letterSpacing="0.17px"
-                                      lineHeight="20px"
-                                      style={
-                                        {
-                                          "color": "#FFFFFF",
-                                          "fontSize": 14,
-                                          "fontWeight": "400",
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        style={
-                                          {
-                                            "fontWeight": "bold",
+                                        <View
+                                          dataSet={{}}
+                                          style={{}}
+                                        >
+                                          <Text
+                                            dataSet={{}}
+                                            style={
+                                              {
+                                                "backgroundColor": undefined,
+                                                "color": "#fafafa",
+                                                "fontFamily": undefined,
+                                                "fontSize": 14,
+                                                "fontStyle": "normal",
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                                "textDecorationLine": undefined,
+                                              }
+                                            }
+                                          >
+                                            EXPLORE THE DATA
+                                          </Text>
+                                        </View>
+                                        <View
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "width": 6,
+                                            }
                                           }
-                                        }
-                                      >
-                                        Confidence
-                                        : 
-                                      </Text>
-                                      <Text
-                                        style={{}}
-                                      >
-                                        80%
-                                      </Text>
-                                    </Text>
+                                        />
+                                        <Icon
+                                          color="#fafafa"
+                                          name="chevron-right"
+                                          size={20}
+                                          style={{}}
+                                        />
+                                      </View>
+                                    </View>
                                   </View>
                                 </View>
                               </View>

--- a/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -1050,7 +1050,7 @@ exports[`renders correctly 1`] = `
                           </RCTScrollView>
                         </View>
                       </View>
-                      <RNCViewPager
+                      <LEGACY_RNCViewPager
                         collapsable={false}
                         initialPage={0}
                         keyboardDismissMode="on-drag"
@@ -1071,6 +1071,7 @@ exports[`renders correctly 1`] = `
                             "flex": 1,
                           }
                         }
+                        useLegacy={true}
                       >
                         <View
                           collapsable={false}
@@ -1803,7 +1804,7 @@ exports[`renders correctly 1`] = `
                             }
                           />
                         </View>
-                      </RNCViewPager>
+                      </LEGACY_RNCViewPager>
                     </View>
                     <View
                       style={

--- a/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -1,0 +1,2438 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenStack
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          nativeBackButtonDismissalEnabled={false}
+          onAppear={[Function]}
+          onDisappear={[Function]}
+          onDismissed={[Function]}
+          onGestureCancel={[Function]}
+          onHeaderBackButtonClicked={[Function]}
+          onNativeDismissCancelled={[Function]}
+          onTransitionProgress={[Function]}
+          onWillDisappear={[Function]}
+          replaceAnimation="push"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          stackPresentation="push"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          swipeDirection="horizontal"
+        >
+          <View
+            accessibilityElementsHidden={false}
+            importantForAccessibility="auto"
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "column-reverse",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <RNCSafeAreaView
+                edges={
+                  {
+                    "bottom": "additive",
+                    "left": "additive",
+                    "right": "additive",
+                    "top": "additive",
+                  }
+                }
+                style={
+                  [
+                    {
+                      "flex": 1,
+                    },
+                    {
+                      "backgroundColor": "#00582B",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "column",
+                      },
+                      {
+                        "backgroundColor": "#FFFFFF",
+                        "flex": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    onLayout={[Function]}
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "column",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "paddingHorizontal": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "minHeight": 56,
+                              "paddingVertical": 4,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "row",
+                              },
+                              {
+                                "alignItems": "center",
+                                "columnGap": 24,
+                                "flex": 1,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityRole="button"
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": undefined,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            colorScheme="primary"
+                            dataSet={{}}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "borderRadius": 4,
+                                "flexDirection": "row",
+                                "justifyContent": "center",
+                                "paddingBottom": 12,
+                                "paddingLeft": 12,
+                                "paddingRight": 12,
+                                "paddingTop": 12,
+                              }
+                            }
+                          >
+                            <Icon
+                              color="#FFFFFF"
+                              name="arrow-back"
+                              size={24}
+                              style={{}}
+                            />
+                          </View>
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#FFFFFF",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                              }
+                            }
+                          >
+                            1
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      onLayout={[Function]}
+                      style={
+                        [
+                          {
+                            "flex": 1,
+                            "overflow": "hidden",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <View
+                        collapsable={false}
+                        onLayout={[Function]}
+                        style={
+                          {
+                            "backgroundColor": "#EEEEEE",
+                            "elevation": 4,
+                            "shadowColor": "black",
+                            "shadowOffset": {
+                              "height": 0.5,
+                              "width": 0,
+                            },
+                            "shadowOpacity": 0.1,
+                            "shadowRadius": 0.5,
+                            "zIndex": 1,
+                          }
+                        }
+                      >
+                        <View
+                          collapsable={false}
+                          pointerEvents="none"
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "transform": [
+                                {
+                                  "translateX": -0,
+                                },
+                              ],
+                              "width": "160%",
+                            }
+                          }
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#C05621",
+                                "bottom": 0,
+                                "height": "100%",
+                                "left": "0%",
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "transform": [
+                                  {
+                                    "scaleX": 0,
+                                  },
+                                  {
+                                    "translateX": 0.5,
+                                  },
+                                ],
+                                "width": 1,
+                              }
+                            }
+                          />
+                        </View>
+                        <View
+                          style={
+                            {
+                              "overflow": "scroll",
+                            }
+                          }
+                        >
+                          <RCTScrollView
+                            accessibilityRole="tablist"
+                            alwaysBounceHorizontal={false}
+                            automaticallyAdjustContentInsets={false}
+                            collapsable={false}
+                            contentContainerStyle={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                  "flexWrap": "nowrap",
+                                },
+                                {
+                                  "width": "160%",
+                                },
+                                undefined,
+                              ]
+                            }
+                            data={
+                              [
+                                {
+                                  "key": "SITE-stable-nanoid-id",
+                                  "name": "SITE",
+                                  "params": {
+                                    "siteId": "1",
+                                  },
+                                },
+                                {
+                                  "key": "SLOPE-stable-nanoid-id",
+                                  "name": "SLOPE",
+                                  "params": {
+                                    "siteId": "1",
+                                  },
+                                },
+                                {
+                                  "key": "SOIL-stable-nanoid-id",
+                                  "name": "SOIL",
+                                  "params": {
+                                    "siteId": "1",
+                                  },
+                                },
+                                {
+                                  "key": "NOTES-stable-nanoid-id",
+                                  "name": "NOTES",
+                                  "params": {
+                                    "siteId": "1",
+                                  },
+                                },
+                              ]
+                            }
+                            getItem={[Function]}
+                            getItemCount={[Function]}
+                            horizontal={true}
+                            initialNumToRender={10}
+                            keyExtractor={[Function]}
+                            keyboardShouldPersistTaps="handled"
+                            onContentSizeChange={[Function]}
+                            onLayout={[Function]}
+                            onMomentumScrollBegin={[Function]}
+                            onMomentumScrollEnd={[Function]}
+                            onScroll={[Function]}
+                            onScrollBeginDrag={[Function]}
+                            onScrollEndDrag={[Function]}
+                            onViewableItemsChanged={[Function]}
+                            overScrollMode="never"
+                            removeClippedSubviews={false}
+                            renderItem={[Function]}
+                            scrollEnabled={true}
+                            scrollEventThrottle={16}
+                            scrollsToTop={false}
+                            showsHorizontalScrollIndicator={false}
+                            showsVerticalScrollIndicator={false}
+                            stickyHeaderIndices={[]}
+                            style={{}}
+                            viewabilityConfigCallbackPairs={
+                              [
+                                {
+                                  "onViewableItemsChanged": [Function],
+                                  "viewabilityConfig": undefined,
+                                },
+                              ]
+                            }
+                          >
+                            <View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": true,
+                                    }
+                                  }
+                                  accessibilityStates={
+                                    [
+                                      "selected",
+                                    ]
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Site
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 1,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Site
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": false,
+                                    }
+                                  }
+                                  accessibilityStates={[]}
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Slope
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Slope
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": false,
+                                    }
+                                  }
+                                  accessibilityStates={[]}
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Soil
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Soil
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": false,
+                                    }
+                                  }
+                                  accessibilityStates={[]}
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Notes
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Notes
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </RCTScrollView>
+                        </View>
+                      </View>
+                      <RNCViewPager
+                        collapsable={false}
+                        initialPage={0}
+                        keyboardDismissMode="on-drag"
+                        layout={
+                          {
+                            "height": 0,
+                            "width": 0,
+                          }
+                        }
+                        layoutDirection="ltr"
+                        onMoveShouldSetResponderCapture={[Function]}
+                        onPageScroll={[Function]}
+                        onPageScrollStateChanged={[Function]}
+                        onPageSelected={[Function]}
+                        scrollEnabled={true}
+                        style={
+                          {
+                            "flex": 1,
+                          }
+                        }
+                      >
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={false}
+                            importantForAccessibility="auto"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                {
+                                  "bottom": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                },
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          >
+                            <RCTScrollView>
+                              <View>
+                                <View
+                                  onLayout={[Function]}
+                                  style={
+                                    {
+                                      "height": 170,
+                                    }
+                                  }
+                                />
+                                <View
+                                  style={{}}
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "row",
+                                        },
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#00582B",
+                                          "justifyContent": "space-between",
+                                          "paddingHorizontal": 16,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      Details
+                                    </Text>
+                                    <View
+                                      accessibilityRole="button"
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      colorScheme="primary"
+                                      dataSet={{}}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 4,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
+                                        }
+                                      }
+                                    >
+                                      <Icon
+                                        color="#FFFFFF"
+                                        name="expand-less"
+                                        size={24}
+                                        style={{}}
+                                      />
+                                    </View>
+                                  </View>
+                                  <View
+                                    style={
+                                      {
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 8,
+                                      }
+                                    }
+                                  >
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Project
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        1
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Data Privacy
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        Private
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Latitude
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        1.000000
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Longitude
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        1.000000
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Elevation
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        1900 ft
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Location Accuracy
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        20 ft
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Bedrock
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        not found
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#1A202C",
+                                          "fontSize": 16,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Last Modified
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        8/15/23 Sample Sam
+                                      </Text>
+                                    </Text>
+                                  </View>
+                                </View>
+                                <View
+                                  aria-orientation="horizontal"
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": "#d4d4d4",
+                                      "height": 1,
+                                      "width": "100%",
+                                    }
+                                  }
+                                  thickness="1"
+                                />
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "column",
+                                      },
+                                      {
+                                        "padding": 16,
+                                        "rowGap": 20,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "column",
+                                        },
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#028843",
+                                          "paddingVertical": 18,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 16,
+                                          "fontWeight": "bold",
+                                        }
+                                      }
+                                    >
+                                      SOIL ID
+                                    </Text>
+                                    <View
+                                      style={
+                                        {
+                                          "height": 5,
+                                        }
+                                      }
+                                    />
+                                    <Text
+                                      letterSpacing="0.17px"
+                                      lineHeight="20px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Prediction
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        Clifton
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.17px"
+                                      lineHeight="20px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Confidence
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        80%
+                                      </Text>
+                                    </Text>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "column",
+                                        },
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#028843",
+                                          "paddingVertical": 18,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 16,
+                                          "fontWeight": "bold",
+                                        }
+                                      }
+                                    >
+                                      ECOLOGICAL SITE ID
+                                    </Text>
+                                    <View
+                                      style={
+                                        {
+                                          "height": 5,
+                                        }
+                                      }
+                                    />
+                                    <Text
+                                      letterSpacing="0.17px"
+                                      lineHeight="20px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Prediction
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        Loamy Upland
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.17px"
+                                      lineHeight="20px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Confidence
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        80%
+                                      </Text>
+                                    </Text>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "column",
+                                        },
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#028843",
+                                          "paddingVertical": 18,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      letterSpacing="0.15px"
+                                      lineHeight="24px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 16,
+                                          "fontWeight": "bold",
+                                        }
+                                      }
+                                    >
+                                      LAND CAPABILITY CLASSIFICATION
+                                    </Text>
+                                    <View
+                                      style={
+                                        {
+                                          "height": 5,
+                                        }
+                                      }
+                                    />
+                                    <Text
+                                      letterSpacing="0.17px"
+                                      lineHeight="20px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Prediction
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        Class 1
+                                      </Text>
+                                    </Text>
+                                    <Text
+                                      letterSpacing="0.17px"
+                                      lineHeight="20px"
+                                      style={
+                                        {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "400",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "fontWeight": "bold",
+                                          }
+                                        }
+                                      >
+                                        Confidence
+                                        : 
+                                      </Text>
+                                      <Text
+                                        style={{}}
+                                      >
+                                        80%
+                                      </Text>
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </RCTScrollView>
+                          </View>
+                        </View>
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={true}
+                            importantForAccessibility="no-hide-descendants"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                null,
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          />
+                        </View>
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={true}
+                            importantForAccessibility="no-hide-descendants"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                null,
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          />
+                        </View>
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={true}
+                            importantForAccessibility="no-hide-descendants"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                null,
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          />
+                        </View>
+                      </RNCViewPager>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "column",
+                          },
+                          {
+                            "alignItems": "flex-end",
+                            "bottom": 16,
+                            "position": "absolute",
+                            "right": 16,
+                            "rowGap": 16,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        accessibilityRole="button"
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        colorScheme="primary"
+                        dataSet={{}}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#028843",
+                            "borderRadius": 9999,
+                            "elevation": 3,
+                            "flexDirection": "row",
+                            "justifyContent": "center",
+                            "paddingBottom": 16,
+                            "paddingLeft": 16,
+                            "paddingRight": 16,
+                            "paddingTop": 16,
+                            "shadowColor": "#000000",
+                            "shadowOffset": {
+                              "height": 1,
+                              "width": 0,
+                            },
+                            "shadowOpacity": 0.22,
+                            "shadowRadius": 2.22,
+                          }
+                        }
+                      >
+                        <Icon
+                          color="#FFFFFF"
+                          name="add"
+                          size={24}
+                          style={{}}
+                        />
+                      </View>
+                    </View>
+                    <RCTScrollView>
+                      <View>
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "column",
+                              },
+                              {
+                                "marginTop": 48,
+                                "paddingBottom": "65%",
+                                "paddingHorizontal": 20,
+                                "paddingTop": 20,
+                                "rowGap": 12,
+                              },
+                            ]
+                          }
+                        >
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                                "textAlign": "left",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            LandPKS Data Privacy
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              The data visible in public sites
+                            </Text>
+                             includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Public sites
+                            </Text>
+                             are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Data Portal
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Unaffiliated private sites
+                            </Text>
+                             are only visible to you. You can change the privacy of the site at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              A project’s privacy setting determines the privacy of its affiliated sites.
+                            </Text>
+                             Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              When a site is transferred to a project,
+                            </Text>
+                             the project will determine the site’s privacy setting.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            Read more about our data privacy policy:
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Privacy Policy
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </RCTScrollView>
+                    <View
+                      style={
+                        {
+                          "position": "absolute",
+                          "right": 23,
+                          "top": 18,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityRole="button"
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        colorScheme="primary"
+                        dataSet={{}}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#EEEEEE",
+                            "borderRadius": 9999,
+                            "flexDirection": "row",
+                            "justifyContent": "center",
+                            "paddingBottom": 4,
+                            "paddingLeft": 4,
+                            "paddingRight": 4,
+                            "paddingTop": 4,
+                          }
+                        }
+                      >
+                        <Icon
+                          color="#1A202C"
+                          name="close"
+                          size={24}
+                          style={{}}
+                        />
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RNCSafeAreaView>
+            </View>
+          </View>
+          <RNSScreenStackHeaderConfig
+            backButtonInCustomView={false}
+            backTitleVisible={true}
+            backgroundColor="rgb(255, 255, 255)"
+            color="rgb(0, 122, 255)"
+            direction="ltr"
+            disableBackButtonMenu={false}
+            hidden={false}
+            hideBackButton={false}
+            largeTitleHideShadow={false}
+            title="LOCATION_DASHBOARD"
+            titleColor="rgb(28, 28, 30)"
+            topInsetEnabled={false}
+            translucent={false}
+          />
+        </RNSScreen>
+      </RNSScreenStack>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/__tests__/integration/__snapshots__/LoginScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LoginScreen-test.tsx.snap
@@ -1,0 +1,354 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flexDirection": "column",
+          },
+          {
+            "alignItems": "center",
+            "backgroundColor": "#028843",
+            "height": "100%",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "flexGrow": 2,
+          }
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "flexDirection": "column",
+            },
+            {
+              "alignItems": "center",
+              "justifyContent": "flex-end",
+            },
+          ]
+        }
+      >
+        <Text
+          lineHeight="56px"
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 40,
+              "fontWeight": "400",
+            }
+          }
+        >
+          LandPKS
+        </Text>
+        <View
+          style={
+            {
+              "height": 28,
+            }
+          }
+        />
+        <Text
+          lineHeight="32px"
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 24,
+              "fontWeight": "400",
+              "paddingLeft": 40,
+              "paddingRight": 40,
+              "textAlign": "center",
+            }
+          }
+        >
+          Discover the potential of your land
+        </Text>
+        <View
+          style={
+            {
+              "height": 72,
+            }
+          }
+        />
+        <View
+          dataSet={{}}
+          style={
+            {
+              "flexDirection": "column",
+            }
+          }
+        >
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            colorScheme="primary"
+            dataSet={{}}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#FFFFFF",
+                "borderRadius": 4,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "paddingBottom": 8,
+                "paddingLeft": 22,
+                "paddingRight": 22,
+                "paddingTop": 8,
+              }
+            }
+          >
+            <View
+              dataSet={{}}
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
+              test={true}
+            >
+              <
+                color="text.50"
+                size="md"
+              />
+              <View
+                dataSet={{}}
+                style={
+                  {
+                    "width": 6,
+                  }
+                }
+              />
+              <View
+                dataSet={{}}
+                style={{}}
+              >
+                <Text
+                  dataSet={{}}
+                  style={
+                    {
+                      "backgroundColor": undefined,
+                      "color": "#028843",
+                      "fontFamily": undefined,
+                      "fontSize": 15,
+                      "fontStyle": "normal",
+                      "fontWeight": "500",
+                      "letterSpacing": 0.46,
+                      "lineHeight": 26,
+                      "textDecorationLine": undefined,
+                    }
+                  }
+                >
+                  SIGN IN WITH GOOGLE
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            dataSet={{}}
+            style={
+              {
+                "height": 20,
+              }
+            }
+          />
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            colorScheme="primary"
+            dataSet={{}}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#FFFFFF",
+                "borderRadius": 4,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "paddingBottom": 8,
+                "paddingLeft": 22,
+                "paddingRight": 22,
+                "paddingTop": 8,
+              }
+            }
+          >
+            <View
+              dataSet={{}}
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
+              test={true}
+            >
+              <
+                color="text.50"
+                size="md"
+              />
+              <View
+                dataSet={{}}
+                style={
+                  {
+                    "width": 6,
+                  }
+                }
+              />
+              <View
+                dataSet={{}}
+                style={{}}
+              >
+                <Text
+                  dataSet={{}}
+                  style={
+                    {
+                      "backgroundColor": undefined,
+                      "color": "#028843",
+                      "fontFamily": undefined,
+                      "fontSize": 15,
+                      "fontStyle": "normal",
+                      "fontWeight": "500",
+                      "letterSpacing": 0.46,
+                      "lineHeight": 26,
+                      "textDecorationLine": undefined,
+                    }
+                  }
+                >
+                  SIGN IN WITH MICROSOFT
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "flexGrow": 3,
+          }
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "flexDirection": "column",
+            },
+            {
+              "alignItems": "center",
+              "justifyContent": "flex-end",
+              "paddingBottom": 60,
+            },
+          ]
+        }
+      >
+        <
+          height="39px"
+          width="122px"
+        />
+        <View
+          style={
+            {
+              "height": 12,
+            }
+          }
+        />
+        <Text
+          letterSpacing="0.4px"
+          lineHeight="20px"
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontSize": 12,
+              "fontWeight": "400",
+            }
+          }
+        >
+          LandPKS is a Terraso soil science tool.
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -1,0 +1,2631 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenStack
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          nativeBackButtonDismissalEnabled={false}
+          onAppear={[Function]}
+          onDisappear={[Function]}
+          onDismissed={[Function]}
+          onGestureCancel={[Function]}
+          onHeaderBackButtonClicked={[Function]}
+          onNativeDismissCancelled={[Function]}
+          onTransitionProgress={[Function]}
+          onWillDisappear={[Function]}
+          replaceAnimation="push"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          stackPresentation="push"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          swipeDirection="horizontal"
+        >
+          <View
+            accessibilityElementsHidden={false}
+            importantForAccessibility="auto"
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "column-reverse",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <RNCSafeAreaView
+                edges={
+                  {
+                    "bottom": "additive",
+                    "left": "additive",
+                    "right": "additive",
+                    "top": "additive",
+                  }
+                }
+                style={
+                  [
+                    {
+                      "flex": 1,
+                    },
+                    {
+                      "backgroundColor": "#00582B",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "column",
+                      },
+                      {
+                        "backgroundColor": "#FFFFFF",
+                        "flex": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    onLayout={[Function]}
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "column",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "paddingHorizontal": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "minHeight": 56,
+                              "paddingVertical": 4,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "row",
+                              },
+                              {
+                                "alignItems": "center",
+                                "columnGap": 24,
+                                "flex": 1,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityRole="button"
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": undefined,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            colorScheme="primary"
+                            dataSet={{}}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "borderRadius": 4,
+                                "flexDirection": "row",
+                                "justifyContent": "center",
+                                "paddingBottom": 12,
+                                "paddingLeft": 12,
+                                "paddingRight": 12,
+                                "paddingTop": 12,
+                              }
+                            }
+                          >
+                            <Icon
+                              color="#FFFFFF"
+                              name="arrow-back"
+                              size={24}
+                              style={{}}
+                            />
+                          </View>
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#FFFFFF",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                              }
+                            }
+                          >
+                            1
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      onLayout={[Function]}
+                      style={
+                        [
+                          {
+                            "flex": 1,
+                            "overflow": "hidden",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <View
+                        collapsable={false}
+                        onLayout={[Function]}
+                        style={
+                          {
+                            "backgroundColor": "#EEEEEE",
+                            "elevation": 4,
+                            "shadowColor": "black",
+                            "shadowOffset": {
+                              "height": 0.5,
+                              "width": 0,
+                            },
+                            "shadowOpacity": 0.1,
+                            "shadowRadius": 0.5,
+                            "zIndex": 1,
+                          }
+                        }
+                      >
+                        <View
+                          collapsable={false}
+                          pointerEvents="none"
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "transform": [
+                                {
+                                  "translateX": -0,
+                                },
+                              ],
+                              "width": "120%",
+                            }
+                          }
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#C05621",
+                                "bottom": 0,
+                                "height": "100%",
+                                "left": "0%",
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "transform": [
+                                  {
+                                    "scaleX": 0,
+                                  },
+                                  {
+                                    "translateX": 0.5,
+                                  },
+                                ],
+                                "width": 1,
+                              }
+                            }
+                          />
+                        </View>
+                        <View
+                          style={
+                            {
+                              "overflow": "scroll",
+                            }
+                          }
+                        >
+                          <RCTScrollView
+                            accessibilityRole="tablist"
+                            alwaysBounceHorizontal={false}
+                            automaticallyAdjustContentInsets={false}
+                            collapsable={false}
+                            contentContainerStyle={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                  "flexWrap": "nowrap",
+                                },
+                                {
+                                  "width": "120%",
+                                },
+                                undefined,
+                              ]
+                            }
+                            data={
+                              [
+                                {
+                                  "key": "Inputs-stable-nanoid-id",
+                                  "name": "Inputs",
+                                  "params": {
+                                    "projectId": "1",
+                                  },
+                                },
+                                {
+                                  "key": "Sites-stable-nanoid-id",
+                                  "name": "Sites",
+                                  "params": {
+                                    "projectId": "1",
+                                  },
+                                },
+                                {
+                                  "key": "Team-stable-nanoid-id",
+                                  "name": "Team",
+                                  "params": {
+                                    "projectId": "1",
+                                  },
+                                },
+                              ]
+                            }
+                            getItem={[Function]}
+                            getItemCount={[Function]}
+                            horizontal={true}
+                            initialNumToRender={10}
+                            keyExtractor={[Function]}
+                            keyboardShouldPersistTaps="handled"
+                            onContentSizeChange={[Function]}
+                            onLayout={[Function]}
+                            onMomentumScrollBegin={[Function]}
+                            onMomentumScrollEnd={[Function]}
+                            onScroll={[Function]}
+                            onScrollBeginDrag={[Function]}
+                            onScrollEndDrag={[Function]}
+                            onViewableItemsChanged={[Function]}
+                            overScrollMode="never"
+                            removeClippedSubviews={false}
+                            renderItem={[Function]}
+                            scrollEnabled={true}
+                            scrollEventThrottle={16}
+                            scrollsToTop={false}
+                            showsHorizontalScrollIndicator={false}
+                            showsVerticalScrollIndicator={false}
+                            stickyHeaderIndices={[]}
+                            style={{}}
+                            viewabilityConfigCallbackPairs={
+                              [
+                                {
+                                  "onViewableItemsChanged": [Function],
+                                  "viewabilityConfig": undefined,
+                                },
+                              ]
+                            }
+                          >
+                            <View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": true,
+                                    }
+                                  }
+                                  accessibilityStates={
+                                    [
+                                      "selected",
+                                    ]
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "margin": 2,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 0,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "height": 24,
+                                                "width": 24,
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <Icon
+                                            color="#C05621"
+                                            name="tune"
+                                            size={24}
+                                            style={{}}
+                                          />
+                                        </View>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 1,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "height": 24,
+                                                "width": 24,
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <Icon
+                                            color="#FFFFFF"
+                                            name="tune"
+                                            size={24}
+                                            style={{}}
+                                          />
+                                        </View>
+                                      </View>
+                                    </View>
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Inputs
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 1,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Inputs
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": false,
+                                    }
+                                  }
+                                  accessibilityStates={[]}
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "margin": 2,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "height": 24,
+                                                "width": 24,
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <Icon
+                                            color="#C05621"
+                                            name="location-on"
+                                            size={24}
+                                            style={{}}
+                                          />
+                                        </View>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "height": 24,
+                                                "width": 24,
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <Icon
+                                            color="#FFFFFF"
+                                            name="location-on"
+                                            size={24}
+                                            style={{}}
+                                          />
+                                        </View>
+                                      </View>
+                                    </View>
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Sites
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Sites
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    null,
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="tab"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": false,
+                                    }
+                                  }
+                                  accessibilityStates={[]}
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  delayPressIn={0}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onLayout={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "opacity": 1,
+                                      },
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                        null,
+                                      ],
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flex": 1,
+                                          "justifyContent": "center",
+                                          "minHeight": 48,
+                                          "padding": 10,
+                                        },
+                                        {
+                                          "flexDirection": "row",
+                                          "flexGrow": 1,
+                                          "paddingHorizontal": 16,
+                                          "paddingVertical": 9,
+                                          "width": "auto",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "margin": 2,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "height": 24,
+                                                "width": 24,
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <Icon
+                                            color="#C05621"
+                                            name="people"
+                                            size={24}
+                                            style={{}}
+                                          />
+                                        </View>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "height": 24,
+                                                "width": 24,
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <Icon
+                                            color="#FFFFFF"
+                                            name="people"
+                                            size={24}
+                                            style={{}}
+                                          />
+                                        </View>
+                                      </View>
+                                    </View>
+                                    <View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#C05621",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Team
+                                        </Text>
+                                      </View>
+                                      <View
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "bottom": 0,
+                                            "left": 0,
+                                            "opacity": 0,
+                                            "position": "absolute",
+                                            "right": 0,
+                                            "top": 0,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "transparent",
+                                                "fontSize": 13,
+                                                "margin": 4,
+                                                "textAlign": "center",
+                                                "textTransform": "uppercase",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "fontSize": 14,
+                                                "fontWeight": "500",
+                                                "letterSpacing": 0.4,
+                                                "lineHeight": 24,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Team
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </RCTScrollView>
+                        </View>
+                      </View>
+                      <RNCViewPager
+                        collapsable={false}
+                        initialPage={0}
+                        keyboardDismissMode="on-drag"
+                        layout={
+                          {
+                            "height": 0,
+                            "width": 0,
+                          }
+                        }
+                        layoutDirection="ltr"
+                        onMoveShouldSetResponderCapture={[Function]}
+                        onPageScroll={[Function]}
+                        onPageScrollStateChanged={[Function]}
+                        onPageSelected={[Function]}
+                        scrollEnabled={true}
+                        style={
+                          {
+                            "flex": 1,
+                          }
+                        }
+                      >
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={false}
+                            importantForAccessibility="auto"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                {
+                                  "bottom": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                },
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "height": "100%",
+                                  },
+                                ]
+                              }
+                            >
+                              <RCTScrollView>
+                                <View>
+                                  <View
+                                    style={
+                                      {
+                                        "alignItems": "flex-start",
+                                        "padding": 16,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "row",
+                                          },
+                                          {
+                                            "paddingBottom": 16,
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={
+                                          {
+                                            "width": "100%",
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          dataSet={{}}
+                                          feedbackId="field-1-feedback"
+                                          hasFeedbackText={false}
+                                          hasHelpText={false}
+                                          helpTextId="field-1-helptext"
+                                          isDisabled={false}
+                                          isInvalid={false}
+                                          isReadOnly={false}
+                                          isRequired={false}
+                                          labelId="field-1-label"
+                                          nativeID="field-1-label"
+                                          setHasFeedbackText={[Function]}
+                                          setHasHelpText={[Function]}
+                                          style={
+                                            {
+                                              "flexDirection": "row",
+                                              "justifyContent": "flex-start",
+                                              "marginBottom": 4,
+                                              "marginTop": 4,
+                                            }
+                                          }
+                                        >
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "flexDirection": "row",
+                                                },
+                                                {},
+                                              ]
+                                            }
+                                          >
+                                            <Text
+                                              letterSpacing="0.15px"
+                                              lineHeight="24px"
+                                              style={
+                                                {
+                                                  "color": "#1A202C",
+                                                  "fontSize": 16,
+                                                  "fontWeight": "bold",
+                                                }
+                                              }
+                                            >
+                                              Data Privacy
+                                            </Text>
+                                            <View
+                                              accessibilityRole="button"
+                                              accessibilityState={
+                                                {
+                                                  "busy": undefined,
+                                                  "checked": undefined,
+                                                  "disabled": undefined,
+                                                  "expanded": undefined,
+                                                  "selected": undefined,
+                                                }
+                                              }
+                                              accessibilityValue={
+                                                {
+                                                  "max": undefined,
+                                                  "min": undefined,
+                                                  "now": undefined,
+                                                  "text": undefined,
+                                                }
+                                              }
+                                              accessible={true}
+                                              collapsable={false}
+                                              colorScheme="primary"
+                                              dataSet={{}}
+                                              focusable={true}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onFocus={[Function]}
+                                              onResponderGrant={[Function]}
+                                              onResponderMove={[Function]}
+                                              onResponderRelease={[Function]}
+                                              onResponderTerminate={[Function]}
+                                              onResponderTerminationRequest={[Function]}
+                                              onStartShouldSetResponder={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "borderRadius": 4,
+                                                  "flexDirection": "row",
+                                                  "justifyContent": "center",
+                                                  "paddingBottom": 0,
+                                                  "paddingLeft": 8,
+                                                  "paddingRight": 12,
+                                                  "paddingTop": 0,
+                                                }
+                                              }
+                                            >
+                                              <Icon
+                                                color="#1A202C"
+                                                name="info"
+                                                size={24}
+                                                style={{}}
+                                              />
+                                            </View>
+                                          </View>
+                                        </View>
+                                        <View
+                                          aria-disabled={false}
+                                          colorScheme="primary"
+                                          dataSet={{}}
+                                          name="project-privacy"
+                                          onChange={[Function]}
+                                          role="radiogroup"
+                                          style={
+                                            {
+                                              "alignItems": "flex-start",
+                                              "marginLeft": 0,
+                                            }
+                                          }
+                                          value="PRIVATE"
+                                        >
+                                          <View
+                                            accessibilityRole="radio"
+                                            accessibilityState={
+                                              {
+                                                "busy": undefined,
+                                                "checked": false,
+                                                "disabled": true,
+                                                "expanded": undefined,
+                                                "selected": undefined,
+                                              }
+                                            }
+                                            accessibilityValue={
+                                              {
+                                                "max": undefined,
+                                                "min": undefined,
+                                                "now": undefined,
+                                                "text": undefined,
+                                              }
+                                            }
+                                            accessible={true}
+                                            checked={false}
+                                            collapsable={false}
+                                            dataSet={{}}
+                                            feedbackId="field-1-feedback"
+                                            focusable={true}
+                                            formControlContext={
+                                              {
+                                                "feedbackId": "field-1-feedback",
+                                                "hasFeedbackText": false,
+                                                "hasHelpText": false,
+                                                "helpTextId": "field-1-helptext",
+                                                "isDisabled": false,
+                                                "isInvalid": false,
+                                                "isReadOnly": false,
+                                                "isRequired": false,
+                                                "labelId": "field-1-label",
+                                                "nativeID": "field-1",
+                                                "setHasFeedbackText": [Function],
+                                                "setHasHelpText": [Function],
+                                              }
+                                            }
+                                            hasFeedbackText={false}
+                                            hasHelpText={false}
+                                            helpTextId="field-1-helptext"
+                                            isInvalid={false}
+                                            isReadOnly={false}
+                                            isRequired={false}
+                                            labelId="field-1-label"
+                                            nativeID="field-1"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onResponderGrant={[Function]}
+                                            onResponderMove={[Function]}
+                                            onResponderRelease={[Function]}
+                                            onResponderTerminate={[Function]}
+                                            onResponderTerminationRequest={[Function]}
+                                            onStartShouldSetResponder={[Function]}
+                                            role="radio"
+                                            setHasFeedbackText={[Function]}
+                                            setHasHelpText={[Function]}
+                                            state={
+                                              {
+                                                "lastFocusedValue": null,
+                                                "name": "project-privacy",
+                                                "selectedValue": "PRIVATE",
+                                                "setLastFocusedValue": [Function],
+                                                "setSelectedValue": [Function],
+                                              }
+                                            }
+                                            style={{}}
+                                            value="PUBLIC"
+                                          >
+                                            <View
+                                              dataSet={{}}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "flexDirection": "row",
+                                                  "opacity": 0.6,
+                                                }
+                                              }
+                                            >
+                                              <View
+                                                dataSet={{}}
+                                                style={
+                                                  {
+                                                    "alignItems": "center",
+                                                    "display": "flex",
+                                                    "justifyContent": "center",
+                                                  }
+                                                }
+                                              >
+                                                <View
+                                                  dataSet={{}}
+                                                  style={{}}
+                                                />
+                                                <View
+                                                  colorScheme="primary"
+                                                  dataSet={{}}
+                                                  defaultIsChecked={false}
+                                                  feedbackId="field-1-feedback"
+                                                  formControlContext={
+                                                    {
+                                                      "feedbackId": "field-1-feedback",
+                                                      "hasFeedbackText": false,
+                                                      "hasHelpText": false,
+                                                      "helpTextId": "field-1-helptext",
+                                                      "isDisabled": false,
+                                                      "isInvalid": false,
+                                                      "isReadOnly": false,
+                                                      "isRequired": false,
+                                                      "labelId": "field-1-label",
+                                                      "nativeID": "field-1",
+                                                      "setHasFeedbackText": [Function],
+                                                      "setHasHelpText": [Function],
+                                                    }
+                                                  }
+                                                  hasFeedbackText={false}
+                                                  hasHelpText={false}
+                                                  helpTextId="field-1-helptext"
+                                                  isDisabled={true}
+                                                  isInvalid={false}
+                                                  isReadOnly={false}
+                                                  isRequired={false}
+                                                  labelId="field-1-label"
+                                                  nativeID="field-1"
+                                                  setHasFeedbackText={[Function]}
+                                                  setHasHelpText={[Function]}
+                                                  state={
+                                                    {
+                                                      "lastFocusedValue": null,
+                                                      "name": "project-privacy",
+                                                      "selectedValue": "PRIVATE",
+                                                      "setLastFocusedValue": [Function],
+                                                      "setSelectedValue": [Function],
+                                                    }
+                                                  }
+                                                  style={
+                                                    {
+                                                      "alignItems": "center",
+                                                      "backgroundColor": "#fafafa",
+                                                      "borderColor": "#a3a3a3",
+                                                      "borderRadius": 9999,
+                                                      "borderWidth": 2,
+                                                      "display": "flex",
+                                                      "fontSize": 16,
+                                                      "fontWeight": "400",
+                                                      "justifyContent": "center",
+                                                      "letterSpacing": 0.15,
+                                                      "lineHeight": 24,
+                                                      "marginBottom": 8,
+                                                      "marginLeft": 8,
+                                                      "marginRight": 0,
+                                                      "marginTop": 8,
+                                                      "opacity": 0.6,
+                                                      "paddingBottom": 4,
+                                                      "paddingLeft": 4,
+                                                      "paddingRight": 4,
+                                                      "paddingTop": 4,
+                                                    }
+                                                  }
+                                                  value="PUBLIC"
+                                                >
+                                                  <RNSVGSvgView
+                                                    accessibilityRole="image"
+                                                    align="xMidYMid"
+                                                    bbHeight={12}
+                                                    bbWidth={12}
+                                                    dataSet={{}}
+                                                    focusable={false}
+                                                    meetOrSlice={0}
+                                                    minX={0}
+                                                    minY={0}
+                                                    stroke=""
+                                                    style={
+                                                      [
+                                                        {
+                                                          "backgroundColor": "transparent",
+                                                          "borderWidth": 0,
+                                                        },
+                                                        {
+                                                          "backgroundColor": "#00000000",
+                                                          "color": "#737373",
+                                                          "height": 12,
+                                                          "opacity": 0,
+                                                          "width": 12,
+                                                        },
+                                                        {
+                                                          "flex": 0,
+                                                          "height": 12,
+                                                          "width": 12,
+                                                        },
+                                                      ]
+                                                    }
+                                                    tintColor="#737373"
+                                                    vbHeight={24}
+                                                    vbWidth={24}
+                                                  >
+                                                    <RNSVGGroup
+                                                      fill={
+                                                        {
+                                                          "payload": 4278190080,
+                                                          "type": 0,
+                                                        }
+                                                      }
+                                                      opacity={0}
+                                                      propList={
+                                                        [
+                                                          "stroke",
+                                                        ]
+                                                      }
+                                                      stroke={null}
+                                                    >
+                                                      <RNSVGGroup
+                                                        fill={
+                                                          {
+                                                            "payload": 4278190080,
+                                                            "type": 0,
+                                                          }
+                                                        }
+                                                      >
+                                                        <RNSVGPath
+                                                          d="M0 12C-2.34822e-08 13.5759 0.310389 15.1363 0.913445 16.5922C1.5165 18.0481 2.40042 19.371 3.51472 20.4853C4.62902 21.5996 5.95189 22.4835 7.4078 23.0866C8.86371 23.6896 10.4241 24 12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12C24 10.4241 23.6896 8.86371 23.0866 7.4078C22.4835 5.95189 21.5996 4.62902 20.4853 3.51472C19.371 2.40042 18.0481 1.5165 16.5922 0.913446C15.1363 0.310389 13.5759 0 12 0C10.4241 0 8.86371 0.310389 7.4078 0.913446C5.95189 1.5165 4.62902 2.40042 3.51472 3.51472C2.40042 4.62902 1.5165 5.95189 0.913445 7.4078C0.310389 8.86371 -2.34822e-08 10.4241 0 12Z"
+                                                          fill={
+                                                            {
+                                                              "type": 2,
+                                                            }
+                                                          }
+                                                          propList={
+                                                            [
+                                                              "fill",
+                                                              "stroke",
+                                                            ]
+                                                          }
+                                                          stroke={null}
+                                                        />
+                                                      </RNSVGGroup>
+                                                    </RNSVGGroup>
+                                                  </RNSVGSvgView>
+                                                </View>
+                                              </View>
+                                              <View
+                                                dataSet={{}}
+                                                style={
+                                                  {
+                                                    "width": 8,
+                                                  }
+                                                }
+                                              />
+                                              <Text
+                                                dataSet={{}}
+                                                style={
+                                                  {
+                                                    "backgroundColor": undefined,
+                                                    "color": "#171717",
+                                                    "fontFamily": undefined,
+                                                    "fontSize": 16,
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "400",
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                    "textDecorationLine": undefined,
+                                                  }
+                                                }
+                                              >
+                                                Public
+                                              </Text>
+                                            </View>
+                                          </View>
+                                          <View
+                                            dataSet={{}}
+                                            style={{}}
+                                          />
+                                          <View
+                                            accessibilityRole="radio"
+                                            accessibilityState={
+                                              {
+                                                "busy": undefined,
+                                                "checked": true,
+                                                "disabled": true,
+                                                "expanded": undefined,
+                                                "selected": undefined,
+                                              }
+                                            }
+                                            accessibilityValue={
+                                              {
+                                                "max": undefined,
+                                                "min": undefined,
+                                                "now": undefined,
+                                                "text": undefined,
+                                              }
+                                            }
+                                            accessible={true}
+                                            checked={true}
+                                            collapsable={false}
+                                            dataSet={{}}
+                                            feedbackId="field-1-feedback"
+                                            focusable={true}
+                                            formControlContext={
+                                              {
+                                                "feedbackId": "field-1-feedback",
+                                                "hasFeedbackText": false,
+                                                "hasHelpText": false,
+                                                "helpTextId": "field-1-helptext",
+                                                "isDisabled": false,
+                                                "isInvalid": false,
+                                                "isReadOnly": false,
+                                                "isRequired": false,
+                                                "labelId": "field-1-label",
+                                                "nativeID": "field-1",
+                                                "setHasFeedbackText": [Function],
+                                                "setHasHelpText": [Function],
+                                              }
+                                            }
+                                            hasFeedbackText={false}
+                                            hasHelpText={false}
+                                            helpTextId="field-1-helptext"
+                                            isInvalid={false}
+                                            isReadOnly={false}
+                                            isRequired={false}
+                                            labelId="field-1-label"
+                                            nativeID="field-1"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onResponderGrant={[Function]}
+                                            onResponderMove={[Function]}
+                                            onResponderRelease={[Function]}
+                                            onResponderTerminate={[Function]}
+                                            onResponderTerminationRequest={[Function]}
+                                            onStartShouldSetResponder={[Function]}
+                                            role="radio"
+                                            setHasFeedbackText={[Function]}
+                                            setHasHelpText={[Function]}
+                                            state={
+                                              {
+                                                "lastFocusedValue": null,
+                                                "name": "project-privacy",
+                                                "selectedValue": "PRIVATE",
+                                                "setLastFocusedValue": [Function],
+                                                "setSelectedValue": [Function],
+                                              }
+                                            }
+                                            style={{}}
+                                            value="PRIVATE"
+                                          >
+                                            <View
+                                              dataSet={{}}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "flexDirection": "row",
+                                                  "opacity": 0.6,
+                                                }
+                                              }
+                                            >
+                                              <View
+                                                dataSet={{}}
+                                                style={
+                                                  {
+                                                    "alignItems": "center",
+                                                    "display": "flex",
+                                                    "justifyContent": "center",
+                                                  }
+                                                }
+                                              >
+                                                <View
+                                                  dataSet={{}}
+                                                  style={{}}
+                                                />
+                                                <View
+                                                  colorScheme="primary"
+                                                  dataSet={{}}
+                                                  defaultIsChecked={false}
+                                                  feedbackId="field-1-feedback"
+                                                  formControlContext={
+                                                    {
+                                                      "feedbackId": "field-1-feedback",
+                                                      "hasFeedbackText": false,
+                                                      "hasHelpText": false,
+                                                      "helpTextId": "field-1-helptext",
+                                                      "isDisabled": false,
+                                                      "isInvalid": false,
+                                                      "isReadOnly": false,
+                                                      "isRequired": false,
+                                                      "labelId": "field-1-label",
+                                                      "nativeID": "field-1",
+                                                      "setHasFeedbackText": [Function],
+                                                      "setHasHelpText": [Function],
+                                                    }
+                                                  }
+                                                  hasFeedbackText={false}
+                                                  hasHelpText={false}
+                                                  helpTextId="field-1-helptext"
+                                                  isDisabled={true}
+                                                  isInvalid={false}
+                                                  isReadOnly={false}
+                                                  isRequired={false}
+                                                  labelId="field-1-label"
+                                                  nativeID="field-1"
+                                                  setHasFeedbackText={[Function]}
+                                                  setHasHelpText={[Function]}
+                                                  state={
+                                                    {
+                                                      "lastFocusedValue": null,
+                                                      "name": "project-privacy",
+                                                      "selectedValue": "PRIVATE",
+                                                      "setLastFocusedValue": [Function],
+                                                      "setSelectedValue": [Function],
+                                                    }
+                                                  }
+                                                  style={
+                                                    {
+                                                      "alignItems": "center",
+                                                      "backgroundColor": "#fafafa",
+                                                      "borderColor": "#028843",
+                                                      "borderRadius": 9999,
+                                                      "borderWidth": 2,
+                                                      "display": "flex",
+                                                      "fontSize": 16,
+                                                      "fontWeight": "400",
+                                                      "justifyContent": "center",
+                                                      "letterSpacing": 0.15,
+                                                      "lineHeight": 24,
+                                                      "marginBottom": 8,
+                                                      "marginLeft": 8,
+                                                      "marginRight": 0,
+                                                      "marginTop": 8,
+                                                      "opacity": 0.6,
+                                                      "paddingBottom": 4,
+                                                      "paddingLeft": 4,
+                                                      "paddingRight": 4,
+                                                      "paddingTop": 4,
+                                                    }
+                                                  }
+                                                  value="PRIVATE"
+                                                >
+                                                  <RNSVGSvgView
+                                                    accessibilityRole="image"
+                                                    align="xMidYMid"
+                                                    bbHeight={12}
+                                                    bbWidth={12}
+                                                    dataSet={{}}
+                                                    focusable={false}
+                                                    meetOrSlice={0}
+                                                    minX={0}
+                                                    minY={0}
+                                                    stroke=""
+                                                    style={
+                                                      [
+                                                        {
+                                                          "backgroundColor": "transparent",
+                                                          "borderWidth": 0,
+                                                        },
+                                                        {
+                                                          "backgroundColor": "#00000000",
+                                                          "color": "#028843",
+                                                          "height": 12,
+                                                          "opacity": 1,
+                                                          "width": 12,
+                                                        },
+                                                        {
+                                                          "flex": 0,
+                                                          "height": 12,
+                                                          "width": 12,
+                                                        },
+                                                      ]
+                                                    }
+                                                    tintColor="#028843"
+                                                    vbHeight={24}
+                                                    vbWidth={24}
+                                                  >
+                                                    <RNSVGGroup
+                                                      fill={
+                                                        {
+                                                          "payload": 4278190080,
+                                                          "type": 0,
+                                                        }
+                                                      }
+                                                      opacity={1}
+                                                      propList={
+                                                        [
+                                                          "stroke",
+                                                        ]
+                                                      }
+                                                      stroke={null}
+                                                    >
+                                                      <RNSVGGroup
+                                                        fill={
+                                                          {
+                                                            "payload": 4278190080,
+                                                            "type": 0,
+                                                          }
+                                                        }
+                                                      >
+                                                        <RNSVGPath
+                                                          d="M0 12C-2.34822e-08 13.5759 0.310389 15.1363 0.913445 16.5922C1.5165 18.0481 2.40042 19.371 3.51472 20.4853C4.62902 21.5996 5.95189 22.4835 7.4078 23.0866C8.86371 23.6896 10.4241 24 12 24C13.5759 24 15.1363 23.6896 16.5922 23.0866C18.0481 22.4835 19.371 21.5996 20.4853 20.4853C21.5996 19.371 22.4835 18.0481 23.0866 16.5922C23.6896 15.1363 24 13.5759 24 12C24 10.4241 23.6896 8.86371 23.0866 7.4078C22.4835 5.95189 21.5996 4.62902 20.4853 3.51472C19.371 2.40042 18.0481 1.5165 16.5922 0.913446C15.1363 0.310389 13.5759 0 12 0C10.4241 0 8.86371 0.310389 7.4078 0.913446C5.95189 1.5165 4.62902 2.40042 3.51472 3.51472C2.40042 4.62902 1.5165 5.95189 0.913445 7.4078C0.310389 8.86371 -2.34822e-08 10.4241 0 12Z"
+                                                          fill={
+                                                            {
+                                                              "type": 2,
+                                                            }
+                                                          }
+                                                          propList={
+                                                            [
+                                                              "fill",
+                                                              "stroke",
+                                                            ]
+                                                          }
+                                                          stroke={null}
+                                                        />
+                                                      </RNSVGGroup>
+                                                    </RNSVGGroup>
+                                                  </RNSVGSvgView>
+                                                </View>
+                                              </View>
+                                              <View
+                                                dataSet={{}}
+                                                style={
+                                                  {
+                                                    "width": 8,
+                                                  }
+                                                }
+                                              />
+                                              <Text
+                                                dataSet={{}}
+                                                style={
+                                                  {
+                                                    "backgroundColor": undefined,
+                                                    "color": "#171717",
+                                                    "fontFamily": undefined,
+                                                    "fontSize": 16,
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "400",
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                    "textDecorationLine": undefined,
+                                                  }
+                                                }
+                                              >
+                                                Private
+                                              </Text>
+                                            </View>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <View
+                                    style={{}}
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "row",
+                                          },
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#00582B",
+                                            "justifyContent": "space-between",
+                                            "paddingHorizontal": 16,
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        letterSpacing="0.15px"
+                                        lineHeight="24px"
+                                        style={
+                                          {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 16,
+                                            "fontWeight": "400",
+                                            "paddingBottom": 12,
+                                            "paddingTop": 12,
+                                          }
+                                        }
+                                      >
+                                        Soil Pit
+                                      </Text>
+                                      <View
+                                        accessibilityRole="button"
+                                        accessibilityState={
+                                          {
+                                            "busy": undefined,
+                                            "checked": undefined,
+                                            "disabled": undefined,
+                                            "expanded": undefined,
+                                            "selected": undefined,
+                                          }
+                                        }
+                                        accessibilityValue={
+                                          {
+                                            "max": undefined,
+                                            "min": undefined,
+                                            "now": undefined,
+                                            "text": undefined,
+                                          }
+                                        }
+                                        accessible={true}
+                                        collapsable={false}
+                                        colorScheme="primary"
+                                        dataSet={{}}
+                                        focusable={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onResponderGrant={[Function]}
+                                        onResponderMove={[Function]}
+                                        onResponderRelease={[Function]}
+                                        onResponderTerminate={[Function]}
+                                        onResponderTerminationRequest={[Function]}
+                                        onStartShouldSetResponder={[Function]}
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "borderRadius": 4,
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                            "paddingBottom": 4,
+                                            "paddingLeft": 4,
+                                            "paddingRight": 4,
+                                            "paddingTop": 4,
+                                          }
+                                        }
+                                      >
+                                        <Icon
+                                          color="#FFFFFF"
+                                          name="expand-more"
+                                          size={24}
+                                          style={{}}
+                                        />
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <View
+                                    style={
+                                      {
+                                        "height": 16,
+                                      }
+                                    }
+                                  />
+                                  <View
+                                    style={{}}
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "row",
+                                          },
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#00582B",
+                                            "justifyContent": "space-between",
+                                            "paddingHorizontal": 16,
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        letterSpacing="0.15px"
+                                        lineHeight="24px"
+                                        style={
+                                          {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 16,
+                                            "fontWeight": "400",
+                                            "paddingBottom": 12,
+                                            "paddingTop": 12,
+                                          }
+                                        }
+                                      >
+                                        Data Collection Requirements
+                                      </Text>
+                                      <View
+                                        accessibilityRole="button"
+                                        accessibilityState={
+                                          {
+                                            "busy": undefined,
+                                            "checked": undefined,
+                                            "disabled": undefined,
+                                            "expanded": undefined,
+                                            "selected": undefined,
+                                          }
+                                        }
+                                        accessibilityValue={
+                                          {
+                                            "max": undefined,
+                                            "min": undefined,
+                                            "now": undefined,
+                                            "text": undefined,
+                                          }
+                                        }
+                                        accessible={true}
+                                        collapsable={false}
+                                        colorScheme="primary"
+                                        dataSet={{}}
+                                        focusable={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onResponderGrant={[Function]}
+                                        onResponderMove={[Function]}
+                                        onResponderRelease={[Function]}
+                                        onResponderTerminate={[Function]}
+                                        onResponderTerminationRequest={[Function]}
+                                        onStartShouldSetResponder={[Function]}
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "borderRadius": 4,
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                            "paddingBottom": 4,
+                                            "paddingLeft": 4,
+                                            "paddingRight": 4,
+                                            "paddingTop": 4,
+                                          }
+                                        }
+                                      >
+                                        <Icon
+                                          color="#FFFFFF"
+                                          name="expand-more"
+                                          size={24}
+                                          style={{}}
+                                        />
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </RCTScrollView>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={true}
+                            importantForAccessibility="no-hide-descendants"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                null,
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          />
+                        </View>
+                        <View
+                          collapsable={false}
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <View
+                            accessibilityElementsHidden={true}
+                            importantForAccessibility="no-hide-descendants"
+                            style={
+                              [
+                                {
+                                  "flex": 1,
+                                  "overflow": "hidden",
+                                },
+                                null,
+                                [
+                                  [
+                                    {
+                                      "backgroundColor": "rgb(242, 242, 242)",
+                                    },
+                                    undefined,
+                                  ],
+                                  {
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ],
+                              ]
+                            }
+                          />
+                        </View>
+                      </RNCViewPager>
+                    </View>
+                  </View>
+                </View>
+              </RNCSafeAreaView>
+              <RCTScrollView>
+                <View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "marginTop": 48,
+                          "paddingBottom": "65%",
+                          "paddingHorizontal": 20,
+                          "paddingTop": 20,
+                          "rowGap": 12,
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      lineHeight="32px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 20,
+                          "fontWeight": "500",
+                          "textAlign": "left",
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      LandPKS Data Privacy
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        The data visible in public sites
+                      </Text>
+                       includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        Public sites
+                      </Text>
+                       are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          style={{}}
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              colorScheme="primary"
+                              dataSet={{}}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "borderRadius": 4,
+                                  "flexDirection": "row",
+                                  "justifyContent": "center",
+                                  "paddingBottom": 0,
+                                  "paddingLeft": 0,
+                                  "paddingRight": 0,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            >
+                              <Icon
+                                color="#028843"
+                                name="open-in-new"
+                                size={24}
+                                style={{}}
+                              />
+                            </View>
+                            <Text
+                              letterSpacing="0.15px"
+                              lineHeight="24px"
+                              style={
+                                {
+                                  "color": "#028843",
+                                  "fontSize": 16,
+                                  "fontWeight": "400",
+                                  "paddingLeft": 4,
+                                  "textTransform": "uppercase",
+                                }
+                              }
+                            >
+                              LandPKS Data Portal
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        Unaffiliated private sites
+                      </Text>
+                       are only visible to you. You can change the privacy of the site at any time.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        A project’s privacy setting determines the privacy of its affiliated sites.
+                      </Text>
+                       Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          {
+                            "fontWeight": "bold",
+                          }
+                        }
+                      >
+                        When a site is transferred to a project,
+                      </Text>
+                       the project will determine the site’s privacy setting.
+                    </Text>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      Read more about our data privacy policy:
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          style={{}}
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "row",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              colorScheme="primary"
+                              dataSet={{}}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "borderRadius": 4,
+                                  "flexDirection": "row",
+                                  "justifyContent": "center",
+                                  "paddingBottom": 0,
+                                  "paddingLeft": 0,
+                                  "paddingRight": 0,
+                                  "paddingTop": 0,
+                                }
+                              }
+                            >
+                              <Icon
+                                color="#028843"
+                                name="open-in-new"
+                                size={24}
+                                style={{}}
+                              />
+                            </View>
+                            <Text
+                              letterSpacing="0.15px"
+                              lineHeight="24px"
+                              style={
+                                {
+                                  "color": "#028843",
+                                  "fontSize": 16,
+                                  "fontWeight": "400",
+                                  "paddingLeft": 4,
+                                  "textTransform": "uppercase",
+                                }
+                              }
+                            >
+                              LandPKS Privacy Policy
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RCTScrollView>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 23,
+                    "top": 18,
+                  }
+                }
+              >
+                <View
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  colorScheme="primary"
+                  dataSet={{}}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "#EEEEEE",
+                      "borderRadius": 9999,
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "paddingBottom": 4,
+                      "paddingLeft": 4,
+                      "paddingRight": 4,
+                      "paddingTop": 4,
+                    }
+                  }
+                >
+                  <Icon
+                    color="#1A202C"
+                    name="close"
+                    size={24}
+                    style={{}}
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <RNSScreenStackHeaderConfig
+            backButtonInCustomView={false}
+            backTitleVisible={true}
+            backgroundColor="rgb(255, 255, 255)"
+            color="rgb(0, 122, 255)"
+            direction="ltr"
+            disableBackButtonMenu={false}
+            hidden={false}
+            hideBackButton={false}
+            largeTitleHideShadow={false}
+            title="PROJECT_VIEW"
+            titleColor="rgb(28, 28, 30)"
+            topInsetEnabled={false}
+            translucent={false}
+          />
+        </RNSScreen>
+      </RNSScreenStack>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -1087,7 +1087,7 @@ exports[`renders correctly 1`] = `
                           </RCTScrollView>
                         </View>
                       </View>
-                      <RNCViewPager
+                      <LEGACY_RNCViewPager
                         collapsable={false}
                         initialPage={0}
                         keyboardDismissMode="on-drag"
@@ -1108,6 +1108,7 @@ exports[`renders correctly 1`] = `
                             "flex": 1,
                           }
                         }
+                        useLegacy={true}
                       >
                         <View
                           collapsable={false}
@@ -2131,7 +2132,7 @@ exports[`renders correctly 1`] = `
                             }
                           />
                         </View>
-                      </RNCViewPager>
+                      </LEGACY_RNCViewPager>
                     </View>
                   </View>
                 </View>

--- a/dev-client/__tests__/integration/__snapshots__/SlopeScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SlopeScreen-test.tsx.snap
@@ -1,0 +1,545 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenStack
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          nativeBackButtonDismissalEnabled={false}
+          onAppear={[Function]}
+          onDisappear={[Function]}
+          onDismissed={[Function]}
+          onGestureCancel={[Function]}
+          onHeaderBackButtonClicked={[Function]}
+          onNativeDismissCancelled={[Function]}
+          onTransitionProgress={[Function]}
+          onWillDisappear={[Function]}
+          replaceAnimation="push"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          stackPresentation="push"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          swipeDirection="horizontal"
+        >
+          <View
+            accessibilityElementsHidden={false}
+            importantForAccessibility="auto"
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "column-reverse",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                    },
+                    {
+                      "rowGap": 1,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#FFFFFF",
+                        "padding": 15,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    lineHeight="32px"
+                    style={
+                      {
+                        "color": "#1A202C",
+                        "fontSize": 20,
+                        "fontWeight": "500",
+                      }
+                    }
+                  >
+                    Slope
+                  </Text>
+                  <View
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                  >
+                    <View
+                      accessibilityRole="button"
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      colorScheme="primary"
+                      dataSet={{}}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "borderRadius": 4,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "marginLeft": 6,
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        }
+                      }
+                    >
+                      <Icon
+                        color="#1A202CB2"
+                        name="info"
+                        size={24}
+                        style={{}}
+                      />
+                    </View>
+                  </View>
+                  <RCTScrollView>
+                    <View>
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "column",
+                            },
+                            {
+                              "padding": 16,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "row",
+                              },
+                              {
+                                "alignItems": "center",
+                                "marginBottom": 16,
+                              },
+                            ]
+                          }
+                        >
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 24,
+                                "fontWeight": "700",
+                              }
+                            }
+                          >
+                            Slope
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "flex": 1,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityRole="button"
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": undefined,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            colorScheme="primary"
+                            dataSet={{}}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#EEEEEE",
+                                "borderRadius": 9999,
+                                "flexDirection": "row",
+                                "justifyContent": "center",
+                                "paddingBottom": 16,
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "paddingTop": 16,
+                              }
+                            }
+                          >
+                            <Icon
+                              color="#1A202C"
+                              name="close"
+                              size={24}
+                              style={{}}
+                            />
+                          </View>
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                            }
+                          }
+                        >
+                          Describe the characteristics of the slope of the land on which the site is located.
+
+Instructions on how to collect each data input are available by tapping on the input name.
+
+Slope is important in identifying the soil. It also helps determine the soil’s erosion potential, ability to hold water, and more.
+                        </Text>
+                      </View>
+                    </View>
+                  </RCTScrollView>
+                </View>
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "row",
+                        },
+                        {
+                          "backgroundColor": "#E2FFE5",
+                          "padding": 15,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "width": 37,
+                        }
+                      }
+                    >
+                      <Icon
+                        color="#00582B"
+                        name="check-circle"
+                        size={24}
+                        style={{}}
+                      />
+                    </View>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "700",
+                          "textTransform": "uppercase",
+                        }
+                      }
+                    >
+                      STEEPNESS
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    />
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                        }
+                      }
+                    >
+                      Flat 0–2%
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "row",
+                        },
+                        {
+                          "backgroundColor": "#FFFFFF",
+                          "padding": 15,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "width": 37,
+                        }
+                      }
+                    >
+                      <Icon
+                        name="radio-button-unchecked"
+                        size={24}
+                        style={{}}
+                      />
+                    </View>
+                    <Text
+                      letterSpacing="0.15px"
+                      lineHeight="24px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 16,
+                          "fontWeight": "700",
+                          "textTransform": "uppercase",
+                        }
+                      }
+                    >
+                      SHAPE
+                    </Text>
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <RNSScreenStackHeaderConfig
+            backButtonInCustomView={false}
+            backTitleVisible={true}
+            backgroundColor="rgb(255, 255, 255)"
+            color="rgb(0, 122, 255)"
+            direction="ltr"
+            disableBackButtonMenu={false}
+            hidden={false}
+            hideBackButton={false}
+            largeTitleHideShadow={false}
+            title="LOCATION_DASHBOARD"
+            titleColor="rgb(28, 28, 30)"
+            topInsetEnabled={false}
+            translucent={false}
+          />
+        </RNSScreen>
+      </RNSScreenStack>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
@@ -1,0 +1,7091 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenStack
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          nativeBackButtonDismissalEnabled={false}
+          onAppear={[Function]}
+          onDisappear={[Function]}
+          onDismissed={[Function]}
+          onGestureCancel={[Function]}
+          onHeaderBackButtonClicked={[Function]}
+          onNativeDismissCancelled={[Function]}
+          onTransitionProgress={[Function]}
+          onWillDisappear={[Function]}
+          replaceAnimation="push"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          stackPresentation="push"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          swipeDirection="horizontal"
+        >
+          <View
+            accessibilityElementsHidden={false}
+            importantForAccessibility="auto"
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "column-reverse",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <RCTScrollView
+                contentContainerStyle={
+                  [
+                    {},
+                    {
+                      "dataSet": {},
+                    },
+                    {},
+                  ]
+                }
+                dataSet={{}}
+                style={
+                  {
+                    "backgroundColor": "#E0E0E0",
+                  }
+                }
+              >
+                <View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#FFFFFF",
+                            "paddingHorizontal": 16,
+                            "paddingVertical": 12,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#1A202C",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        Soil Surface
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        />
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Vertical Cracks
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "height": 16,
+                      }
+                    }
+                  />
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "row",
+                        },
+                        {
+                          "backgroundColor": "#FFFFFF",
+                          "justifyContent": "space-between",
+                          "paddingHorizontal": 16,
+                          "paddingVertical": 12,
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      lineHeight="32px"
+                      style={
+                        {
+                          "color": "#1A202C",
+                          "fontSize": 20,
+                          "fontWeight": "500",
+                        }
+                      }
+                    >
+                      Soil Pit
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "justifyContent": "space-between",
+                            "paddingHorizontal": 12,
+                            "paddingVertical": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        0–10cm
+                      </Text>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "borderRadius": 4,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 4,
+                              "paddingLeft": 4,
+                              "paddingRight": 4,
+                              "paddingTop": 4,
+                            }
+                          }
+                        >
+                          <Icon
+                            color="#FFFFFF"
+                            name="more-vert"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                      </View>
+                      <RCTScrollView>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                    "marginBottom": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                lineHeight="32px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 20,
+                                    "fontWeight": "500",
+                                  }
+                                }
+                              >
+                                0–10cm
+                              </Text>
+                              <View
+                                style={
+                                  {
+                                    "flex": 1,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#EEEEEE",
+                                    "borderRadius": 9999,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 16,
+                                  }
+                                }
+                              >
+                                <Icon
+                                  color="#1A202C"
+                                  name="close"
+                                  size={24}
+                                  style={{}}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "marginBottom": 23,
+                                    "marginHorizontal": 15,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "column",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                      "rowGap": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilTextureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Texture (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilColorEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Color (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilStructureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Structure (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="carbonatesEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Carbonates
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="phEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    pH
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="electricalConductivityEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Electrical Conductivity
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="soilOrganicCarbonMatterEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SOC/SOM
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="sodiumAdsorptionRatioEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SAR
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="checkbox"
+                                  accessibilityState={
+                                    {
+                                      "checked": false,
+                                      "disabled": false,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "text": "off",
+                                    }
+                                  }
+                                  accessible={true}
+                                  pointerEvents="auto"
+                                >
+                                  <RNCCheckbox
+                                    forwardedRef={null}
+                                    name="applyToAll"
+                                    onValueChange={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                          "height": 32,
+                                          "width": 32,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    value={false}
+                                  />
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "backgroundColor": undefined,
+                                        "color": "#1A202C",
+                                        "fontFamily": undefined,
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0.15,
+                                        "lineHeight": 24,
+                                        "textDecorationLine": undefined,
+                                      }
+                                    }
+                                  >
+                                    Apply to all intervals
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "justifyContent": "flex-end",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flex": 1,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#028843",
+                                        "borderRadius": 4,
+                                        "flex": 1,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": "auto",
+                                        "marginRight": "auto",
+                                        "paddingBottom": 8,
+                                        "paddingLeft": 22,
+                                        "paddingRight": 22,
+                                        "paddingTop": 8,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                      test={true}
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      >
+                                        <Text
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "backgroundColor": undefined,
+                                              "color": "#fafafa",
+                                              "fontFamily": undefined,
+                                              "fontSize": 15,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0.46,
+                                              "lineHeight": 26,
+                                              "textDecorationLine": undefined,
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Save
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Texture
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Rock Fragment
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Color
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Structure
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "justifyContent": "space-between",
+                            "paddingHorizontal": 12,
+                            "paddingVertical": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        10–20cm
+                      </Text>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "borderRadius": 4,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 4,
+                              "paddingLeft": 4,
+                              "paddingRight": 4,
+                              "paddingTop": 4,
+                            }
+                          }
+                        >
+                          <Icon
+                            color="#FFFFFF"
+                            name="more-vert"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                      </View>
+                      <RCTScrollView>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                    "marginBottom": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                lineHeight="32px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 20,
+                                    "fontWeight": "500",
+                                  }
+                                }
+                              >
+                                10–20cm
+                              </Text>
+                              <View
+                                style={
+                                  {
+                                    "flex": 1,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#EEEEEE",
+                                    "borderRadius": 9999,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 16,
+                                  }
+                                }
+                              >
+                                <Icon
+                                  color="#1A202C"
+                                  name="close"
+                                  size={24}
+                                  style={{}}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "marginBottom": 23,
+                                    "marginHorizontal": 15,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "column",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                      "rowGap": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilTextureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Texture (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilColorEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Color (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilStructureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Structure (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="carbonatesEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Carbonates
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="phEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    pH
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="electricalConductivityEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Electrical Conductivity
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="soilOrganicCarbonMatterEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SOC/SOM
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="sodiumAdsorptionRatioEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SAR
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="checkbox"
+                                  accessibilityState={
+                                    {
+                                      "checked": false,
+                                      "disabled": false,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "text": "off",
+                                    }
+                                  }
+                                  accessible={true}
+                                  pointerEvents="auto"
+                                >
+                                  <RNCCheckbox
+                                    forwardedRef={null}
+                                    name="applyToAll"
+                                    onValueChange={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                          "height": 32,
+                                          "width": 32,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    value={false}
+                                  />
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "backgroundColor": undefined,
+                                        "color": "#1A202C",
+                                        "fontFamily": undefined,
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0.15,
+                                        "lineHeight": 24,
+                                        "textDecorationLine": undefined,
+                                      }
+                                    }
+                                  >
+                                    Apply to all intervals
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "justifyContent": "flex-end",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flex": 1,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#028843",
+                                        "borderRadius": 4,
+                                        "flex": 1,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": "auto",
+                                        "marginRight": "auto",
+                                        "paddingBottom": 8,
+                                        "paddingLeft": 22,
+                                        "paddingRight": 22,
+                                        "paddingTop": 8,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                      test={true}
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      >
+                                        <Text
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "backgroundColor": undefined,
+                                              "color": "#fafafa",
+                                              "fontFamily": undefined,
+                                              "fontSize": 15,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0.46,
+                                              "lineHeight": 26,
+                                              "textDecorationLine": undefined,
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Save
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Texture
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Rock Fragment
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Color
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Structure
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "justifyContent": "space-between",
+                            "paddingHorizontal": 12,
+                            "paddingVertical": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        20–50cm
+                      </Text>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "borderRadius": 4,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 4,
+                              "paddingLeft": 4,
+                              "paddingRight": 4,
+                              "paddingTop": 4,
+                            }
+                          }
+                        >
+                          <Icon
+                            color="#FFFFFF"
+                            name="more-vert"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                      </View>
+                      <RCTScrollView>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                    "marginBottom": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                lineHeight="32px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 20,
+                                    "fontWeight": "500",
+                                  }
+                                }
+                              >
+                                20–50cm
+                              </Text>
+                              <View
+                                style={
+                                  {
+                                    "flex": 1,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#EEEEEE",
+                                    "borderRadius": 9999,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 16,
+                                  }
+                                }
+                              >
+                                <Icon
+                                  color="#1A202C"
+                                  name="close"
+                                  size={24}
+                                  style={{}}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "marginBottom": 23,
+                                    "marginHorizontal": 15,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "column",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                      "rowGap": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilTextureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Texture (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilColorEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Color (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilStructureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Structure (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="carbonatesEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Carbonates
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="phEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    pH
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="electricalConductivityEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Electrical Conductivity
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="soilOrganicCarbonMatterEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SOC/SOM
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="sodiumAdsorptionRatioEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SAR
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="checkbox"
+                                  accessibilityState={
+                                    {
+                                      "checked": false,
+                                      "disabled": false,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "text": "off",
+                                    }
+                                  }
+                                  accessible={true}
+                                  pointerEvents="auto"
+                                >
+                                  <RNCCheckbox
+                                    forwardedRef={null}
+                                    name="applyToAll"
+                                    onValueChange={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                          "height": 32,
+                                          "width": 32,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    value={false}
+                                  />
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "backgroundColor": undefined,
+                                        "color": "#1A202C",
+                                        "fontFamily": undefined,
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0.15,
+                                        "lineHeight": 24,
+                                        "textDecorationLine": undefined,
+                                      }
+                                    }
+                                  >
+                                    Apply to all intervals
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "justifyContent": "flex-end",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flex": 1,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#028843",
+                                        "borderRadius": 4,
+                                        "flex": 1,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": "auto",
+                                        "marginRight": "auto",
+                                        "paddingBottom": 8,
+                                        "paddingLeft": 22,
+                                        "paddingRight": 22,
+                                        "paddingTop": 8,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                      test={true}
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      >
+                                        <Text
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "backgroundColor": undefined,
+                                              "color": "#fafafa",
+                                              "fontFamily": undefined,
+                                              "fontSize": 15,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0.46,
+                                              "lineHeight": 26,
+                                              "textDecorationLine": undefined,
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Save
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Texture
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Rock Fragment
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Color
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Structure
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "justifyContent": "space-between",
+                            "paddingHorizontal": 12,
+                            "paddingVertical": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        50–70cm
+                      </Text>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "borderRadius": 4,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 4,
+                              "paddingLeft": 4,
+                              "paddingRight": 4,
+                              "paddingTop": 4,
+                            }
+                          }
+                        >
+                          <Icon
+                            color="#FFFFFF"
+                            name="more-vert"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                      </View>
+                      <RCTScrollView>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                    "marginBottom": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                lineHeight="32px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 20,
+                                    "fontWeight": "500",
+                                  }
+                                }
+                              >
+                                50–70cm
+                              </Text>
+                              <View
+                                style={
+                                  {
+                                    "flex": 1,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#EEEEEE",
+                                    "borderRadius": 9999,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 16,
+                                  }
+                                }
+                              >
+                                <Icon
+                                  color="#1A202C"
+                                  name="close"
+                                  size={24}
+                                  style={{}}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "marginBottom": 23,
+                                    "marginHorizontal": 15,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "column",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                      "rowGap": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilTextureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Texture (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilColorEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Color (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilStructureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Structure (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="carbonatesEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Carbonates
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="phEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    pH
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="electricalConductivityEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Electrical Conductivity
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="soilOrganicCarbonMatterEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SOC/SOM
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="sodiumAdsorptionRatioEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SAR
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="checkbox"
+                                  accessibilityState={
+                                    {
+                                      "checked": false,
+                                      "disabled": false,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "text": "off",
+                                    }
+                                  }
+                                  accessible={true}
+                                  pointerEvents="auto"
+                                >
+                                  <RNCCheckbox
+                                    forwardedRef={null}
+                                    name="applyToAll"
+                                    onValueChange={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                          "height": 32,
+                                          "width": 32,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    value={false}
+                                  />
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "backgroundColor": undefined,
+                                        "color": "#1A202C",
+                                        "fontFamily": undefined,
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0.15,
+                                        "lineHeight": 24,
+                                        "textDecorationLine": undefined,
+                                      }
+                                    }
+                                  >
+                                    Apply to all intervals
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "justifyContent": "flex-end",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flex": 1,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#028843",
+                                        "borderRadius": 4,
+                                        "flex": 1,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": "auto",
+                                        "marginRight": "auto",
+                                        "paddingBottom": 8,
+                                        "paddingLeft": 22,
+                                        "paddingRight": 22,
+                                        "paddingTop": 8,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                      test={true}
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      >
+                                        <Text
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "backgroundColor": undefined,
+                                              "color": "#fafafa",
+                                              "fontFamily": undefined,
+                                              "fontSize": 15,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0.46,
+                                              "lineHeight": 26,
+                                              "textDecorationLine": undefined,
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Save
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Texture
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Rock Fragment
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Color
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Structure
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "justifyContent": "space-between",
+                            "paddingHorizontal": 12,
+                            "paddingVertical": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        70–100cm
+                      </Text>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "borderRadius": 4,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 4,
+                              "paddingLeft": 4,
+                              "paddingRight": 4,
+                              "paddingTop": 4,
+                            }
+                          }
+                        >
+                          <Icon
+                            color="#FFFFFF"
+                            name="more-vert"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                      </View>
+                      <RCTScrollView>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                    "marginBottom": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                lineHeight="32px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 20,
+                                    "fontWeight": "500",
+                                  }
+                                }
+                              >
+                                70–100cm
+                              </Text>
+                              <View
+                                style={
+                                  {
+                                    "flex": 1,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#EEEEEE",
+                                    "borderRadius": 9999,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 16,
+                                  }
+                                }
+                              >
+                                <Icon
+                                  color="#1A202C"
+                                  name="close"
+                                  size={24}
+                                  style={{}}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "marginBottom": 23,
+                                    "marginHorizontal": 15,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "column",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                      "rowGap": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilTextureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Texture (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilColorEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Color (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilStructureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Structure (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="carbonatesEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Carbonates
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="phEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    pH
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="electricalConductivityEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Electrical Conductivity
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="soilOrganicCarbonMatterEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SOC/SOM
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="sodiumAdsorptionRatioEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SAR
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="checkbox"
+                                  accessibilityState={
+                                    {
+                                      "checked": false,
+                                      "disabled": false,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "text": "off",
+                                    }
+                                  }
+                                  accessible={true}
+                                  pointerEvents="auto"
+                                >
+                                  <RNCCheckbox
+                                    forwardedRef={null}
+                                    name="applyToAll"
+                                    onValueChange={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                          "height": 32,
+                                          "width": 32,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    value={false}
+                                  />
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "backgroundColor": undefined,
+                                        "color": "#1A202C",
+                                        "fontFamily": undefined,
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0.15,
+                                        "lineHeight": 24,
+                                        "textDecorationLine": undefined,
+                                      }
+                                    }
+                                  >
+                                    Apply to all intervals
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "justifyContent": "flex-end",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flex": 1,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#028843",
+                                        "borderRadius": 4,
+                                        "flex": 1,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": "auto",
+                                        "marginRight": "auto",
+                                        "paddingBottom": 8,
+                                        "paddingLeft": 22,
+                                        "paddingRight": 22,
+                                        "paddingTop": 8,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                      test={true}
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      >
+                                        <Text
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "backgroundColor": undefined,
+                                              "color": "#fafafa",
+                                              "fontFamily": undefined,
+                                              "fontSize": 15,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0.46,
+                                              "lineHeight": 26,
+                                              "textDecorationLine": undefined,
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Save
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Texture
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Rock Fragment
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Color
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Structure
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "column",
+                        },
+                        {
+                          "rowGap": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                          },
+                          {
+                            "backgroundColor": "#00582B",
+                            "justifyContent": "space-between",
+                            "paddingHorizontal": 12,
+                            "paddingVertical": 8,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        lineHeight="32px"
+                        style={
+                          {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "500",
+                          }
+                        }
+                      >
+                        100–200cm
+                      </Text>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          colorScheme="primary"
+                          dataSet={{}}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "borderRadius": 4,
+                              "flexDirection": "row",
+                              "justifyContent": "center",
+                              "paddingBottom": 4,
+                              "paddingLeft": 4,
+                              "paddingRight": 4,
+                              "paddingTop": 4,
+                            }
+                          }
+                        >
+                          <Icon
+                            color="#FFFFFF"
+                            name="more-vert"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                      </View>
+                      <RCTScrollView>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexDirection": "column",
+                                },
+                                {
+                                  "padding": 16,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                    "marginBottom": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                lineHeight="32px"
+                                style={
+                                  {
+                                    "color": "#1A202C",
+                                    "fontSize": 20,
+                                    "fontWeight": "500",
+                                  }
+                                }
+                              >
+                                100–200cm
+                              </Text>
+                              <View
+                                style={
+                                  {
+                                    "flex": 1,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                colorScheme="primary"
+                                dataSet={{}}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#EEEEEE",
+                                    "borderRadius": 9999,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 16,
+                                  }
+                                }
+                              >
+                                <Icon
+                                  color="#1A202C"
+                                  name="close"
+                                  size={24}
+                                  style={{}}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                  },
+                                  {
+                                    "marginBottom": 23,
+                                    "marginHorizontal": 15,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "column",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                      "rowGap": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilTextureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Texture (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilColorEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Color (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={true}
+                                    name="soilStructureEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={true}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#9EA8AB",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Structure (required)
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="carbonatesEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Carbonates
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="phEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    pH
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="electricalConductivityEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    Electrical Conductivity
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="soilOrganicCarbonMatterEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SOC/SOM
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {
+                                        "justifyContent": "flex-start",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <RCTSwitch
+                                    accessibilityRole="switch"
+                                    disabled={false}
+                                    name="sodiumAdsorptionRatioEnabled"
+                                    onChange={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "height": 31,
+                                        "width": 51,
+                                      }
+                                    }
+                                    value={false}
+                                  />
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#1A202C",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                      }
+                                    }
+                                  >
+                                    SAR
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "marginBottom": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  accessibilityRole="checkbox"
+                                  accessibilityState={
+                                    {
+                                      "checked": false,
+                                      "disabled": false,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "text": "off",
+                                    }
+                                  }
+                                  accessible={true}
+                                  pointerEvents="auto"
+                                >
+                                  <RNCCheckbox
+                                    forwardedRef={null}
+                                    name="applyToAll"
+                                    onValueChange={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "backgroundColor": "transparent",
+                                          "height": 32,
+                                          "width": 32,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    value={false}
+                                  />
+                                </View>
+                                <View
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "flexDirection": "row",
+                                      "justifyContent": "flex-start",
+                                      "marginBottom": 4,
+                                      "marginTop": 4,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    dataSet={{}}
+                                    style={
+                                      {
+                                        "backgroundColor": undefined,
+                                        "color": "#1A202C",
+                                        "fontFamily": undefined,
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0.15,
+                                        "lineHeight": 24,
+                                        "textDecorationLine": undefined,
+                                      }
+                                    }
+                                  >
+                                    Apply to all intervals
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "flexDirection": "row",
+                                    },
+                                    {
+                                      "justifyContent": "flex-end",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flex": 1,
+                                    }
+                                  }
+                                />
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#028843",
+                                        "borderRadius": 4,
+                                        "flex": 1,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": "auto",
+                                        "marginRight": "auto",
+                                        "paddingBottom": 8,
+                                        "paddingLeft": 22,
+                                        "paddingRight": 22,
+                                        "paddingTop": 8,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      dataSet={{}}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                      test={true}
+                                    >
+                                      <View
+                                        dataSet={{}}
+                                        style={{}}
+                                      >
+                                        <Text
+                                          dataSet={{}}
+                                          style={
+                                            {
+                                              "backgroundColor": undefined,
+                                              "color": "#fafafa",
+                                              "fontFamily": undefined,
+                                              "fontSize": 15,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0.46,
+                                              "lineHeight": 26,
+                                              "textDecorationLine": undefined,
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Save
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </RCTScrollView>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Texture
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Rock Fragment
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Color
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "padding": 15,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "width": 37,
+                            }
+                          }
+                        >
+                          <Icon
+                            name="radio-button-unchecked"
+                            size={24}
+                            style={{}}
+                          />
+                        </View>
+                        <Text
+                          letterSpacing="0.15px"
+                          lineHeight="24px"
+                          style={
+                            {
+                              "color": "#1A202C",
+                              "fontSize": 16,
+                              "fontWeight": "700",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                          Structure
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                            }
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </RCTScrollView>
+            </View>
+          </View>
+          <RNSScreenStackHeaderConfig
+            backButtonInCustomView={false}
+            backTitleVisible={true}
+            backgroundColor="rgb(255, 255, 255)"
+            color="rgb(0, 122, 255)"
+            direction="ltr"
+            disableBackButtonMenu={false}
+            hidden={false}
+            hideBackButton={false}
+            largeTitleHideShadow={false}
+            title="LOCATION_DASHBOARD"
+            titleColor="rgb(28, 28, 30)"
+            topInsetEnabled={false}
+            translucent={false}
+          />
+        </RNSScreen>
+      </RNSScreenStack>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+</RNCSafeAreaProvider>
+`;

--- a/dev-client/babel.config.js
+++ b/dev-client/babel.config.js
@@ -2,7 +2,7 @@ module.exports = api => {
   api.cache(true);
 
   return {
-    presets: ['module:@react-native/babel-preset'],
+    presets: ['babel-preset-expo', '@babel/preset-typescript'],
     plugins: [
       [
         'babel-plugin-root-import',

--- a/dev-client/jest/data.ts
+++ b/dev-client/jest/data.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {AppState} from 'terraso-mobile-client/store';
+
+export const testState: Partial<AppState> = {
+  account: {
+    currentUser: {
+      data: {
+        id: '1',
+        email: 'test@domain.com',
+        firstName: 'firstname',
+        lastName: 'lastname',
+        profileImage: '',
+        preferences: {},
+      },
+      fetching: false,
+    },
+    users: {
+      '1': {
+        id: '1',
+        email: 'test@domain.com',
+        firstName: 'firstname',
+        lastName: 'lastname',
+        profileImage: '',
+        preferences: {},
+      },
+    },
+  } as any,
+  site: {
+    sites: {
+      '1': {
+        id: '1',
+        name: '1',
+        latitude: 1,
+        longitude: 1,
+        privacy: 'PRIVATE',
+        archived: false,
+        updatedAt: '',
+        notes: {},
+        projectId: '1',
+      },
+    },
+  },
+  project: {
+    projects: {
+      '1': {
+        id: '1',
+        name: '1',
+        privacy: 'PRIVATE',
+        archived: false,
+        updatedAt: '',
+        measurementUnits: 'METRIC',
+        description: 'desc',
+        memberships: {},
+        sites: {'1': true},
+      },
+    },
+  },
+};

--- a/dev-client/jest/setup.ts
+++ b/dev-client/jest/setup.ts
@@ -20,7 +20,7 @@ import 'terraso-mobile-client/translations';
 import 'react-native-gesture-handler/jestSetup';
 import {setAPIConfig} from 'terraso-client-shared/config';
 
-// include this section and the NativeAnimatedHelper section for mocking react-native-reanimated
+// the next 3 jest calls are to get animated components to work in tests
 jest.mock('react-native-reanimated', () => {
   const Reanimated = require('react-native-reanimated/mock');
 
@@ -30,12 +30,20 @@ jest.mock('react-native-reanimated', () => {
 
   return Reanimated;
 });
-
-// Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
+jest.useFakeTimers();
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 
-jest.mock('@gorhom/bottom-sheet', () => 'BottomSheet');
-jest.mock('@rnmapbox/maps', () => 'Mapbox');
+// nanoid is a randomness source used by react navigation, here we are
+// setting it to a stable value to get stable snapshot tests
+jest.mock('nanoid/non-secure', () => ({nanoid: () => 'stable-nanoid-id'}));
+
+jest.mock('@gorhom/bottom-sheet', () => require('@gorhom/bottom-sheet/mock'));
+
+jest.mock('@expo/vector-icons/MaterialIcons', () => 'Icon');
+
+jest.mock('terraso-mobile-client/config', () => ({
+  APP_CONFIG: {},
+}));
 
 let mmkvMock = require('react-native-mmkv-storage/jest/dist/jest/memoryStore.js');
 mmkvMock.mock(); // Mock the storage

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -82,6 +82,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
+        "jest-expo": "^50.0.4",
         "prettier": "^3.2.5",
         "react-devtools": "^5.1.0",
         "react-native-svg-transformer": "^1.3.0",
@@ -10325,6 +10326,15 @@
         }
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -10687,6 +10697,17 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -10771,6 +10792,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -11211,6 +11238,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -11243,6 +11277,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
       }
     },
     "node_modules/acorn-jsx": {
@@ -13319,6 +13363,30 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -13328,6 +13396,54 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
       "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -13410,6 +13526,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -13929,6 +14051,28 @@
         }
       ]
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -14329,6 +14473,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -16506,6 +16671,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -16547,6 +16724,20 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/http2-wrapper": {
@@ -16607,6 +16798,18 @@
       ],
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -17211,6 +17414,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
     },
     "node_modules/is-redirect": {
       "version": "1.0.0",
@@ -18112,6 +18321,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -18126,6 +18362,75 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo": {
+      "version": "50.0.4",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-50.0.4.tgz",
+      "integrity": "sha512-qtCqtdGaQtEcA3vc6UPN5Xn78jAyoBJj6Pxpk2raizdwI7carsg9Us9Wc+D4kl+7+ffhBMeS3cYWeJqVIZl1pA==",
+      "dev": true,
+      "dependencies": {
+        "@expo/config": "~8.5.0",
+        "@expo/json-file": "^8.2.37",
+        "@jest/create-cache-key-function": "^29.2.1",
+        "babel-jest": "^29.2.1",
+        "find-up": "^5.0.0",
+        "jest-environment-jsdom": "^29.2.1",
+        "jest-watch-select-projects": "^2.0.0",
+        "jest-watch-typeahead": "2.2.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.19",
+        "react-test-renderer": "18.2.0",
+        "stacktrace-js": "^2.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      }
+    },
+    "node_modules/jest-expo/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-expo/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-expo/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-get-type": {
@@ -18994,6 +19299,251 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-watch-select-projects": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz",
+      "integrity": "sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^3.0.0",
+        "prompts": "^2.2.1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-watch-select-projects/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz",
+      "integrity": "sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-watcher": "^29.0.0",
+        "slash": "^5.0.0",
+        "string-length": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0 || ^28.0.0 || ^29.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/char-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+      "integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-watch-typeahead/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+      "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^2.0.0",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
@@ -19277,6 +19827,120 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -21346,6 +22010,12 @@
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.9.tgz",
+      "integrity": "sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==",
+      "dev": true
+    },
     "node_modules/ob1": {
       "version": "0.80.8",
       "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.8.tgz",
@@ -21842,6 +22512,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -22193,6 +22875,12 @@
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -22272,6 +22960,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -23400,6 +24094,12 @@
         "path-parse": "^1.0.5"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/reselect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
@@ -23606,10 +24306,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "node_modules/sax": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -24007,6 +24725,15 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.2.tgz",
       "integrity": "sha512-tPwQ3c1rLIwbJpq59duoznegEbmgfV630C2n4R4G96LKBFljgK8j+O9AxjqB6cAzu4gE7s4pByrLWtZel8E+Mg=="
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -24030,6 +24757,36 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dev": true,
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.10",
@@ -24478,6 +25235,12 @@
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "node_modules/synckit": {
@@ -24968,6 +25731,30 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -25419,6 +26206,16 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha512-EGXjXJZhIHiQMK2pQukuFcL303nskqIRzWvPvV5O8miOfwoUb9G+a/Cld60kUyeaybEI94wvVClT10DtfeAExA=="
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -25540,6 +26337,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -25566,10 +26375,31 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -25870,6 +26700,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -25897,6 +26736,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -90,6 +90,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
+    "jest-expo": "^50.0.4",
     "prettier": "^3.2.5",
     "react-devtools": "^5.1.0",
     "react-native-svg-transformer": "^1.3.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -99,18 +99,20 @@
     "typescript": "^5.4.5"
   },
   "jest": {
-    "preset": "react-native",
+    "preset": "jest-expo",
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect",
+      "@rnmapbox/maps/setup-jest",
       "./node_modules/react-native-mmkv-storage/jest/mmkvJestSetup.js",
       "<rootDir>/jest/setup.ts"
     ],
     "moduleNameMapper": {
       "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.ts",
-      "^@testing/(.*)": "<rootDir>/jest/$1"
+      "^@testing/(.*)": "<rootDir>/jest/$1",
+      "^terraso-mobile-client/(.*)": "<rootDir>/src/$1"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(react-native|@react-native|react-native-cookies|uuid|react-native-mmkv-storage|react-native-autocomplete-input)/)"
+      "node_modules/(?!(react-native|@react-native|react-native-cookies|uuid|react-native-mmkv-storage|react-native-autocomplete-input|expo(nent)?|@expo(nent)?/.*)|expo-constants|@rnmapbox/)"
     ]
   },
   "expo": {


### PR DESCRIPTION
## Description
Adds a number of snapshot tests of screens, and sets them up to run in CI. I'd appreciate feedback from people if this is mergeable as is, and then can be iterated on in further PRs, or if we'd like to see more progress before merging this.

Basically what's happened here is I've set up a render hook which can accept an initial state for the redux store and a route name, and found a way to get the house of cards of jest mocks for our dependencies to produce reasonable snapshot results. I then fudged around with the implementation files to confirm the snapshots also fudge in the same way. There's many many dimensions for future improvement (testing more screens, testing screens for different sets of data loaded, interacting with screens, coverage statistics, etc) but I wanted to check in if this is making sense for people.

This is a bit of a pivot from my original plan for integration testing, which was to use detox to set up screenshot testing. I ended up getting stuck on that again, and decided to go with this method. It provides less comprehensive/more granular coverage and won't be able to catch e.g. platform bugs, but it is simpler and more robust and most importantly actually works!

I rebased my first native base migration PR on this and it gave me some useful feedback and didn't totally crap out so yay!

One screen I haven't been able to get working with this is the home screen :/ I think the offending component is the `BottomSheetFlatList`, which is pretty core so I don't want to stub it out. I'm also not sure how mocking the map will work, so I'm punting on that screen for now even though it is literally the home screen.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #1167 