### PR TITLE
feat: remove logout from bottom nav, rename home to sites

### DIFF
--- a/dev-client/src/navigation/navigators/BottomNavigator.tsx
+++ b/dev-client/src/navigation/navigators/BottomNavigator.tsx
@@ -35,7 +35,10 @@ export const BottomNavigator = memo(
       state => state.account.currentUser.data !== null,
     );
 
-    const onHome = useCallback(() => navigation.navigate('HOME'), [navigation]);
+    const onSites = useCallback(
+      () => navigation.navigate('HOME'),
+      [navigation],
+    );
 
     const onProject = useCallback(
       () => navigation.navigate('PROJECT_LIST'),
@@ -57,8 +60,8 @@ export const BottomNavigator = memo(
       <Row bg="primary.main" justifyContent="center" space={10} pb={2}>
         <BottomNavIconButton
           name="location-pin"
-          label={t('bottom_navigation.home')}
-          onPress={onHome}
+          label={t('bottom_navigation.sites')}
+          onPress={onSites}
         />
         <BottomNavIconButton
           name="work"

--- a/dev-client/src/navigation/navigators/BottomNavigator.tsx
+++ b/dev-client/src/navigation/navigators/BottomNavigator.tsx
@@ -23,7 +23,6 @@ import {BottomTabsParamList} from 'terraso-mobile-client/navigation/types';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {NavigationHelpers} from '@react-navigation/native';
 import {Row} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {LogoutModal} from 'terraso-mobile-client/components/modals/LogoutModal';
 
 export const BottomTabs = createBottomTabNavigator<BottomTabsParamList>();
 

--- a/dev-client/src/navigation/navigators/BottomNavigator.tsx
+++ b/dev-client/src/navigation/navigators/BottomNavigator.tsx
@@ -70,15 +70,6 @@ export const BottomNavigator = memo(
           label={t('bottom_navigation.settings')}
           onPress={onSettings}
         />
-        <LogoutModal
-          trigger={onOpen => (
-            <BottomNavIconButton
-              name="logout"
-              label={t('bottom_navigation.sign_out')}
-              onPress={onOpen}
-            />
-          )}
-        />
       </Row>
     );
   },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -383,7 +383,7 @@
     }
   },
   "bottom_navigation": {
-    "home": "Home",
+    "sites": "Sites",
     "projects": "Projects",
     "settings": "Settings"
   },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -385,8 +385,7 @@
   "bottom_navigation": {
     "home": "Home",
     "projects": "Projects",
-    "settings": "Settings",
-    "sign_out": "Sign Out"
+    "settings": "Settings"
   },
   "geo": {
     "latitude": {


### PR DESCRIPTION
## Description

Remove the logout button from the bottom navigator, as it is being replaced with the settings screen in https://github.com/techmatters/terraso-mobile-client/pull/1235. Change the 'home' navigation option to 'sites'. Note that the sites screen is still internally called the 'home' screen; I decided that this was too heavyweight of a refactor to handle in this PR. (Issue #1236 has been created to handle this cleanup when we have capacity).

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #1224 

### Verification steps

Open application and verify contents of bottom navigator.