### PR TITLE
fix: use snake_case for additional i18n keys

### DIFF
--- a/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
@@ -187,7 +187,7 @@ export default function ProjectForm({
   });
 
   const EditHeader = editForm ? (
-    <Heading size="sm">{t('projects.edit.inputHeader')}</Heading>
+    <Heading size="sm">{t('projects.edit.input_header')}</Heading>
   ) : (
     <></>
   );

--- a/dev-client/src/screens/SiteNotesScreen/components/SiteInstructionsCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/SiteInstructionsCard.tsx
@@ -51,7 +51,7 @@ export const SiteInstructionsCard = ({siteInstructions}: Props) => {
       <HStack>
         <Icon name="place" color="primary.dark" size="sm" mr={1} />
         <Text bold fontSize="md">
-          {t('site.notes.projectInstructions')}
+          {t('site.notes.project_instructions')}
         </Text>
       </HStack>
       <Text pt={1} fontSize="md" numberOfLines={3} ellipsizeMode="tail">

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/PhotoConditions.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/PhotoConditions.tsx
@@ -34,7 +34,7 @@ export const PhotoConditions = (props: SoilPitInputScreenProps) => {
         (['MOIST', 'DRY'] as const).map(condition => [
           condition,
           {
-            text: t(`soil.color.colorPhotoSoilCondition.${condition}`),
+            text: t(`soil.color.color_photo_soil_condition.${condition}`),
           },
         ]),
       ),
@@ -47,7 +47,7 @@ export const PhotoConditions = (props: SoilPitInputScreenProps) => {
         (['EVEN', 'UNEVEN'] as const).map(condition => [
           condition,
           {
-            text: t(`soil.color.colorPhotoLightingCondition.${condition}`),
+            text: t(`soil.color.color_photo_lighting_condition.${condition}`),
           },
         ]),
       ),

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -114,7 +114,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
         entries(FRAGMENT_IMAGES).map(([value, image]) => [
           value,
           {
-            label: t(`soil.texture.rockFragment.${value}`),
+            label: t(`soil.texture.rock_fragment.${value}`),
             image: <Image style={radioImage} source={image} />,
           },
         ]),

--- a/dev-client/src/screens/SoilScreen/components/RenderValues.tsx
+++ b/dev-client/src/screens/SoilScreen/components/RenderValues.tsx
@@ -54,7 +54,7 @@ export const pitMethodSummary = (
   if (method === 'soilTexture' && soilData.texture) {
     summary = t(`soil.texture.class.${soilData?.texture}`);
   } else if (method === 'rockFragmentVolume' && soilData.rockFragmentVolume) {
-    summary = t(`soil.texture.rockFragment.${soilData.rockFragmentVolume}`);
+    summary = t(`soil.texture.rock_fragment.${soilData.rockFragmentVolume}`);
   } else if (method === 'soilColor' && isColorComplete(soilData)) {
     summary = (
       <Row alignItems="center" space="sm">

--- a/dev-client/src/screens/Toasts.tsx
+++ b/dev-client/src/screens/Toasts.tsx
@@ -29,7 +29,7 @@ export const Toasts = () => {
   useEffect(() => {
     if (soilIdStatus === 'error') {
       toast.show({
-        description: t('errors.soilId'),
+        description: t('errors.generic'),
       });
       dispatch(setSoilIdStatus('ready'));
     }

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -93,7 +93,7 @@
       "confirm_removal_body": "This action cannot be undone.",
       "min_length_error": "Must be at least {{min}} characters",
       "placeholder_text": "Start typing your note…",
-      "projectInstructions": "Site Instructions"
+      "project_instructions": "Site Instructions"
     },
     "search": {
       "placeholder": "Search sites",
@@ -185,7 +185,7 @@
       }
     },
     "edit": {
-      "inputHeader": "General Project Settings"
+      "input_header": "General Project Settings"
     },
     "settings": {
       "copy_download_link": "Copy project download link",
@@ -336,7 +336,7 @@
     "proceed": "Proceed"
   },
   "errors": {
-    "soilId": "Error saving soil ID information."
+    "generic": "Error saving soil ID information."
   },
   "screens": {
     "HOME": "LandPKS",
@@ -545,7 +545,7 @@
         "SILTY_CLAY_LOAM": "Silty Clay Loam",
         "SILT_LOAM": "Silt Loam"
       },
-      "rockFragment": {
+      "rock_fragment": {
         "VOLUME_0_1": "0–1%",
         "VOLUME_1_15": "1–15%",
         "VOLUME_15_35": "15–35%",
@@ -629,11 +629,11 @@
       "use_photo_instead": "Don’t know the soil color values? Use a photo instead (guide included.)",
       "photo_need_help": "To use a photo to determine soil color, you’ll need a 3M Canary Yellow Post-it Note for color reference and a properly prepared soil sample. Need help? Use the step-by-step guide.",
       "use_guide_label": "Use Guide",
-      "colorPhotoSoilCondition": {
+      "color_photo_soil_condition": {
         "MOIST": "Moist",
         "DRY": "Dry"
       },
-      "colorPhotoLightingCondition": {
+      "color_photo_lighting_condition": {
         "EVEN": "Yes",
         "UNEVEN": "No"
       }


### PR DESCRIPTION
## Description
Use snake_case for additional i18n keys. Left in place for now, as these likely require code changes:
* sorting-related keys (*Asc, *Desc)
* soil.collection_method subkeys and soil.data subkeys