### PR TITLE
feat: add elevation to temporary site callout

### DIFF
--- a/dev-client/__tests__/context/GeospatialContext.test.tsx
+++ b/dev-client/__tests__/context/GeospatialContext.test.tsx
@@ -37,17 +37,22 @@ const TestComponent = ({mock}: Props) => {
   return <></>;
 };
 
-const USER_LOCATION = {latitude: 0, longitude: 0};
+const USER_LOCATION = {latitude: 0, longitude: 0, elevation: 0};
 
 const EXAMPLE_SITES = [
-  {id: 'Abidjan', latitude: 5.316667, longitude: -4.033333},
-  {id: 'Accra', latitude: 5.55, longitude: -0.2},
-  {id: 'Lomé', latitude: 6.131944, longitude: 1.222778},
-  {id: 'Porto Novo', latitude: 6.497222, longitude: 2.605},
-  {id: 'Lagos', latitude: 6.455027, longitude: 3.384082},
-  {id: 'Douala', latitude: 4.05, longitude: 9.7},
-  {id: 'Libreville', latitude: 0.390278, longitude: 9.454167},
-  {id: 'Luanda', latitude: -8.838333, longitude: 13.234444},
+  {id: 'Abidjan', latitude: 5.316667, longitude: -4.033333, elevation: 123.45},
+  {id: 'Accra', latitude: 5.55, longitude: -0.2, elevation: 123.45},
+  {id: 'Lomé', latitude: 6.131944, longitude: 1.222778, elevation: 123.45},
+  {id: 'Porto Novo', latitude: 6.497222, longitude: 2.605, elevation: 123.45},
+  {id: 'Lagos', latitude: 6.455027, longitude: 3.384082, elevation: 123.45},
+  {id: 'Douala', latitude: 4.05, longitude: 9.7, elevation: 123.45},
+  {
+    id: 'Libreville',
+    latitude: 0.390278,
+    longitude: 9.454167,
+    elevation: 123.45,
+  },
+  {id: 'Luanda', latitude: -8.838333, longitude: 13.234444, elevation: 123.45},
 ];
 
 const SORTED_EXAMPLE = [

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -455,7 +455,7 @@ exports[`renders correctly 1`] = `
                                   }
                                 }
                               >
-                                GPS accuracy: m
+                                GPS accuracy:  m
                               </Text>
                               <View
                                 dataSet={{}}

--- a/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -1218,7 +1218,7 @@ exports[`renders correctly 1`] = `
                                     <Text
                                       style={{}}
                                     >
-                                      1900 ft
+                                      1.00 m
                                     </Text>
                                   </Text>
                                   <Text
@@ -1539,10 +1539,11 @@ exports[`renders correctly 1`] = `
                                                 "letterSpacing": 0.4,
                                                 "lineHeight": 24,
                                                 "textDecorationLine": undefined,
+                                                "textTransform": "uppercase",
                                               }
                                             }
                                           >
-                                            EXPLORE THE DATA
+                                            Explore the data
                                           </Text>
                                         </View>
                                         <View

--- a/dev-client/jest/data.ts
+++ b/dev-client/jest/data.ts
@@ -48,6 +48,7 @@ export const testState: Partial<AppState> = {
         name: '1',
         latitude: 1,
         longitude: 1,
+        elevation: 1,
         privacy: 'PRIVATE',
         archived: false,
         updatedAt: '',

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -53,7 +53,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.2.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#0ce3830 ",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#3f45918 ",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25508,14 +25508,14 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#0ce3830d72cbff388f23706102543ed3b5348603",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#3f459181b30dfb17222e99a9f9527ab8b5f58916",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#66a3fbf",
+        "terraso-backend": "github:techmatters/terraso-backend#dbfbee5",
         "uuid": "^9.0.1"
       },
       "engines": {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -53,7 +53,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.2.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#805c2fb ",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#0ce3830 ",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25508,14 +25508,14 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#805c2fb4cef4b337585a55db4d7f973d2afece40",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#0ce3830d72cbff388f23706102543ed3b5348603",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#d50504f",
+        "terraso-backend": "github:techmatters/terraso-backend#66a3fbf",
         "uuid": "^9.0.1"
       },
       "engines": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.2.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#0ce3830 ",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#3f45918 ",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.2.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#805c2fb ",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#0ce3830 ",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/src/components/util/site.ts
+++ b/dev-client/src/components/util/site.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {TFunction} from 'i18next';
+
+export const renderElevation = (t: TFunction, elevation: number | undefined) =>
+  elevation
+    ? t('site.elevation_value', {value: elevation.toFixed(2), units: 'm'})
+    : t('site.elevation_unknown');

--- a/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
@@ -15,14 +15,15 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback} from 'react';
-import {Button, Divider} from 'native-base';
+import {useCallback, useMemo, useState} from 'react';
+import {Button, Divider, Spinner} from 'native-base';
 import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {useTranslation} from 'react-i18next';
 import {Card} from 'terraso-mobile-client/components/Card';
 import {CardCloseButton} from 'terraso-mobile-client/components/CardCloseButton';
 import {CalloutDetail} from 'terraso-mobile-client/screens/HomeScreen/components/CalloutDetail';
+import {getElevation} from 'terraso-mobile-client/services';
 import {
   Column,
   Row,
@@ -31,7 +32,6 @@ import {
 
 const TEMP_SOIL_ID_VALUE = 'Clifton';
 const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
-const TEMP_ELEVATION = '2800 feet';
 
 type Props = {
   coords: Coords;
@@ -41,6 +41,15 @@ type Props = {
 export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
+  const [siteElevation, setSiteElevation] = useState('');
+
+  useMemo(async () => {
+    const elevation = await getElevation(
+      parseFloat(coords.latitude.toFixed(5)),
+      parseFloat(coords.longitude.toFixed(5)),
+    );
+    setSiteElevation(t('site.elevation_value', {value: elevation, units: 'm'}));
+  }, [coords, t]);
 
   const onCreate = useCallback(() => {
     navigation.navigate('CREATE_SITE', {coords});
@@ -68,10 +77,14 @@ export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
           value={TEMP_ECO_SITE_PREDICTION.toUpperCase()}
         />
         <Divider />
-        <CalloutDetail
-          label={t('site.elevation').toUpperCase()}
-          value={TEMP_ELEVATION.toUpperCase()}
-        />
+        {siteElevation ? (
+          <CalloutDetail
+            label={t('site.elevation_label').toUpperCase()}
+            value={siteElevation}
+          />
+        ) : (
+          <Spinner size="sm" />
+        )}
         <Divider />
         <Row justifyContent="flex-end">
           <Button onPress={onCreate} size="sm" variant="outline">

--- a/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
@@ -29,6 +29,7 @@ import {
   Row,
   Box,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {renderElevation} from 'terraso-mobile-client/components/util/site';
 
 const TEMP_SOIL_ID_VALUE = 'Clifton';
 const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
@@ -48,7 +49,7 @@ export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
       parseFloat(coords.latitude.toFixed(5)),
       parseFloat(coords.longitude.toFixed(5)),
     );
-    setSiteElevation(t('site.elevation_value', {value: elevation, units: 'm'}));
+    setSiteElevation(renderElevation(t, elevation));
   }, [coords, t]);
 
   const onCreate = useCallback(() => {

--- a/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
@@ -42,14 +42,11 @@ type Props = {
 export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
-  const [siteElevation, setSiteElevation] = useState('');
+  const [siteElevationString, setSiteElevationString] = useState('');
 
   useMemo(async () => {
-    const elevation = await getElevation(
-      parseFloat(coords.latitude.toFixed(5)),
-      parseFloat(coords.longitude.toFixed(5)),
-    );
-    setSiteElevation(renderElevation(t, elevation));
+    const elevation = await getElevation(coords.latitude, coords.longitude);
+    setSiteElevationString(renderElevation(t, elevation));
   }, [coords, t]);
 
   const onCreate = useCallback(() => {
@@ -78,10 +75,10 @@ export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
           value={TEMP_ECO_SITE_PREDICTION.toUpperCase()}
         />
         <Divider />
-        {siteElevation ? (
+        {siteElevationString ? (
           <CalloutDetail
             label={t('site.elevation_label').toUpperCase()}
-            value={siteElevation}
+            value={siteElevationString}
           />
         ) : (
           <Spinner size="sm" />

--- a/dev-client/src/screens/SiteScreen/SiteScreen.tsx
+++ b/dev-client/src/screens/SiteScreen/SiteScreen.tsx
@@ -96,8 +96,11 @@ const LocationPrediction = ({
         <Text>{ecologicalSiteName}</Text>
       </Text>
 
-      <Button w="95%" rightIcon={<Icon name="chevron-right" />}>
-        {t('soil.explore_data').toUpperCase()}
+      <Button
+        w="95%"
+        _text={{textTransform: 'uppercase'}}
+        rightIcon={<Icon name="chevron-right" />}>
+        {t('soil.explore_data')}
       </Button>
     </Column>
   );

--- a/dev-client/src/screens/SiteScreen/SiteScreen.tsx
+++ b/dev-client/src/screens/SiteScreen/SiteScreen.tsx
@@ -41,14 +41,15 @@ import {
 
 import StackedBarChart from 'terraso-mobile-client/assets/stacked-bar.svg';
 import {PeopleBadge} from 'terraso-mobile-client/components/PeopleBadge';
+import {renderElevation} from 'terraso-mobile-client/components/util/site';
 
-const TEMP_ELEVATION = '1900 ft';
 const TEMP_SOIL_ID_VALUE = 'Clifton';
 const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
 
 type Props = {
   siteId?: string;
   coords?: Coords;
+  elevation?: number;
 };
 
 const LocationDetail = ({label, value}: {label: string; value: string}) => (
@@ -106,7 +107,7 @@ const LocationPrediction = ({
   );
 };
 
-export const SiteScreen = ({siteId, coords}: Props) => {
+export const SiteScreen = ({siteId, coords, elevation}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const onInfoPress = useInfoPress();
@@ -121,6 +122,9 @@ export const SiteScreen = ({siteId, coords}: Props) => {
   );
   if (coords === undefined) {
     coords = site!;
+  }
+  if (elevation === undefined) {
+    elevation = site!.elevation;
   }
   const project = useSelector(state =>
     site?.projectId === undefined
@@ -151,7 +155,7 @@ export const SiteScreen = ({siteId, coords}: Props) => {
         />
         <LocationDetail
           label={t('geo.elevation.title')}
-          value={TEMP_ELEVATION}
+          value={renderElevation(t, elevation)}
         />
         {!site && (
           <Box mt={5}>

--- a/dev-client/src/screens/SiteScreen/SiteScreen.tsx
+++ b/dev-client/src/screens/SiteScreen/SiteScreen.tsx
@@ -124,7 +124,7 @@ export const SiteScreen = ({siteId, coords, elevation}: Props) => {
     coords = site!;
   }
   if (elevation === undefined) {
-    elevation = site!.elevation;
+    elevation = site?.elevation;
   }
   const project = useSelector(state =>
     site?.projectId === undefined

--- a/dev-client/src/services.ts
+++ b/dev-client/src/services.ts
@@ -16,7 +16,7 @@
  */
 
 export const getElevation = async (lat: number, lng: number) => {
-  // TypeScript complains if the values passed to URLSearchParams are floats instead of strings
+  // TypeScript complains if the values passed to URLSearchParams are floats instead of strings.
   // This API uses X for longitude and Y for latitude. That's not a typo.
   const params = {
     x: lng.toString(),

--- a/dev-client/src/services.ts
+++ b/dev-client/src/services.ts
@@ -19,18 +19,19 @@ export const getElevation = async (
   lat: number,
   lng: number,
 ): Promise<number | undefined> => {
-  // TypeScript complains if the values passed to URLSearchParams are floats instead of strings.
-  // This API uses X for longitude and Y for latitude. That's not a typo.
-  const params = {
+  // 1. TypeScript requires values passed to URLSearchParams strings,
+  //    which is why we convert the floats to strings.
+  // 2. This API uses X for longitude and Y for latitude. That's not a typo.
+  const queryString = new URLSearchParams({
     x: lng.toString(),
     y: lat.toString(),
     units: 'Meters', // TODO: switch based on user preference
-  };
+  });
   let elevation;
 
   try {
     const response = await fetch(
-      `https://epqs.nationalmap.gov/v1/json/?${new URLSearchParams(params)}`,
+      `https://epqs.nationalmap.gov/v1/json/?${queryString}`,
     );
     const result = await response.json();
 

--- a/dev-client/src/services.ts
+++ b/dev-client/src/services.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+export const getElevation = async (lat: number, lng: number) => {
+  // TypeScript complains if the values passed to URLSearchParams are floats instead of strings
+  // This API uses X for longitude and Y for latitude. That's not a typo.
+  const params = {
+    x: lng.toString(),
+    y: lat.toString(),
+    units: 'Meters', // TODO: switch based on user preference
+  };
+  let elevation = 'unknown';
+
+  try {
+    const response = await fetch(
+      `https://epqs.nationalmap.gov/v1/json/?${new URLSearchParams(params)}`,
+    );
+    const result = await response.json();
+
+    elevation = parseFloat(result.value).toFixed(2);
+  } catch (error) {
+    console.error(error);
+  }
+  return elevation;
+};

--- a/dev-client/src/services.ts
+++ b/dev-client/src/services.ts
@@ -23,8 +23,8 @@ export const getElevation = async (
   //    which is why we convert the floats to strings.
   // 2. This API uses X for longitude and Y for latitude. That's not a typo.
   const queryString = new URLSearchParams({
-    x: lng.toString(),
-    y: lat.toString(),
+    x: lng.toFixed(5),
+    y: lat.toFixed(5),
     units: 'Meters', // TODO: switch based on user preference
   });
   let elevation;

--- a/dev-client/src/services.ts
+++ b/dev-client/src/services.ts
@@ -15,7 +15,10 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-export const getElevation = async (lat: number, lng: number) => {
+export const getElevation = async (
+  lat: number,
+  lng: number,
+): Promise<number | undefined> => {
   // TypeScript complains if the values passed to URLSearchParams are floats instead of strings.
   // This API uses X for longitude and Y for latitude. That's not a typo.
   const params = {
@@ -23,7 +26,7 @@ export const getElevation = async (lat: number, lng: number) => {
     y: lat.toString(),
     units: 'Meters', // TODO: switch based on user preference
   };
-  let elevation = 'unknown';
+  let elevation;
 
   try {
     const response = await fetch(
@@ -31,7 +34,7 @@ export const getElevation = async (lat: number, lng: number) => {
     );
     const result = await response.json();
 
-    elevation = parseFloat(result.value).toFixed(2);
+    elevation = parseFloat(result.value);
   } catch (error) {
     console.error(error);
   }

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -26,6 +26,7 @@
     "annual_precip_avg": "Annual precipitation avg",
     "elevation_label": "Elevation",
     "elevation_value": "{{value}} {{units}}",
+    "elevation_unknown": "unknown",
     "empty": {
       "info": "You don’t have any sites yet. A site lets you collect and save data, learn more about your land and its potential, and share with others.\n\n<bold>Use the map to create a site.</bold> There are three ways to use the map to find a location for a site:\n",
       "bullet_1": "Tap the map to drop a pin and get more information about that location.",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -25,6 +25,7 @@
     "ecological_site_prediction": "Ecological site prediction",
     "annual_precip_avg": "Annual precipitation avg",
     "elevation": "Elevation",
+    "elevation_value": "{{value}} {{units}}",
     "empty": {
       "info": "You don’t have any sites yet. A site lets you collect and save data, learn more about your land and its potential, and share with others.\n\n<bold>Use the map to create a site.</bold> There are three ways to use the map to find a location for a site:\n",
       "bullet_1": "Tap the map to drop a pin and get more information about that location.",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -24,7 +24,7 @@
     "soil_id_prediction": "Soil ID prediction",
     "ecological_site_prediction": "Ecological site prediction",
     "annual_precip_avg": "Annual precipitation avg",
-    "elevation": "Elevation",
+    "elevation_label": "Elevation",
     "elevation_value": "{{value}} {{units}}",
     "empty": {
       "info": "You don’t have any sites yet. A site lets you collect and save data, learn more about your land and its potential, and share with others.\n\n<bold>Use the map to create a site.</bold> There are three ways to use the map to find a location for a site:\n",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -41,7 +41,7 @@
       "manual": "Enter coordinates",
       "name_label": "Site Name",
       "location_label": "Site Location",
-      "location_accuracy": "GPS accuracy: {{accuracyM}}m",
+      "location_accuracy": "GPS accuracy: {{accuracyM}} m",
       "coords_label": "Latitude, Longitude",
       "coords_help": "Enter decimal degrees, with latitude and longitude separated by a comma.",
       "name_placeholder": "Site name",


### PR DESCRIPTION
## Description
Add elevation to temporary site callout. 
- Show spinner when it is loading.
- Show unknown on failure.
- Uses nationalmap.gov API