### PR TITLE
fix: Remove help button and "learn more" link from Projects screen

### DIFF
--- a/dev-client/src/components/ChipBadge.tsx
+++ b/dev-client/src/components/ChipBadge.tsx
@@ -15,12 +15,18 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {ChipBadge} from 'terraso-mobile-client/components/ChipBadge';
+import {Badge} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {Icon, IconName} from 'terraso-mobile-client/components/icons/Icon';
 
 type Props = {
   count: number;
+  iconName: IconName;
 };
 
-export const PeopleBadge = ({count}: Props) => {
-  return <ChipBadge count={count} iconName="people-alt" />;
+export const ChipBadge = ({count, iconName}: Props) => {
+  return (
+    <Badge variant="chip" startIcon={<Icon name={iconName} />}>
+      {count}
+    </Badge>
+  );
 };

--- a/dev-client/src/components/SiteBadge.tsx
+++ b/dev-client/src/components/SiteBadge.tsx
@@ -21,6 +21,6 @@ type Props = {
   count: number;
 };
 
-export const PeopleBadge = ({count}: Props) => {
-  return <ChipBadge count={count} iconName="people-alt" />;
+export const SiteBadge = ({count}: Props) => {
+  return <ChipBadge count={count} iconName="location-on" />;
 };

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -18,7 +18,6 @@
 import {useCallback, useMemo} from 'react';
 import {useSelector} from 'terraso-mobile-client/store';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
-import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useTranslation} from 'react-i18next';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -71,13 +70,7 @@ export const ProjectListScreen = () => {
   );
 
   return (
-    <ScreenScaffold
-      AppBar={
-        <AppBar
-          LeftButton={null}
-          RightButton={<AppBarIconButton name="help" />}
-        />
-      }>
+    <ScreenScaffold AppBar={<AppBar LeftButton={null} />}>
       <VStack
         bg="grey.200"
         p={5}

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -21,7 +21,7 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useTranslation} from 'react-i18next';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {Link, Spinner} from 'native-base';
+import {Spinner} from 'native-base';
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
 import {
   ListFilterModal,
@@ -92,9 +92,6 @@ export const ProjectListScreen = () => {
             <>
               <Text variant="body1-strong">{t('projects.none.header')}</Text>
               <Text>{t('projects.none.info')}</Text>
-              <Link _text={{color: 'primary.main'}} alignItems="center" mb="4">
-                {t('projects.learn_more')}
-              </Link>
             </>
           )
         )}

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -78,24 +78,22 @@ export const ProjectListScreen = () => {
         flexShrink={0}
         flexBasis="70%"
         space="10px">
+        {isLoadingData ? (
+          <Spinner size="lg" />
+        ) : (
+          activeProjects.length === 0 && (
+            <Box mb={4}>
+              <Text bold>{t('projects.none.header')}</Text>
+              <Text>{t('projects.none.info')}</Text>
+            </Box>
+          )
+        )}
         <Box alignItems="flex-start" pb={3}>
           <AddButton
             text={t('projects.create_button')}
             buttonProps={{onPress}}
           />
         </Box>
-
-        {isLoadingData ? (
-          <Spinner size="lg" />
-        ) : (
-          activeProjects.length === 0 && (
-            <>
-              <Text variant="body1-strong">{t('projects.none.header')}</Text>
-              <Text>{t('projects.none.info')}</Text>
-            </>
-          )
-        )}
-
         {activeProjects.length > 0 && (
           <ListFilterProvider
             items={activeProjects}

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -82,13 +82,13 @@ export const ProjectListScreen = () => {
           <Spinner size="lg" />
         ) : (
           activeProjects.length === 0 && (
-            <Box mb={4}>
+            <Box mb="md">
               <Text bold>{t('projects.none.header')}</Text>
               <Text>{t('projects.none.info')}</Text>
             </Box>
           )
         )}
-        <Box alignItems="flex-start" pb={3}>
+        <Box alignItems="flex-start" pb="md">
           <AddButton
             text={t('projects.create_button')}
             buttonProps={{onPress}}

--- a/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
+++ b/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
@@ -14,13 +14,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useTranslation} from 'react-i18next';
 import {useCallback} from 'react';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Card} from 'terraso-mobile-client/components/Card';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Project} from 'terraso-client-shared/project/projectSlice';
-import {formatDate} from 'terraso-mobile-client/util';
 import {
   HStack,
   Badge,
@@ -34,7 +32,6 @@ type Props = {
 };
 
 export const ProjectPreviewCard = ({project}: Props) => {
-  const {t} = useTranslation();
   const navigation = useNavigation();
 
   const goToProject = useCallback(async () => {
@@ -44,12 +41,6 @@ export const ProjectPreviewCard = ({project}: Props) => {
   return (
     <Card onPress={goToProject}>
       <HStack mb="8px">
-        {/** TODO: backend does not have isNew status
-        {project.isNew && (
-          <Badge variant="chip" flexGrow={0} borderRadius={8} _text={{textTransform: 'uppercase'}}>
-            {t('badge.new')}
-          </Badge>
-        )} **/}
         <Heading variant="h6" color="primary.main">
           {project.name}
         </Heading>

--- a/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
+++ b/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
@@ -17,15 +17,14 @@
 import {useCallback} from 'react';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Card} from 'terraso-mobile-client/components/Card';
-import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Project} from 'terraso-client-shared/project/projectSlice';
 import {
   HStack,
-  Badge,
   Heading,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {PeopleBadge} from 'terraso-mobile-client/components/PeopleBadge';
+import {SiteBadge} from 'terraso-mobile-client/components/SiteBadge';
 
 type Props = {
   project: Project;
@@ -46,10 +45,8 @@ export const ProjectPreviewCard = ({project}: Props) => {
         </Heading>
       </HStack>
       {project.description.length > 0 && <Text>{project.description}</Text>}
-      <HStack space={2} alignItems="center">
-        <Badge variant="chip" startIcon={<Icon name="location-on" />}>
-          {Object.keys(project.sites).length}
-        </Badge>
+      <HStack space={2} pt={4} alignItems="center">
+        <SiteBadge count={Object.keys(project.sites).length} />
         <PeopleBadge count={Object.keys(project.memberships).length} />
       </HStack>
     </Card>

--- a/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
+++ b/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
@@ -55,9 +55,6 @@ export const ProjectPreviewCard = ({project}: Props) => {
         </Heading>
       </HStack>
       {project.description.length > 0 && <Text>{project.description}</Text>}
-      <Text variant="subtitle2" color="text.secondary" mb="16px">
-        {t('general.last_modified')}: {formatDate(project.updatedAt)}
-      </Text>
       <HStack space={2} alignItems="center">
         {/* TODO: Progress still not stored on backend */}
         <Text>30%</Text>

--- a/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
+++ b/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
@@ -56,8 +56,6 @@ export const ProjectPreviewCard = ({project}: Props) => {
       </HStack>
       {project.description.length > 0 && <Text>{project.description}</Text>}
       <HStack space={2} alignItems="center">
-        {/* TODO: Progress still not stored on backend */}
-        <Text>30%</Text>
         <Badge variant="chip" startIcon={<Icon name="location-on" />}>
           {Object.keys(project.sites).length}
         </Badge>


### PR DESCRIPTION
## Description
Remove help button and "learn more" link from Projects screen.

### Related Issues
Addresses #1268.