### PR TITLE
feat: update client shared with soil id service

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -53,7 +53,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.2.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#fc3c380",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#7841647",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25520,7 +25520,7 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#fc3c380e7395ef54785a4576ce927c8561f47611",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#78416471fa8e4a1999242b18b039660d66a166c9",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -53,7 +53,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.2.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#3f45918 ",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#542c81a",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25520,18 +25520,29 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#3f459181b30dfb17222e99a9f9527ab8b5f58916",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#542c81a48142c09dc9bc6dcdd3def85bcda709d7",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
-        "react": "^18.2.0",
+        "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#dbfbee5",
+        "terraso-backend": "github:techmatters/terraso-backend#fe4cbf8",
         "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/terraso-client-shared/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/terser": {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -53,7 +53,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.2.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#542c81a",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#d866588",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25520,7 +25520,7 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#542c81a48142c09dc9bc6dcdd3def85bcda709d7",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#d8665886fbb9d1827615aa30b942270a1bb522f2",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -53,7 +53,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.2.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#d866588",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#fc3c380",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25520,29 +25520,18 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#d8665886fbb9d1827615aa30b942270a1bb522f2",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#fc3c380e7395ef54785a4576ce927c8561f47611",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
-        "react": "^18.3.1",
+        "react": "18.2.0",
         "react-redux": "^8.1.3",
         "terraso-backend": "github:techmatters/terraso-backend#fe4cbf8",
         "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/terraso-client-shared/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/terser": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.2.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#fc3c380",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#7841647",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.2.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#d866588",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#fc3c380",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.2.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#542c81a",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#d866588",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.2.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#3f45918 ",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#542c81a",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/src/components/StaticMapView.tsx
+++ b/dev-client/src/components/StaticMapView.tsx
@@ -18,7 +18,6 @@
 import Mapbox from '@rnmapbox/maps';
 import {StyleProp, ViewStyle} from 'react-native';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {Position} from '@rnmapbox/maps/lib/typescript/src/types/Position';
 import {useMemo} from 'react';
 import {COORDINATE_PRECISION} from 'terraso-mobile-client/constants';
@@ -28,6 +27,7 @@ import {
   LONGITUDE_MIN,
   LONGITUDE_MAX,
 } from 'terraso-mobile-client/constants';
+import {Coords} from 'terraso-client-shared/types';
 
 const coordsRegex = /^(-?\d+\.\d+)\s*[, ]\s*(-?\d+\.\d+)$/;
 export type CoordsParseErrorReason =

--- a/dev-client/src/context/GeospatialContext.tsx
+++ b/dev-client/src/context/GeospatialContext.tsx
@@ -16,9 +16,9 @@
  */
 import {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import haversine from 'haversine';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {GEOSPATIAL_CONTEXT_USER_DISTANCE_CACHE} from 'terraso-mobile-client/constants';
 import {AppState, useSelector} from 'terraso-mobile-client/store';
+import {Coords} from 'terraso-client-shared/types';
 
 type GeospatialInfo = {
   /* list of site IDs, sorted with respect to user's current location */

--- a/dev-client/src/model/map/mapSlice.ts
+++ b/dev-client/src/model/map/mapSlice.ts
@@ -16,11 +16,7 @@
  */
 
 import {PayloadAction, createSlice} from '@reduxjs/toolkit';
-
-export type Coords = {
-  latitude: number;
-  longitude: number;
-};
+import {Coords} from 'terraso-client-shared/types';
 
 export type UserLocation = {
   coords: Coords | null;

--- a/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
@@ -19,7 +19,6 @@ import {useCallback, useRef} from 'react';
 import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 
 import {useDispatch} from 'terraso-mobile-client/store';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {CreateSiteView} from 'terraso-mobile-client/screens/CreateSiteScreen/components/CreateSiteView';
 import {
   addSite,
@@ -30,6 +29,7 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {ScreenCloseButton} from 'terraso-mobile-client/navigation/components/ScreenCloseButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {PrivacyInfoModal} from 'terraso-mobile-client/components/modals/privacy/PrivacyInfoModal';
+import {Coords} from 'terraso-client-shared/types';
 
 type Props =
   | {

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -30,7 +30,6 @@ import {FormikProps} from 'formik';
 
 import {siteValidationSchema} from 'terraso-mobile-client/schemas/siteValidationSchema';
 import {useSelector} from 'terraso-mobile-client/store';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {ProjectSelect} from 'terraso-mobile-client/components/ProjectSelect';
 import {coordsToString} from 'terraso-mobile-client/components/StaticMapView';
 import {FormRadio} from 'terraso-mobile-client/components/form/FormRadio';
@@ -45,6 +44,7 @@ import {
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {HelpTooltipButton} from 'terraso-mobile-client/components/tooltips/HelpTooltipButton';
+import {Coords} from 'terraso-client-shared/types';
 
 export type FormState = Omit<
   InferType<ReturnType<typeof siteValidationSchema>>,

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -24,7 +24,6 @@ import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigatio
 import {siteValidationSchema} from 'terraso-mobile-client/schemas/siteValidationSchema';
 import {useSelector} from 'terraso-mobile-client/store';
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {
   coordsToString,
   parseCoords,
@@ -34,6 +33,7 @@ import {
   FormState,
 } from 'terraso-mobile-client/screens/CreateSiteScreen/components/CreateSiteForm';
 import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
+import {Coords} from 'terraso-client-shared/types';
 
 type Props = {
   defaultProjectId?: string;

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -32,7 +32,6 @@ import {
   useImperativeHandle,
 } from 'react';
 import Mapbox from '@rnmapbox/maps';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {Site} from 'terraso-client-shared/site/siteSlice';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -54,6 +53,7 @@ import {
   siteCallout,
   locationCallout,
 } from 'terraso-mobile-client/screens/HomeScreen/HomeScreenCallout';
+import {Coords} from 'terraso-client-shared/types';
 
 type HomeScreenRef = {
   showSiteOnMap: (site: Site) => void;

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
@@ -16,7 +16,7 @@
  */
 
 import {Site} from 'terraso-client-shared/site/siteSlice';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
+import {Coords} from 'terraso-client-shared/types';
 
 export type CalloutState =
   | {

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -26,7 +26,6 @@ import {
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
 import {Keyboard} from 'react-native';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {isValidCoordinates} from 'terraso-mobile-client/util';
 import {
   Box,
@@ -35,6 +34,7 @@ import {
   VStack,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {Coords} from 'terraso-client-shared/types';
 
 const {getSuggestions, retrieveFeature} = initMapSearch();
 

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -45,7 +45,7 @@ import {repositionCamera} from 'terraso-mobile-client/screens/HomeScreen/utils/r
 import {SiteMapCallout} from 'terraso-mobile-client/screens/HomeScreen/components/SiteMapCallout';
 import {CustomUserLocation} from 'terraso-mobile-client/screens/HomeScreen/components/CustomUserLocation';
 import {useListFilter} from 'terraso-mobile-client/components/ListFilter';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
+import {Coords} from 'terraso-client-shared/types';
 
 const DEFAULT_LOCATION = [-98.0, 38.5];
 const MAX_EXPANSION_ZOOM = 15;

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -32,7 +32,7 @@ import {CloseButton} from 'terraso-mobile-client/components/buttons/CloseButton'
 import {SiteCard} from 'terraso-mobile-client/components/SiteCard';
 import {SiteClusterCalloutListItem} from 'terraso-mobile-client/screens/HomeScreen/components/SiteClusterCalloutListItem';
 import {TemporarySiteCallout} from 'terraso-mobile-client/screens/HomeScreen/components/TemporarySiteCallout';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
+import {Coords} from 'terraso-client-shared/types';
 
 type Props = {
   sites: Record<string, Site>;

--- a/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
@@ -17,7 +17,6 @@
 
 import {useCallback, useMemo, useState} from 'react';
 import {Button, Divider, Spinner} from 'native-base';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {useTranslation} from 'react-i18next';
 import {Card} from 'terraso-mobile-client/components/Card';
@@ -30,6 +29,7 @@ import {
   Box,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {renderElevation} from 'terraso-mobile-client/components/util/site';
+import {Coords} from 'terraso-client-shared/types';
 
 const TEMP_SOIL_ID_VALUE = 'Clifton';
 const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -25,7 +25,6 @@ import {SitePrivacy, updateSite} from 'terraso-client-shared/site/siteSlice';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {StaticMapView} from 'terraso-mobile-client/components/StaticMapView';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {ProjectInstructionsButton} from 'terraso-mobile-client/screens/LocationScreens/components/ProjectInstructionsButton';
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 
@@ -43,6 +42,7 @@ import {
 import StackedBarChart from 'terraso-mobile-client/assets/stacked-bar.svg';
 import {PeopleBadge} from 'terraso-mobile-client/components/PeopleBadge';
 import {renderElevation} from 'terraso-mobile-client/components/util/site';
+import {Coords} from 'terraso-client-shared/types';
 
 const TEMP_SOIL_ID_VALUE = 'Clifton';
 const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -132,7 +132,7 @@ export const LocationDashboardContent = ({
     coords = site!;
   }
   if (elevation === undefined) {
-    elevation = site?.elevation;
+    elevation = site?.elevation ?? undefined;
   }
   const project = useSelector(state =>
     site?.projectId === undefined

--- a/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
@@ -25,13 +25,13 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {LocationDashboardTabNavigator} from 'terraso-mobile-client/navigation/navigators/LocationDashboardTabNavigator';
 import {PrivacyInfoModal} from 'terraso-mobile-client/components/modals/privacy/PrivacyInfoModal';
 import {BottomSheetPrivacyModalContext} from 'terraso-mobile-client/context/BottomSheetPrivacyModalContext';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {selectSite, selectUserRoleSite} from 'terraso-client-shared/selectors';
 import {isSiteManager} from 'terraso-mobile-client/util';
+import {Coords} from 'terraso-client-shared/types';
 
 type Props = {siteId: string} | {coords: Coords};
 

--- a/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
@@ -20,7 +20,6 @@ import {useTranslation} from 'react-i18next';
 import {useSelector} from 'terraso-mobile-client/store';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {
   SoilIdDescriptionSection,
@@ -29,6 +28,7 @@ import {
 import {SiteDataSection} from 'terraso-mobile-client/screens/LocationScreens/components/SiteDataSection';
 import {selectSite} from 'terraso-client-shared/selectors';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {Coords} from 'terraso-client-shared/types';
 
 type Props = {
   siteId?: string;

--- a/dev-client/src/screens/LocationScreens/components/CreateSiteButton.tsx
+++ b/dev-client/src/screens/LocationScreens/components/CreateSiteButton.tsx
@@ -20,8 +20,8 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'native-base';
 
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {Coords} from 'terraso-mobile-client/model/map/mapSlice';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {Coords} from 'terraso-client-shared/types';
 
 type Props = {coords: Coords};
 


### PR DESCRIPTION
## Description
Updates the client-shared version to expose the new soil id service.

Also fixes a type error, and consolidates the `Coords` type with the new one that was needed upstream.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Resolves https://github.com/techmatters/terraso-backend/issues/1265
Resolves https://github.com/techmatters/terraso-backend/issues/1266

