### PR TITLE
feat: Add "Soil Properties" content with table using bogus data + unfinished "Add soil data" button

### DIFF
--- a/dev-client/src/components/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/SoilPropertiesDataTable.tsx
@@ -30,7 +30,7 @@ type DataTableHeaderProps = {
 const DataTableHeader = ({width, text}: DataTableHeaderProps) => {
   return (
     <Text
-      variant="table-header"
+      variant="body1-medium"
       width={width}
       paddingHorizontal="sm"
       pb="sm"
@@ -41,10 +41,10 @@ const DataTableHeader = ({width, text}: DataTableHeaderProps) => {
 };
 
 type DataTableCellProps = {
-  text: string;
   width: NBDimensionValue;
+  text: string;
 };
-const DataTableCell = ({text, width}: DataTableCellProps) => {
+const DataTableCell = ({width, text}: DataTableCellProps) => {
   return (
     <Box
       flex={1}
@@ -67,10 +67,10 @@ type Props = {
 export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
   const {t} = useTranslation();
 
-  const columnWidthDepth: NBDimensionValue = '80px';
-  const columnWidthTexture: NBDimensionValue = '100px';
-  const columnWidthColor: NBDimensionValue = '100px';
-  const columnWidthRockFragment: NBDimensionValue = '80px';
+  const columnWidthDepth: NBDimensionValue = '85px';
+  const columnWidthTexture: NBDimensionValue = '115px';
+  const columnWidthColor: NBDimensionValue = '110px';
+  const columnWidthRockFragment: NBDimensionValue = '110px';
 
   // React wants a `key` prop on components rendered with map, for DOM reconciliation purposes.
   // However, using the index alone for the key is an anti-pattern,

--- a/dev-client/src/components/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/SoilPropertiesDataTable.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {useTranslation} from 'react-i18next';
+import {
+  Box,
+  Row,
+  Text,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {NBDimensionValue} from 'terraso-mobile-client/components/util/nativeBaseAdapters';
+
+type DataTableHeaderProps = {
+  width: NBDimensionValue;
+  text: string;
+};
+const DataTableHeader = ({width, text}: DataTableHeaderProps) => {
+  return (
+    <Text
+      variant="table-header"
+      width={width}
+      paddingHorizontal={'sm'}
+      pb={'sm'}
+      alignSelf={'flex-end'}>
+      {text}
+    </Text>
+  );
+};
+
+type DataTableCellProps = {
+  text: string;
+  index: number;
+  width: NBDimensionValue;
+};
+const DataTableCell = ({text, index, width}: DataTableCellProps) => {
+  return (
+    <Box
+      flex={1}
+      key={index}
+      width={width}
+      borderRightWidth={'1px'}
+      borderBottomWidth={'1px'}
+      paddingHorizontal={'8px'}
+      paddingVertical={'4px'}>
+      <Text>{text}</Text>
+    </Box>
+  );
+};
+
+type Props = {
+  rows: [string, string, string, string][];
+  // rows: string[][4];
+} & React.ComponentProps<typeof Box>;
+
+export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
+  const {t} = useTranslation();
+
+  const columnWidthDepth: NBDimensionValue = '80px';
+  const columnWidthTexture: NBDimensionValue = '100px';
+  const columnWidthColor: NBDimensionValue = '100px';
+  const columnWidthRockFragment: NBDimensionValue = '80px';
+
+  return (
+    <Box {...containerProps}>
+      <Row justifyContent="flex-start">
+        <DataTableHeader
+          width={columnWidthDepth}
+          text={t('site.soil_id.site_data.soil_properties.depth')}
+        />
+        <DataTableHeader
+          width={columnWidthTexture}
+          text={t('site.soil_id.site_data.soil_properties.texture')}
+        />
+        <DataTableHeader
+          width={columnWidthColor}
+          text={t('site.soil_id.site_data.soil_properties.color')}
+        />
+        <DataTableHeader
+          width={columnWidthRockFragment}
+          text={t('site.soil_id.site_data.soil_properties.rock_fragment')}
+        />
+      </Row>
+
+      <Box borderTopWidth={'1px'} borderLeftWidth={'1px'}>
+        {rows.map((row: (typeof rows)[number], i: number) => (
+          <Row justifyContent="flex-start" key={i}>
+            <DataTableCell text={row[0]} index={0} width={columnWidthDepth} />
+            <DataTableCell text={row[1]} index={1} width={columnWidthTexture} />
+            <DataTableCell text={row[2]} index={2} width={columnWidthColor} />
+            <DataTableCell
+              text={row[3]}
+              index={3}
+              width={columnWidthRockFragment}
+            />
+          </Row>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/dev-client/src/components/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/SoilPropertiesDataTable.tsx
@@ -59,9 +59,9 @@ const DataTableCell = ({text, width}: DataTableCellProps) => {
   );
 };
 
-type Row = [string, string, string, string];
+export type SoilPropertiesDataTableRow = [string, string, string, string];
 type Props = {
-  rows: Row[];
+  rows: SoilPropertiesDataTableRow[];
 } & React.ComponentProps<typeof Box>;
 
 export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
@@ -79,7 +79,7 @@ export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
   // I expect the data to be unique for each row -- unless the entire row is empty,
   // in which case I expect using the index to be fine.
   // And I don't expect there to be much rearranging of items anyway.
-  const uniqueKeyForRow = (row: Row, index: number) => {
+  const uniqueKeyForRow = (row: SoilPropertiesDataTableRow, index: number) => {
     return row[0] + row[1] + row[2] + row[3] + index.toString();
   };
 

--- a/dev-client/src/components/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/SoilPropertiesDataTable.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+
 import {useTranslation} from 'react-i18next';
 import {
   Box,
@@ -31,9 +32,9 @@ const DataTableHeader = ({width, text}: DataTableHeaderProps) => {
     <Text
       variant="table-header"
       width={width}
-      paddingHorizontal={'sm'}
-      pb={'sm'}
-      alignSelf={'flex-end'}>
+      paddingHorizontal="sm"
+      pb="sm"
+      alignSelf="flex-end">
       {text}
     </Text>
   );
@@ -41,14 +42,12 @@ const DataTableHeader = ({width, text}: DataTableHeaderProps) => {
 
 type DataTableCellProps = {
   text: string;
-  index: number;
   width: NBDimensionValue;
 };
-const DataTableCell = ({text, index, width}: DataTableCellProps) => {
+const DataTableCell = ({text, width}: DataTableCellProps) => {
   return (
     <Box
       flex={1}
-      key={index}
       width={width}
       borderRightWidth="1px"
       borderBottomWidth="1px"
@@ -60,8 +59,9 @@ const DataTableCell = ({text, index, width}: DataTableCellProps) => {
   );
 };
 
+type Row = [string, string, string, string];
 type Props = {
-  rows: [string, string, string, string][];
+  rows: Row[];
 } & React.ComponentProps<typeof Box>;
 
 export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
@@ -72,12 +72,25 @@ export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
   const columnWidthColor: NBDimensionValue = '100px';
   const columnWidthRockFragment: NBDimensionValue = '80px';
 
+  // React wants a `key` prop on components rendered with map, for DOM reconciliation purposes.
+  // However, using the index alone for the key is an anti-pattern,
+  // as that can cause an issue if list items are rearranged, added, or removed.
+  // This should be a sufficiently unique id for our purposes;
+  // I expect the data to be unique for each row -- unless the entire row is empty,
+  // in which case I expect using the index to be fine.
+  // And I don't expect there to be much rearranging of items anyway.
+  const uniqueKeyForRow = (row: Row, index: number) => {
+    return row[0] + row[1] + row[2] + row[3] + index.toString();
+  };
+
   return (
     <Box {...containerProps}>
       <Row justifyContent="flex-start">
         <DataTableHeader
           width={columnWidthDepth}
-          text={t('site.soil_id.site_data.soil_properties.depth')}
+          text={t('site.soil_id.site_data.soil_properties.depth', {
+            units: 'METRIC',
+          })}
         />
         <DataTableHeader
           width={columnWidthTexture}
@@ -93,17 +106,13 @@ export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
         />
       </Row>
 
-      <Box borderTopWidth={'1px'} borderLeftWidth={'1px'}>
+      <Box borderTopWidth="1px" borderLeftWidth="1px">
         {rows.map((row: (typeof rows)[number], i: number) => (
-          <Row justifyContent="flex-start" key={i}>
-            <DataTableCell text={row[0]} index={0} width={columnWidthDepth} />
-            <DataTableCell text={row[1]} index={1} width={columnWidthTexture} />
-            <DataTableCell text={row[2]} index={2} width={columnWidthColor} />
-            <DataTableCell
-              text={row[3]}
-              index={3}
-              width={columnWidthRockFragment}
-            />
+          <Row justifyContent="flex-start" key={uniqueKeyForRow(row, i)}>
+            <DataTableCell text={row[0]} width={columnWidthDepth} />
+            <DataTableCell text={row[1]} width={columnWidthTexture} />
+            <DataTableCell text={row[2]} width={columnWidthColor} />
+            <DataTableCell text={row[3]} width={columnWidthRockFragment} />
           </Row>
         ))}
       </Box>

--- a/dev-client/src/components/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/SoilPropertiesDataTable.tsx
@@ -50,10 +50,11 @@ const DataTableCell = ({text, index, width}: DataTableCellProps) => {
       flex={1}
       key={index}
       width={width}
-      borderRightWidth={'1px'}
-      borderBottomWidth={'1px'}
-      paddingHorizontal={'8px'}
-      paddingVertical={'4px'}>
+      borderRightWidth="1px"
+      borderBottomWidth="1px"
+      paddingHorizontal="8px"
+      paddingVertical="4px"
+      justifyContent="center">
       <Text>{text}</Text>
     </Box>
   );
@@ -61,7 +62,6 @@ const DataTableCell = ({text, index, width}: DataTableCellProps) => {
 
 type Props = {
   rows: [string, string, string, string][];
-  // rows: string[][4];
 } & React.ComponentProps<typeof Box>;
 
 export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {

--- a/dev-client/src/components/util/nativeBaseAdapters.ts
+++ b/dev-client/src/components/util/nativeBaseAdapters.ts
@@ -89,6 +89,7 @@ const nativeBaseDimensions = {
 } as const;
 
 const nativeBaseNumerics = {
+  borderTopWidth: 'borderTopWidth',
   borderBottomWidth: 'borderBottomWidth',
   borderLeftWidth: 'borderLeftWidth',
   borderRightWidth: 'borderRightWidth',

--- a/dev-client/src/navigation/navigators/LocationDashboardTabNavigator.tsx
+++ b/dev-client/src/navigation/navigators/LocationDashboardTabNavigator.tsx
@@ -40,6 +40,8 @@ type ScreenName = keyof TabsParamList;
 
 const Tab = createMaterialTopTabNavigator<TabsParamList>();
 
+// TODO-cknipe: Add to LocationDashboardTabNavigator params something that sets it initialRouteName to whatever you want.
+// TODO-cknipe: Anything special with memo()?
 export const LocationDashboardTabNavigator = memo(
   (params: {siteId: string}) => {
     const {t} = useTranslation();

--- a/dev-client/src/navigation/navigators/LocationDashboardTabNavigator.tsx
+++ b/dev-client/src/navigation/navigators/LocationDashboardTabNavigator.tsx
@@ -40,8 +40,6 @@ type ScreenName = keyof TabsParamList;
 
 const Tab = createMaterialTopTabNavigator<TabsParamList>();
 
-// TODO-cknipe: Add to LocationDashboardTabNavigator params something that sets it initialRouteName to whatever you want.
-// TODO-cknipe: Anything special with memo()?
 export const LocationDashboardTabNavigator = memo(
   (params: {siteId: string}) => {
     const {t} = useTranslation();

--- a/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
@@ -49,7 +49,7 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
       <SoilIdDescriptionSection siteId={siteId} />
       <SoilIdMatchesSection siteId={siteId} />
       {siteId ? (
-        <SiteDataSection />
+        <SiteDataSection siteId={siteId} />
       ) : (
         <Box paddingVertical="md">
           <CreateSiteButton coords={coords} />

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -28,7 +28,10 @@ import {
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+import {
+  SoilPropertiesDataTable,
+  SoilPropertiesDataTableRow,
+} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 type Props = {siteId: string};
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
@@ -39,7 +42,7 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
     navigation.navigate('LOCATION_DASHBOARD', {siteId});
   }, [navigation, siteId]);
 
-  const bogusDataRows: [string, string, string, string][] = [
+  const bogusDataRows: SoilPropertiesDataTableRow[] = [
     ['0-10', 'Clay', '7.5YR 8.5/1', '50-85%'],
     ['11-20', 'Sandy Clay Loam', '7.5YR 8.5/1', '1-15%'],
     ['100-120', '', '', ''],

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -16,14 +16,51 @@
  */
 
 import {useTranslation} from 'react-i18next';
+import {Button} from 'native-base';
 
 import {
+  Box,
   Heading,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {useCallback} from 'react';
 
-export const SiteDataSection = () => {
+// TODO-cknipe: Move the table to its own thing
+// Make sure it can share whatever makes sense between soil & site id variants
+// TODO-cknipe: Hide button for Viewer role
+type Props = {siteId: string};
+export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
+  const {t} = useTranslation();
+  const navigation = useNavigation();
+
+  // TODO-cknipe: How to make it navigate to the Soil tab? (LocationDashboardTabNavigator)
+  const onAddSoilDataPress = useCallback(() => {
+    navigation.navigate('LOCATION_DASHBOARD', {siteId});
+  }, [navigation, siteId]);
+
+  return (
+    <>
+      <Heading variant="h6" pt="lg">
+        {t('site.soil_id.site_data.soil_properties.title')}
+      </Heading>
+
+      <Box paddingVertical={'lg'}>
+        <Button
+          _text={{textTransform: 'uppercase'}}
+          alignSelf={'flex-end'}
+          rightIcon={<Icon name="chevron-right" />}
+          onPress={onAddSoilDataPress}>
+          {t('site.soil_id.site_data.soil_properties.add_data')}
+        </Button>
+      </Box>
+    </>
+  );
+};
+
+export const SiteDataSection = ({siteId}: Props) => {
   const {t} = useTranslation();
 
   return (
@@ -32,9 +69,8 @@ export const SiteDataSection = () => {
       <Heading variant="h6" pt="lg">
         {t('site.soil_id.site_data.slope.title')}
       </Heading>
-      <Heading variant="h6" pt="lg">
-        {t('site.soil_id.site_data.soil_properties.title')}
-      </Heading>
+
+      <SiteSoilPropertiesDataSection siteId={siteId} />
     </ScreenContentSection>
   );
 };

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -30,15 +30,11 @@ import {ScreenContentSection} from 'terraso-mobile-client/components/content/Scr
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {useCallback} from 'react';
 
-// TODO-cknipe: Move the table to its own thing
-// Make sure it can share whatever makes sense between soil & site id variants
-// TODO-cknipe: Hide button for Viewer role
 type Props = {siteId: string};
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
 
-  // TODO-cknipe: How to make it navigate to the Soil tab? (LocationDashboardTabNavigator)
   const onAddSoilDataPress = useCallback(() => {
     navigation.navigate('LOCATION_DASHBOARD', {siteId});
   }, [navigation, siteId]);

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -17,6 +17,8 @@
 
 import {useTranslation} from 'react-i18next';
 import {Button} from 'native-base';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 import {
   Box,
@@ -41,11 +43,22 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
     navigation.navigate('LOCATION_DASHBOARD', {siteId});
   }, [navigation, siteId]);
 
+  const bogusDataRows: [string, string, string, string][] = [
+    ['0-10', 'Clay', '7.5YR 8.5/1', '50-85%'],
+    ['11-20', 'Sandy Clay Loam', '7.5YR 8.5/1', '1-15%'],
+    ['100-120', '', '', ''],
+  ];
+
   return (
     <>
       <Heading variant="h6" pt="lg">
         {t('site.soil_id.site_data.soil_properties.title')}
       </Heading>
+
+      <Box marginTop={'sm'} />
+      <ScrollView horizontal={true}>
+        <SoilPropertiesDataTable rows={bogusDataRows} />
+      </ScrollView>
 
       <Box paddingVertical={'lg'}>
         <Button

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -15,20 +15,20 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button} from 'native-base';
 import {ScrollView} from 'react-native-gesture-handler';
-import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 import {
   Box,
   Heading,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {useCallback} from 'react';
+import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 type Props = {siteId: string};
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -54,15 +54,15 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
         {t('site.soil_id.site_data.soil_properties.title')}
       </Heading>
 
-      <Box marginTop={'sm'} />
+      <Box marginTop="sm" />
       <ScrollView horizontal={true}>
         <SoilPropertiesDataTable rows={bogusDataRows} />
       </ScrollView>
 
-      <Box paddingVertical={'lg'}>
+      <Box paddingVertical="lg">
         <Button
           _text={{textTransform: 'uppercase'}}
-          alignSelf={'flex-end'}
+          alignSelf="flex-end"
           rightIcon={<Icon name="chevron-right" />}
           onPress={onAddSoilDataPress}>
           {t('site.soil_id.site_data.soil_properties.add_data')}

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -351,6 +351,12 @@ export const theme = extendTheme({
           fontSize: '16px',
           lineHeight: '24px',
         },
+        'body1-medium': {
+          fontSize: '16px',
+          fontWeight: 500,
+          lineHeight: '24px',
+          letterSpacing: '0.17px',
+        },
         body2: {
           fontSize: '14px',
           fontWeight: 400,

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -109,6 +109,10 @@
         },
         "soil_properties": {
           "title": "Soil Properties",
+          "depth": "Depth (cm)",
+          "texture": "Texture",
+          "color": "Color",
+          "rock_fragment": "Rock Fragment",
           "add_data": "Add soil data"
         }
       }

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -108,7 +108,8 @@
           "title": "Slope"
         },
         "soil_properties": {
-          "title": "Soil Properties"
+          "title": "Soil Properties",
+          "add_data": "Add soil data"
         }
       }
     },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -109,7 +109,9 @@
         },
         "soil_properties": {
           "title": "Soil Properties",
-          "depth": "Depth (cm)",
+          "depth": "Depth ($t(site.soil_id.site_data.soil_properties.depth_units, {\"context\": \"{{units}}\"}))",
+          "depth_units_METRIC": "cm",
+          "depth_units_ENGLISH": "”",
           "texture": "Texture",
           "color": "Color",
           "rock_fragment": "Rock Fragment",


### PR DESCRIPTION
## Description
Add soil properties table (with bogus data) 
Add "Add soil data >" button (but does not yet navigate to the correct tab)

### Checklist
- [x] Corresponding issue has been opened
- [ ] Future PR: Make button navigate to the correct tab
- [ ] Future PR: Check in with Courtney about the exact styling

### Related Issues
Partially implements #1230 
Would like reviews on this part now, to unblock Ruxandra's work that uses the table

### Verification steps
Look at the bottom of the Soil ID sheet for a site

Currently looks like this: 
(alas, I was trying so hard to get the table narrow enough to not need horizontal scrolling, but still fit the strings nicely *shakes fist at Android*)
![Screenshot 2024-05-14 at 4 20 55 PM](https://github.com/techmatters/terraso-mobile-client/assets/5590815/baed0d99-195f-4d6e-93da-115c4062b007)
