### PR TITLE
Feat: 'Add soil data' button navigates to site's soil data tab

### DIFF
--- a/dev-client/src/navigation/navigators/SiteLocationDashboardTabNavigator.tsx
+++ b/dev-client/src/navigation/navigators/SiteLocationDashboardTabNavigator.tsx
@@ -28,6 +28,8 @@ import {SoilScreen} from 'terraso-mobile-client/screens/SoilScreen/SoilScreen';
 import {useDefaultTabOptions} from 'terraso-mobile-client/navigation/hooks/useDefaultTabOptions';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 
+type TabsParamList = ParamList<typeof tabDefinitions>;
+type SiteTabName = keyof TabsParamList;
 const tabDefinitions = {
   SITE: LocationDashboardContent,
   SLOPE: SlopeScreen,
@@ -35,35 +37,31 @@ const tabDefinitions = {
   NOTES: SiteNotesScreen,
 } satisfies ScreenDefinitions;
 
-type TabsParamList = ParamList<typeof tabDefinitions>;
-type ScreenName = keyof TabsParamList;
-
 const Tab = createMaterialTopTabNavigator<TabsParamList>();
 
-export const LocationDashboardTabNavigator = memo(
-  (params: {siteId: string}) => {
-    const {t} = useTranslation();
-    const defaultOptions = useDefaultTabOptions();
-    const tabs = useMemo(
-      () =>
-        Object.entries(tabDefinitions).map(([name, View]) => (
-          <Tab.Screen
-            name={name as ScreenName}
-            key={name}
-            initialParams={params}
-            options={{...defaultOptions, tabBarLabel: t(`site.tabs.${name}`)}}
-            children={props => (
-              <View {...((props.route.params ?? {}) as any)} />
-            )}
-          />
-        )),
-      [params, t, defaultOptions],
-    );
+type Props = {
+  siteId: string;
+};
+export const SiteLocationDashboardTabNavigator = memo((params: Props) => {
+  const {t} = useTranslation();
+  const defaultOptions = useDefaultTabOptions();
+  const tabs = useMemo(
+    () =>
+      Object.entries(tabDefinitions).map(([name, View]) => (
+        <Tab.Screen
+          name={name as SiteTabName}
+          key={name}
+          initialParams={params}
+          options={{...defaultOptions, tabBarLabel: t(`site.tabs.${name}`)}}
+          children={props => <View {...((props.route.params ?? {}) as any)} />}
+        />
+      )),
+    [params, t, defaultOptions],
+  );
 
-    return (
-      <BottomSheetModalProvider>
-        <Tab.Navigator initialRouteName="SITE">{tabs}</Tab.Navigator>
-      </BottomSheetModalProvider>
-    );
-  },
-);
+  return (
+    <BottomSheetModalProvider>
+      <Tab.Navigator initialRouteName="SITE">{tabs}</Tab.Navigator>
+    </BottomSheetModalProvider>
+  );
+});

--- a/dev-client/src/navigation/navigators/SiteLocationDashboardTabNavigator.tsx
+++ b/dev-client/src/navigation/navigators/SiteLocationDashboardTabNavigator.tsx
@@ -29,7 +29,7 @@ import {useDefaultTabOptions} from 'terraso-mobile-client/navigation/hooks/useDe
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 
 type TabsParamList = ParamList<typeof tabDefinitions>;
-type SiteTabName = keyof TabsParamList;
+export type SiteTabName = keyof TabsParamList;
 const tabDefinitions = {
   SITE: LocationDashboardContent,
   SLOPE: SlopeScreen,
@@ -41,27 +41,32 @@ const Tab = createMaterialTopTabNavigator<TabsParamList>();
 
 type Props = {
   siteId: string;
+  initialTab: SiteTabName;
 };
-export const SiteLocationDashboardTabNavigator = memo((params: Props) => {
-  const {t} = useTranslation();
-  const defaultOptions = useDefaultTabOptions();
-  const tabs = useMemo(
-    () =>
-      Object.entries(tabDefinitions).map(([name, View]) => (
-        <Tab.Screen
-          name={name as SiteTabName}
-          key={name}
-          initialParams={params}
-          options={{...defaultOptions, tabBarLabel: t(`site.tabs.${name}`)}}
-          children={props => <View {...((props.route.params ?? {}) as any)} />}
-        />
-      )),
-    [params, t, defaultOptions],
-  );
+export const SiteLocationDashboardTabNavigator = memo(
+  ({siteId, initialTab}: Props) => {
+    const {t} = useTranslation();
+    const defaultOptions = useDefaultTabOptions();
+    const tabs = useMemo(
+      () =>
+        Object.entries(tabDefinitions).map(([name, View]) => (
+          <Tab.Screen
+            name={name as SiteTabName}
+            key={name}
+            initialParams={{siteId}}
+            options={{...defaultOptions, tabBarLabel: t(`site.tabs.${name}`)}}
+            children={props => (
+              <View {...((props.route.params ?? {}) as any)} />
+            )}
+          />
+        )),
+      [siteId, t, defaultOptions],
+    );
 
-  return (
-    <BottomSheetModalProvider>
-      <Tab.Navigator initialRouteName="SITE">{tabs}</Tab.Navigator>
-    </BottomSheetModalProvider>
-  );
-});
+    return (
+      <BottomSheetModalProvider>
+        <Tab.Navigator initialRouteName={initialTab}>{tabs}</Tab.Navigator>
+      </BottomSheetModalProvider>
+    );
+  },
+);

--- a/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
@@ -25,7 +25,7 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
-import {LocationDashboardTabNavigator} from 'terraso-mobile-client/navigation/navigators/LocationDashboardTabNavigator';
+import {SiteLocationDashboardTabNavigator} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 import {PrivacyInfoModal} from 'terraso-mobile-client/components/modals/privacy/PrivacyInfoModal';
 import {BottomSheetPrivacyModalContext} from 'terraso-mobile-client/context/BottomSheetPrivacyModalContext';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
@@ -87,7 +87,7 @@ export const LocationDashboardScreen = (props: Props) => {
         BottomNavigation={null}>
         {siteId ? (
           <SiteRoleContextProvider siteId={siteId}>
-            <LocationDashboardTabNavigator siteId={siteId} />
+            <SiteLocationDashboardTabNavigator siteId={siteId} />
           </SiteRoleContextProvider>
         ) : (
           <LocationDashboardContent siteId={siteId} coords={coords} />

--- a/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
@@ -25,7 +25,10 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
-import {SiteLocationDashboardTabNavigator} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
+import {
+  SiteTabName,
+  SiteLocationDashboardTabNavigator,
+} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 import {PrivacyInfoModal} from 'terraso-mobile-client/components/modals/privacy/PrivacyInfoModal';
 import {BottomSheetPrivacyModalContext} from 'terraso-mobile-client/context/BottomSheetPrivacyModalContext';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
@@ -33,13 +36,15 @@ import {selectSite, selectUserRoleSite} from 'terraso-client-shared/selectors';
 import {isSiteManager} from 'terraso-mobile-client/util';
 import {Coords} from 'terraso-client-shared/types';
 
-type Props = {siteId: string} | {coords: Coords};
+type Props = ({siteId: string} | {coords: Coords}) & {initialTab?: SiteTabName};
 
 // A "Location" can refer to a "Site" (with siteId) xor a "Temporary Location" (with only coords)
 export const LocationDashboardScreen = (props: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
   const infoModalRef = useRef<BottomSheetModal>(null);
+  const initialTab = props.initialTab === undefined ? 'SITE' : props.initialTab;
+
   const siteId = 'siteId' in props ? props.siteId : undefined;
   const site = useSelector(state =>
     siteId === undefined ? undefined : selectSite(siteId)(state),
@@ -87,7 +92,10 @@ export const LocationDashboardScreen = (props: Props) => {
         BottomNavigation={null}>
         {siteId ? (
           <SiteRoleContextProvider siteId={siteId}>
-            <SiteLocationDashboardTabNavigator siteId={siteId} />
+            <SiteLocationDashboardTabNavigator
+              siteId={siteId}
+              initialTab={initialTab}
+            />
           </SiteRoleContextProvider>
         ) : (
           <LocationDashboardContent siteId={siteId} coords={coords} />

--- a/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
@@ -30,6 +30,7 @@ import {selectSite} from 'terraso-client-shared/selectors';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {Coords} from 'terraso-client-shared/types';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 
 type Props = {
   siteId?: string;
@@ -51,7 +52,9 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
         <SoilIdDescriptionSection siteId={siteId} coords={coords} />
         <SoilIdMatchesSection siteId={siteId} coords={coords} />
         {siteId ? (
-          <SiteDataSection siteId={siteId} />
+          <SiteRoleContextProvider siteId={siteId}>
+            <SiteDataSection siteId={siteId} />
+          </SiteRoleContextProvider>
         ) : (
           <Box paddingVertical="md">
             <CreateSiteButton coords={coords} />

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -29,6 +29,7 @@ import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 import {SOIL_PROPERTIES_TABLE_ROWS} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
+import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 
 type Props = {siteId: string};
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
@@ -36,7 +37,11 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
   const navigation = useNavigation();
 
   const onAddSoilDataPress = useCallback(() => {
-    navigation.navigate('LOCATION_DASHBOARD', {siteId});
+    // TODO-cknipe: Confirm this navigation stack behavior is okay
+    navigation.push('LOCATION_DASHBOARD', {
+      siteId: siteId,
+      initialTab: 'SOIL' as SiteTabName,
+    });
   }, [navigation, siteId]);
 
   return (

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -30,6 +30,7 @@ import {ScreenContentSection} from 'terraso-mobile-client/components/content/Scr
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 import {SOIL_PROPERTIES_TABLE_ROWS} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 
 type Props = {siteId: string};
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
@@ -53,15 +54,22 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
       <Box marginTop="sm" />
       <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
 
-      <Box paddingVertical="lg">
-        <Button
-          _text={{textTransform: 'uppercase'}}
-          alignSelf="flex-end"
-          rightIcon={<Icon name="chevron-right" />}
-          onPress={onAddSoilDataPress}>
-          {t('site.soil_id.site_data.soil_properties.add_data')}
-        </Button>
-      </Box>
+      <RestrictBySiteRole
+        role={[
+          {kind: 'site', role: 'OWNER'},
+          {kind: 'project', role: 'MANAGER'},
+          {kind: 'project', role: 'CONTRIBUTOR'},
+        ]}>
+        <Box paddingVertical="lg">
+          <Button
+            _text={{textTransform: 'uppercase'}}
+            alignSelf="flex-end"
+            rightIcon={<Icon name="chevron-right" />}
+            onPress={onAddSoilDataPress}>
+            {t('site.soil_id.site_data.soil_properties.add_data')}
+          </Button>
+        </Box>
+      </RestrictBySiteRole>
     </>
   );
 };

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -38,7 +38,6 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
   const navigation = useNavigation();
 
   const onAddSoilDataPress = useCallback(() => {
-    // TODO-cknipe: Confirm this navigation stack behavior is okay
     navigation.push('LOCATION_DASHBOARD', {
       siteId: siteId,
       initialTab: 'SOIL' as SiteTabName,


### PR DESCRIPTION
## Description
- Button to “Add soil data” navigates to the site’s “Soil” tab
- Button does not appear for Viewer role
- Minor renaming

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
2nd PR implementing #1230 

### Verification steps
1. Go to a site's soil ID screen and see the "Add soil data" button (unless you're only a Viewer of the site).
2. Click it and confirm it goes to the Soil tab for the site