### PR TITLE
feat: integrate soil id info sheets with data table

### DIFF
--- a/dev-client/src/components/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/SoilPropertiesDataTable.tsx
@@ -15,6 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {ScrollView} from 'native-base';
 import {useTranslation} from 'react-i18next';
 import {
   Box,
@@ -64,7 +65,7 @@ type Props = {
   rows: SoilPropertiesDataTableRow[];
 } & React.ComponentProps<typeof Box>;
 
-export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
+export const SoilPropertiesDataTable = ({rows}: Props) => {
   const {t} = useTranslation();
 
   const columnWidthDepth: NBDimensionValue = '85px';
@@ -84,38 +85,40 @@ export const SoilPropertiesDataTable = ({rows, ...containerProps}: Props) => {
   };
 
   return (
-    <Box {...containerProps}>
-      <Row justifyContent="flex-start">
-        <DataTableHeader
-          width={columnWidthDepth}
-          text={t('site.soil_id.site_data.soil_properties.depth', {
-            units: 'METRIC',
-          })}
-        />
-        <DataTableHeader
-          width={columnWidthTexture}
-          text={t('site.soil_id.site_data.soil_properties.texture')}
-        />
-        <DataTableHeader
-          width={columnWidthColor}
-          text={t('site.soil_id.site_data.soil_properties.color')}
-        />
-        <DataTableHeader
-          width={columnWidthRockFragment}
-          text={t('site.soil_id.site_data.soil_properties.rock_fragment')}
-        />
-      </Row>
+    <ScrollView horizontal={true}>
+      <Box>
+        <Row justifyContent="flex-start">
+          <DataTableHeader
+            width={columnWidthDepth}
+            text={t('site.soil_id.site_data.soil_properties.depth', {
+              units: 'METRIC',
+            })}
+          />
+          <DataTableHeader
+            width={columnWidthTexture}
+            text={t('site.soil_id.site_data.soil_properties.texture')}
+          />
+          <DataTableHeader
+            width={columnWidthColor}
+            text={t('site.soil_id.site_data.soil_properties.color')}
+          />
+          <DataTableHeader
+            width={columnWidthRockFragment}
+            text={t('site.soil_id.site_data.soil_properties.rock_fragment')}
+          />
+        </Row>
 
-      <Box borderTopWidth="1px" borderLeftWidth="1px">
-        {rows.map((row: (typeof rows)[number], i: number) => (
-          <Row justifyContent="flex-start" key={uniqueKeyForRow(row, i)}>
-            <DataTableCell text={row[0]} width={columnWidthDepth} />
-            <DataTableCell text={row[1]} width={columnWidthTexture} />
-            <DataTableCell text={row[2]} width={columnWidthColor} />
-            <DataTableCell text={row[3]} width={columnWidthRockFragment} />
-          </Row>
-        ))}
+        <Box borderTopWidth="1px" borderLeftWidth="1px">
+          {rows.map((row: (typeof rows)[number], i: number) => (
+            <Row justifyContent="flex-start" key={uniqueKeyForRow(row, i)}>
+              <DataTableCell text={row[0]} width={columnWidthDepth} />
+              <DataTableCell text={row[1]} width={columnWidthTexture} />
+              <DataTableCell text={row[2]} width={columnWidthColor} />
+              <DataTableCell text={row[3]} width={columnWidthRockFragment} />
+            </Row>
+          ))}
+        </Box>
       </Box>
-    </Box>
+    </ScrollView>
   );
 };

--- a/dev-client/src/model/soilId/soilIdPlaceholders.ts
+++ b/dev-client/src/model/soilId/soilIdPlaceholders.ts
@@ -15,7 +15,15 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {SoilPropertiesDataTableRow} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+
 /* To be replaced with actual integration w/ soilId schema */
+
+export const SOIL_PROPERTIES_TABLE_ROWS: SoilPropertiesDataTableRow[] = [
+  ['0-10', 'Clay', '7.5YR 8.5/1', '50-85%'],
+  ['11-20', 'Sandy Clay Loam', '7.5YR 8.5/1', '1-15%'],
+  ['100-120', '', '', ''],
+];
 
 export type LocationBasedSoilMatch = {
   dataSource: string;

--- a/dev-client/src/model/soilId/soilIdPlaceholders.ts
+++ b/dev-client/src/model/soilId/soilIdPlaceholders.ts
@@ -105,3 +105,5 @@ export const DATA_BASED_SOIL_MATCH: DataBasedSoilMatch = {
   dataMatch: SOIL_MATCH_INFO,
   combinedMatch: SOIL_MATCH_INFO,
 };
+
+export const SOIL_DATA: any = {};

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -28,10 +28,8 @@ import {
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {
-  SoilPropertiesDataTable,
-  SoilPropertiesDataTableRow,
-} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+import {SOIL_PROPERTIES_TABLE_ROWS} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 
 type Props = {siteId: string};
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
@@ -42,12 +40,6 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
     navigation.navigate('LOCATION_DASHBOARD', {siteId});
   }, [navigation, siteId]);
 
-  const bogusDataRows: SoilPropertiesDataTableRow[] = [
-    ['0-10', 'Clay', '7.5YR 8.5/1', '50-85%'],
-    ['11-20', 'Sandy Clay Loam', '7.5YR 8.5/1', '1-15%'],
-    ['100-120', '', '', ''],
-  ];
-
   return (
     <>
       <Heading variant="h6" pt="lg">
@@ -56,7 +48,7 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
 
       <Box marginTop="sm" />
       <ScrollView horizontal={true}>
-        <SoilPropertiesDataTable rows={bogusDataRows} />
+        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
       </ScrollView>
 
       <Box paddingVertical="lg">

--- a/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SiteDataSection.tsx
@@ -18,7 +18,6 @@
 import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button} from 'native-base';
-import {ScrollView} from 'react-native-gesture-handler';
 
 import {
   Box,
@@ -47,9 +46,7 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
       </Heading>
 
       <Box marginTop="sm" />
-      <ScrollView horizontal={true}>
-        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
-      </ScrollView>
+      <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
 
       <Box paddingVertical="lg">
         <Button

--- a/dev-client/src/screens/LocationScreens/components/SoilIdSections.tsx
+++ b/dev-client/src/screens/LocationScreens/components/SoilIdSections.tsx
@@ -28,6 +28,7 @@ import {ScreenContentSection} from 'terraso-mobile-client/components/content/Scr
 import {
   DATA_BASED_SOIL_MATCH,
   LOCATION_BASED_SOIL_MATCH,
+  SOIL_DATA,
 } from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {InfoOverlaySheet} from 'terraso-mobile-client/components/sheets/InfoOverlaySheet';
@@ -55,6 +56,7 @@ export const SoilIdMatchesSection = ({siteId, coords}: SoilIdSectionProps) => {
   const isSite = !!siteId;
 
   const locationMatch = LOCATION_BASED_SOIL_MATCH;
+  const soilData = SOIL_DATA;
   const dataMatch = DATA_BASED_SOIL_MATCH;
 
   return (
@@ -76,6 +78,7 @@ export const SoilIdMatchesSection = ({siteId, coords}: SoilIdSectionProps) => {
           <SiteScoreInfoContent
             locationMatch={locationMatch}
             dataMatch={dataMatch}
+            soilData={soilData}
             coords={coords}
           />
         ) : (

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
@@ -22,7 +22,6 @@ import {
   LocationBasedSoilMatch,
   SOIL_PROPERTIES_TABLE_ROWS,
 } from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
-import {ScrollView} from 'react-native-gesture-handler';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 import {VStack} from 'native-base';
 
@@ -37,9 +36,7 @@ export function PropertiesDisplay({}: PropertiesDisplayProps) {
       <Heading variant="h6">
         {t('site.soil_id.soil_info.properties_header')}
       </Heading>
-      <ScrollView horizontal={true}>
-        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
-      </ScrollView>
+      <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
     </VStack>
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
@@ -17,42 +17,26 @@
 
 import {useTranslation} from 'react-i18next';
 
+import {Heading} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
-  Heading,
-  HStack,
-  Row,
-  VStack,
-} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
-import {
-  DataBasedSoilMatch,
+  LocationBasedSoilMatch,
   SOIL_PROPERTIES_TABLE_ROWS,
 } from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
-import {SoilPropertiesScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilPropertiesScoreInfoContent';
-import {ScoreTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreTile';
 import {ScrollView} from 'react-native-gesture-handler';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+import {VStack} from 'native-base';
 
-type PropertiesScoreDisplayProps = {
-  match: DataBasedSoilMatch;
+type PropertiesDisplayProps = {
+  match: LocationBasedSoilMatch;
 };
 
-export function PropertiesScoreDisplay({match}: PropertiesScoreDisplayProps) {
+export function PropertiesDisplay({}: PropertiesDisplayProps) {
   const {t} = useTranslation();
   return (
     <VStack space="16px">
-      <HStack justifyContent="space-between" alignItems="center">
-        <Row alignItems="stretch" maxWidth="75%">
-          <Heading variant="h6">
-            {t('site.soil_id.soil_properties_score_info.header')}
-          </Heading>
-          <InfoOverlaySheetButton
-            Header={t('site.soil_id.soil_properties_score_info.header')}>
-            <SoilPropertiesScoreInfoContent />
-          </InfoOverlaySheetButton>
-        </Row>
-        <ScoreTile score={match.combinedMatch.score} />
-      </HStack>
+      <Heading variant="h6">
+        {t('site.soil_id.soil_info.properties_header')}
+      </Heading>
       <ScrollView horizontal={true}>
         <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
       </ScrollView>

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
@@ -31,8 +31,10 @@ import {
 import {SoilPropertiesScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilPropertiesScoreInfoContent';
 import {ScoreTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreTile';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+import {SoilData} from 'terraso-client-shared/soilId/soilIdTypes';
 
 type PropertiesScoreDisplayProps = {
+  data: SoilData;
   match: DataBasedSoilMatch;
 };
 

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
@@ -30,7 +30,6 @@ import {
 } from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {SoilPropertiesScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilPropertiesScoreInfoContent';
 import {ScoreTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreTile';
-import {ScrollView} from 'react-native-gesture-handler';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 type PropertiesScoreDisplayProps = {
@@ -53,9 +52,7 @@ export function PropertiesScoreDisplay({match}: PropertiesScoreDisplayProps) {
         </Row>
         <ScoreTile score={match.combinedMatch.score} />
       </HStack>
-      <ScrollView horizontal={true}>
-        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
-      </ScrollView>
+      <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
     </VStack>
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
@@ -19,15 +19,12 @@ import {SoilInfoDisplay} from 'terraso-mobile-client/screens/LocationScreens/com
 import {
   DataBasedSoilMatch,
   LocationBasedSoilMatch,
-  SOIL_PROPERTIES_TABLE_ROWS,
 } from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {Divider} from 'native-base';
 import {PropertiesScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay';
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {ScoreInfoContainer} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreInfoContainer';
 import {Coords} from 'terraso-client-shared/types';
-import {ScrollView} from 'react-native-gesture-handler';
-import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 type SiteScoreInfoContentProps = {
   locationMatch: LocationBasedSoilMatch;
@@ -54,9 +51,6 @@ export function SiteScoreInfoContent({
       />
       <Divider />
       <PropertiesScoreDisplay match={dataMatch} />
-      <ScrollView horizontal={true}>
-        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
-      </ScrollView>
     </ScoreInfoContainer>
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
@@ -25,15 +25,18 @@ import {PropertiesScoreDisplay} from 'terraso-mobile-client/screens/LocationScre
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {ScoreInfoContainer} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreInfoContainer';
 import {Coords} from 'terraso-client-shared/types';
+import {SoilData} from 'terraso-client-shared/soilId/soilIdTypes';
 
 type SiteScoreInfoContentProps = {
   locationMatch: LocationBasedSoilMatch;
+  soilData: SoilData;
   dataMatch: DataBasedSoilMatch;
   coords: Coords;
 };
 
 export function SiteScoreInfoContent({
   locationMatch,
+  soilData,
   dataMatch,
   coords,
 }: SiteScoreInfoContentProps) {
@@ -50,7 +53,7 @@ export function SiteScoreInfoContent({
         coords={coords}
       />
       <Divider />
-      <PropertiesScoreDisplay match={dataMatch} />
+      <PropertiesScoreDisplay data={soilData} match={dataMatch} />
     </ScoreInfoContainer>
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
@@ -19,12 +19,15 @@ import {SoilInfoDisplay} from 'terraso-mobile-client/screens/LocationScreens/com
 import {
   DataBasedSoilMatch,
   LocationBasedSoilMatch,
+  SOIL_PROPERTIES_TABLE_ROWS,
 } from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {Divider} from 'native-base';
 import {PropertiesScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay';
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {ScoreInfoContainer} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreInfoContainer';
 import {Coords} from 'terraso-client-shared/types';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
 
 type SiteScoreInfoContentProps = {
   locationMatch: LocationBasedSoilMatch;
@@ -51,6 +54,9 @@ export function SiteScoreInfoContent({
       />
       <Divider />
       <PropertiesScoreDisplay match={dataMatch} />
+      <ScrollView horizontal={true}>
+        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
+      </ScrollView>
     </ScoreInfoContainer>
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
@@ -16,12 +16,19 @@
  */
 
 import {SoilInfoDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilInfoDisplay';
-import {LocationBasedSoilMatch} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
+import {
+  LocationBasedSoilMatch,
+  SOIL_PROPERTIES_TABLE_ROWS,
+} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {Divider} from 'native-base';
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {ScoreInfoContainer} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreInfoContainer';
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {Coords} from 'terraso-client-shared/types';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
+import {Heading} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useTranslation} from 'react-i18next';
 
 type TempScoreInfoContentProps = {
   locationMatch: LocationBasedSoilMatch;
@@ -32,6 +39,7 @@ export function TempScoreInfoContent({
   locationMatch,
   coords,
 }: TempScoreInfoContentProps) {
+  const {t} = useTranslation();
   return (
     <ScoreInfoContainer>
       <SoilInfoDisplay
@@ -44,6 +52,13 @@ export function TempScoreInfoContent({
         match={locationMatch}
         coords={coords}
       />
+      <Divider />
+      <Heading variant="h6">
+        {t('site.soil_id.soil_info.properties_header')}
+      </Heading>
+      <ScrollView horizontal={true}>
+        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
+      </ScrollView>
       <CreateSiteButton coords={coords} />
     </ScoreInfoContainer>
   );

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
@@ -16,19 +16,13 @@
  */
 
 import {SoilInfoDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilInfoDisplay';
-import {
-  LocationBasedSoilMatch,
-  SOIL_PROPERTIES_TABLE_ROWS,
-} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
+import {LocationBasedSoilMatch} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {Divider} from 'native-base';
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {ScoreInfoContainer} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreInfoContainer';
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {Coords} from 'terraso-client-shared/types';
-import {ScrollView} from 'react-native-gesture-handler';
-import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/SoilPropertiesDataTable';
-import {Heading} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useTranslation} from 'react-i18next';
+import {PropertiesDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/PropertiesDisplay';
 
 type TempScoreInfoContentProps = {
   locationMatch: LocationBasedSoilMatch;
@@ -39,7 +33,6 @@ export function TempScoreInfoContent({
   locationMatch,
   coords,
 }: TempScoreInfoContentProps) {
-  const {t} = useTranslation();
   return (
     <ScoreInfoContainer>
       <SoilInfoDisplay
@@ -53,12 +46,7 @@ export function TempScoreInfoContent({
         coords={coords}
       />
       <Divider />
-      <Heading variant="h6">
-        {t('site.soil_id.soil_info.properties_header')}
-      </Heading>
-      <ScrollView horizontal={true}>
-        <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
-      </ScrollView>
+      <PropertiesDisplay match={locationMatch} />
       <CreateSiteButton coords={coords} />
     </ScoreInfoContainer>
   );

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -128,7 +128,8 @@
         "location_url": "View location on soil web",
         "inside_map_label": "In soil map unit",
         "outside_map_label": "In adjacent map unit, {{distance}} {{units}} distance",
-        "map_units_METRIC": "meters"
+        "map_units_METRIC": "meters",
+        "properties_header": "Soil Properties"
       },
       "location_score_info": {
         "header": "Location Score",


### PR DESCRIPTION
## Description

Add soil data table to temp location and site soil info sheets. Refactor some associated components and add basic data plumbing to make future integration work on soil ID easier.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes [#....](https://github.com/techmatters/terraso-mobile-client/issues/1158)

### Verification steps

Open temp location pin and navigate to info sheet. Verify that table displays as expected. Open a site and navigate to the info sheet. Verify that the table displays as expected there as well.