### PR TITLE
fix: request permissions before using camera/media library in image picker

### DIFF
--- a/dev-client/.depcheckrc
+++ b/dev-client/.depcheckrc
@@ -16,6 +16,7 @@
     "eslint-plugin-prettier",
     "expo-crypto",
     "expo-dev-client",
+    "expo-modules-core",
     "metro-react-native-babel-preset",
     "react-devtools",
     "react-native-gradle-plugin",

--- a/dev-client/src/components/inputs/image/ImagePicker.tsx
+++ b/dev-client/src/components/inputs/image/ImagePicker.tsx
@@ -23,6 +23,8 @@ import {
   launchCameraAsync,
   launchImageLibraryAsync,
   MediaTypeOptions,
+  useCameraPermissions,
+  useMediaLibraryPermissions,
 } from 'expo-image-picker';
 import {createAssetAsync} from 'expo-media-library';
 
@@ -35,6 +37,7 @@ import {
   ModalHandle,
   ModalTrigger,
 } from 'terraso-mobile-client/components/modals/Modal';
+import {PermissionsRequestModal} from 'terraso-mobile-client/components/modals/PermissionsRequestModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {OverlaySheet} from 'terraso-mobile-client/components/sheets/OverlaySheet';
 
@@ -56,10 +59,16 @@ export const decodeBase64Jpg = (base64: string) =>
 
 type Props = {
   onPick: (result: Photo) => void;
+  featureName: string;
   children: ModalTrigger;
 };
 
-export const ImagePicker = ({onPick, children, ...modalProps}: Props) => {
+export const ImagePicker = ({
+  onPick,
+  children,
+  featureName,
+  ...modalProps
+}: Props) => {
   const {t} = useTranslation();
   const ref = useRef<ModalHandle>(null);
 
@@ -74,9 +83,9 @@ export const ImagePicker = ({onPick, children, ...modalProps}: Props) => {
       onPick(response.assets[0]);
     }
     ref.current?.onClose();
-  }, [onPick, ref]);
+  }, [onPick]);
 
-  const onUseGallery = useCallback(async () => {
+  const onUseMediaLibrary = useCallback(async () => {
     const response = await launchImageLibraryAsync({
       mediaTypes: MediaTypeOptions.Images,
     });
@@ -84,25 +93,41 @@ export const ImagePicker = ({onPick, children, ...modalProps}: Props) => {
       onPick(response.assets[0]);
     }
     ref.current?.onClose();
-  }, [onPick, ref]);
+  }, [onPick]);
 
-  const onCancel = useCallback(() => ref.current?.onClose(), [ref]);
+  const onCancel = useCallback(() => ref.current?.onClose(), []);
 
   return (
     <OverlaySheet ref={ref} trigger={children} Closer={null} {...modalProps}>
       <Column padding="lg" space="md">
-        <Button
-          _text={{textTransform: 'uppercase'}}
-          onPress={onUseCamera}
-          rightIcon={<Icon name="photo-camera" />}>
-          {t('image.use_camera')}
-        </Button>
-        <Button
-          _text={{textTransform: 'uppercase'}}
-          onPress={onUseGallery}
-          rightIcon={<Icon name="photo-library" />}>
-          {t('image.choose_from_gallery')}
-        </Button>
+        <PermissionsRequestModal
+          title={t('permissions.camera_title')}
+          body={t('permissions.camera_body', {feature: featureName})}
+          usePermissions={useCameraPermissions}
+          permissionedAction={onUseCamera}>
+          {onRequestAction => (
+            <Button
+              _text={{textTransform: 'uppercase'}}
+              onPress={onRequestAction}
+              rightIcon={<Icon name="photo-camera" />}>
+              {t('image.use_camera')}
+            </Button>
+          )}
+        </PermissionsRequestModal>
+        <PermissionsRequestModal
+          title={t('permissions.gallery_title')}
+          body={t('permissions.gallery_body', {feature: featureName})}
+          usePermissions={useMediaLibraryPermissions}
+          permissionedAction={onUseMediaLibrary}>
+          {onRequestAction => (
+            <Button
+              _text={{textTransform: 'uppercase'}}
+              onPress={onRequestAction}
+              rightIcon={<Icon name="photo-library" />}>
+              {t('image.choose_from_gallery')}
+            </Button>
+          )}
+        </PermissionsRequestModal>
         <Button
           _text={{textTransform: 'uppercase'}}
           variant="outline"

--- a/dev-client/src/components/inputs/image/PickImageButton.tsx
+++ b/dev-client/src/components/inputs/image/PickImageButton.tsx
@@ -18,16 +18,20 @@
 import {Pressable} from 'react-native';
 
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {ImagePicker, Photo} from 'terraso-mobile-client/components/ImagePicker';
+import {
+  ImagePicker,
+  Photo,
+} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 
 type Props = {
+  featureName: string;
   onPick: (photo: Photo) => void;
 };
 
-export const PickImageButton = ({onPick}: Props) => {
+export const PickImageButton = ({featureName, onPick}: Props) => {
   return (
-    <ImagePicker onPick={onPick}>
+    <ImagePicker featureName={featureName} onPick={onPick}>
       {onOpen => (
         <Pressable onPress={onOpen}>
           <Box

--- a/dev-client/src/components/modals/PermissionsRequestModal.tsx
+++ b/dev-client/src/components/modals/PermissionsRequestModal.tsx
@@ -1,0 +1,63 @@
+import {useCallback, useRef} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Linking} from 'react-native';
+
+import {createPermissionHook} from 'expo-modules-core';
+
+import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
+import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
+
+type PermissionHook = ReturnType<typeof createPermissionHook>;
+
+type Props = {
+  title: string;
+  body: string;
+  usePermissions: PermissionHook;
+  permissionedAction?: () => void;
+  children: (onOpen: () => void) => React.ReactNode;
+};
+
+export const PermissionsRequestModal = ({
+  title,
+  body,
+  usePermissions,
+  permissionedAction,
+  children,
+}: Props) => {
+  const {t} = useTranslation();
+  const ref = useRef<ModalHandle>(null);
+  const [permissions, requestPermissions] = usePermissions();
+
+  const onRequestAction = useCallback(async () => {
+    if (permissions === null) {
+      return;
+    }
+
+    if (permissions.granted) {
+      if (permissionedAction !== undefined) {
+        permissionedAction();
+      }
+    } else if (permissions.canAskAgain) {
+      const result = await requestPermissions();
+      if (result.granted && permissionedAction !== undefined) {
+        permissionedAction();
+      }
+    } else {
+      ref.current?.onOpen();
+    }
+  }, [permissionedAction, permissions, requestPermissions]);
+
+  return (
+    <>
+      <ConfirmModal
+        ref={ref}
+        isConfirmError={false}
+        actionName={t('general.open_settings')}
+        title={title}
+        body={body}
+        handleConfirm={Linking.openSettings}
+      />
+      {children(onRequestAction)}
+    </>
+  );
+};

--- a/dev-client/src/components/modals/PermissionsRequestModal.tsx
+++ b/dev-client/src/components/modals/PermissionsRequestModal.tsx
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
 import {useCallback, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Linking} from 'react-native';

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
@@ -28,7 +28,7 @@ import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
 import {
   decodeBase64Jpg,
   PhotoWithBase64,
-} from 'terraso-mobile-client/components/ImagePicker';
+} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {
   ActionButton,
   ActionsModal,

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
@@ -17,7 +17,7 @@
 
 import {useMemo, useState} from 'react';
 
-import {Photo} from 'terraso-mobile-client/components/ImagePicker';
+import {Photo} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {DEFAULT_STACK_NAVIGATOR_OPTIONS} from 'terraso-mobile-client/navigation/constants';
 import {
   ColorAnalysisContext,

--- a/dev-client/src/screens/ColorAnalysisScreen/components/ColorCropScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/components/ColorCropScreen.tsx
@@ -38,7 +38,7 @@ import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   Photo,
   PhotoWithBase64,
-} from 'terraso-mobile-client/components/ImagePicker';
+} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {
   Box,
   Column,

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -17,24 +17,23 @@
 
 import {useCallback, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Linking} from 'react-native';
 
 import {CameraView, useCameraPermissions} from 'expo-camera';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import {DeviceMotion} from 'expo-sensors';
 
-import {Button, Link} from 'native-base';
+import {Button} from 'native-base';
 
 import {updateSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
 
 import {BigCloseButton} from 'terraso-mobile-client/components/buttons/BigCloseButton';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {PermissionsRequestModal} from 'terraso-mobile-client/components/modals/PermissionsRequestModal';
 import {
   Box,
   Column,
   Heading,
   Row,
-  Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -47,7 +46,7 @@ const toDegrees = (rad: number) => Math.round(Math.abs((rad * 180) / Math.PI));
 
 export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
   const {t} = useTranslation();
-  const [permission, requestPermission] = useCameraPermissions();
+  const [permission] = useCameraPermissions();
   const [deviceTiltDeg, setDeviceTiltDeg] = useState<number | null>(null);
   const navigation = useNavigation();
   const dispatch = useDispatch();
@@ -100,20 +99,19 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
                 <Box flex={1} bg="#00000080" />
               </Column>
             </CameraView>
-          ) : permission?.canAskAgain ? (
-            <Button size="lg" onPress={requestPermission}>
-              {t('slope.steepness.camera_grant')}
-            </Button>
           ) : (
-            <>
-              <Heading variant="h6">{t('slope.steepness.no_camera')}</Heading>
-              <Text variant="body1" textAlign="center">
-                {t('slope.steepness.no_camera_explanation')}
-              </Text>
-              <Link onPress={Linking.openSettings}>
-                {t('general.open_settings')}
-              </Link>
-            </>
+            <PermissionsRequestModal
+              title={t('permissions.camera_title')}
+              body={t('permissions.camera_body', {
+                feature: t('slope.steepness.slope_meter'),
+              })}
+              usePermissions={useCameraPermissions}>
+              {onRequest => (
+                <Button size="lg" onPress={onRequest}>
+                  {t('slope.steepness.camera_grant')}
+                </Button>
+              )}
+            </PermissionsRequestModal>
           )}
         </Box>
         <Column alignItems="center">

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
@@ -23,7 +23,10 @@ import {Button} from 'native-base';
 
 import {BulletList} from 'terraso-mobile-client/components/BulletList';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {ImagePicker, Photo} from 'terraso-mobile-client/components/ImagePicker';
+import {
+  ImagePicker,
+  Photo,
+} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {
   Box,
   Column,
@@ -125,7 +128,9 @@ export const ColorGuideScreen = (props: SoilPitInputScreenProps) => {
         <Button variant="link" onPress={onGoBack}>
           {t('soil.color.guide.go_back')}
         </Button>
-        <ImagePicker onPick={onTakePhoto}>
+        <ImagePicker
+          featureName={t('soil.color.featureName')}
+          onPick={onTakePhoto}>
           {onOpen => (
             <Button
               _text={{textTransform: 'uppercase'}}

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/CameraWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/CameraWorkflow.tsx
@@ -21,8 +21,8 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'native-base';
 
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {Photo} from 'terraso-mobile-client/components/ImagePicker';
-import {PickImageButton} from 'terraso-mobile-client/components/inputs/PickImageButton';
+import {Photo} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
+import {PickImageButton} from 'terraso-mobile-client/components/inputs/image/PickImageButton';
 import {
   Box,
   Column,
@@ -53,7 +53,10 @@ export const CameraWorkflow = (props: SoilPitInputScreenProps) => {
   return (
     <Column>
       <Box alignItems="center" paddingVertical="lg">
-        <PickImageButton onPick={onPickImage} />
+        <PickImageButton
+          featureName={t('soil.color.featureName')}
+          onPick={onPickImage}
+        />
       </Box>
       <Column
         backgroundColor="grey.300"

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -442,10 +442,10 @@
     "proceed": "Proceed"
   },
   "permissions": {
-    "camera_title": "LandPKS needs to access your camera",
-    "camera_body": "To use {{feature}}, grant LandPKS access to your camera in device settings.",
-    "gallery_title": "LandPKS needs to access your photo gallery",
-    "gallery_body": "To use {{feature}}, grant LandPKS access to your photo gallery in device settings."
+    "camera_title": "LandPKS Soil ID needs to access your camera",
+    "camera_body": "To use {{feature}}, grant LandPKS Soil ID access to your camera in device settings.",
+    "gallery_title": "LandPKS Soil ID needs to access your photo gallery",
+    "gallery_body": "To use {{feature}}, grant LandPKS Soil ID access to your photo gallery in device settings."
   },
   "errors": {
     "generic": "Error saving soil ID information."

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -435,11 +435,17 @@
     },
     "required": "Required",
     "character_limit": "{{current}} / {{limit}} characters",
-    "open_settings": "Open Settings",
+    "open_settings": "Go to settings",
     "yes": "Yes",
     "no": "No",
     "next": "Next",
     "proceed": "Proceed"
+  },
+  "permissions": {
+    "camera_title": "LandPKS needs to access your camera",
+    "camera_body": "To use {{feature}}, grant LandPKS access to your camera in device settings.",
+    "gallery_title": "LandPKS needs to access your photo gallery",
+    "gallery_body": "To use {{feature}}, grant LandPKS access to your photo gallery in device settings."
   },
   "errors": {
     "generic": "Error saving soil ID information."
@@ -715,6 +721,7 @@
     },
     "color": {
       "title": "Soil Color",
+      "featureName": "Soil Color",
       "info": {
         "p1": "Soil color can tell you a lot about soil, including:",
         "bullet1": "Which minerals are present",


### PR DESCRIPTION
## Description
What it says on the tin. In draft til I can validate on iOS. Right now when you fix the permissions in settings from the slope screen and then return to the app, you need to leave/re-enter the slope screen to get the app to pick up on the change, the `usePermissions` hook doesn't seem to re-render the screen. not sure if there's a better workaround.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes https://github.com/techmatters/terraso-mobile-client/issues/1328