### PR TITLE
feat: Use actual site data for the soil properties table

### DIFF
--- a/dev-client/src/components/tables/soilProperties/SoilPropertiesData.tsx
+++ b/dev-client/src/components/tables/soilProperties/SoilPropertiesData.tsx
@@ -22,6 +22,7 @@ import {
   SoilIdDepthDependentSoilDataTextureChoices,
   SoilIdSoilData,
 } from 'terraso-client-shared/graphqlSchema/graphql';
+import {AggregatedInterval} from 'terraso-client-shared/selectors';
 import {sameDepth} from 'terraso-client-shared/soilId/soilIdSlice';
 import {
   SoilData,
@@ -39,10 +40,11 @@ export type SoilPropertiesDataTableRow = {
   munsellColor?: string;
 };
 
-export const rowsFromSoilData = (
+export const rowsFromSiteSoilData = (
   data: SoilData,
+  intervals: AggregatedInterval[],
 ): SoilPropertiesDataTableRow[] => {
-  return data.depthIntervals.map(interval => rowFromSoilData(data, interval));
+  return intervals.map(interval => rowFromSoilData(data, interval.interval));
 };
 
 export const rowFromSoilData = (

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
@@ -38,7 +38,6 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
 
-  // TODO: Later we'll likely want the table columns to be based on the required inputs of the project, like in SoilScreen
   const soilData = useSelector(selectSoilData(siteId));
   const dataTableRows = rowsFromSoilData(soilData);
 

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
@@ -18,22 +18,29 @@
 import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button} from 'native-base';
+
 import {
   Box,
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useSelector} from 'terraso-mobile-client/store';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesDataTable';
-import {SOIL_PROPERTIES_TABLE_ROWS} from 'terraso-mobile-client/model/soilId/soilIdPlaceholders';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {selectSoilData} from 'terraso-client-shared/selectors';
+import {rowsFromSoilData} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesData';
 
 type Props = {siteId: string};
 
 export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
+
+  // TODO: Later we'll likely want the table columns to be based on the required inputs of the project, like in SoilScreen
+  const soilData = useSelector(selectSoilData(siteId));
+  const dataTableRows = rowsFromSoilData(soilData);
 
   const onAddSoilDataPress = useCallback(() => {
     navigation.push('LOCATION_DASHBOARD', {
@@ -49,7 +56,7 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
       </Heading>
 
       <Box marginTop="sm" />
-      <SoilPropertiesDataTable rows={SOIL_PROPERTIES_TABLE_ROWS} />
+      <SoilPropertiesDataTable rows={dataTableRows} />
 
       <RestrictBySiteRole
         role={[

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
@@ -23,14 +23,17 @@ import {
   Box,
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useSelector} from 'terraso-mobile-client/store';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesDataTable';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {selectSoilData} from 'terraso-client-shared/selectors';
-import {rowsFromSoilData} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesData';
+import {rowsFromSiteSoilData} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesData';
+import {
+  selectSoilData,
+  useSiteSoilIntervals,
+} from 'terraso-client-shared/selectors';
+import {useSelector} from 'terraso-mobile-client/store';
 
 type Props = {siteId: string};
 
@@ -38,8 +41,9 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
 
+  const allIntervals = useSiteSoilIntervals(siteId);
   const soilData = useSelector(selectSoilData(siteId));
-  const dataTableRows = rowsFromSoilData(soilData);
+  const dataTableRows = rowsFromSiteSoilData(soilData, allIntervals);
 
   const onAddSoilDataPress = useCallback(() => {
     navigation.push('LOCATION_DASHBOARD', {


### PR DESCRIPTION
## Description
- Create table rows with real soilData collected for the site
- Use `SoilData.depthIntervals` (which has one per depth interval, regardless of if there are data collected for that interval) to make table rows, instead of `SoilData.depthDependentData` (which excludes depth intervals for which there are no data). 

### Related Issues
Implements #1231