### PR TITLE
feat: add lat/lng to temporary site popover

### DIFF
--- a/dev-client/src/components/StaticMapView.tsx
+++ b/dev-client/src/components/StaticMapView.tsx
@@ -20,7 +20,6 @@ import {StyleProp, ViewStyle} from 'react-native';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Position} from '@rnmapbox/maps/lib/typescript/src/types/Position';
 import {useMemo} from 'react';
-import {COORDINATE_PRECISION} from 'terraso-mobile-client/constants';
 import {
   LATITUDE_MAX,
   LATITUDE_MIN,
@@ -28,6 +27,7 @@ import {
   LONGITUDE_MAX,
 } from 'terraso-mobile-client/constants';
 import {Coords} from 'terraso-client-shared/types';
+import {formatCoordinate} from 'terraso-mobile-client/util';
 
 const coordsRegex = /^(-?\d+\.\d+)\s*[, ]\s*(-?\d+\.\d+)$/;
 export type CoordsParseErrorReason =
@@ -73,10 +73,8 @@ export const parseCoords = (coords: string) => {
   }
 };
 
-export const coordToString = (coord: number) =>
-  coord.toFixed(COORDINATE_PRECISION);
 export const coordsToString = ({latitude, longitude}: Coords): string =>
-  `${coordToString(latitude)},${coordToString(longitude)}`;
+  `${formatCoordinate(latitude)},${formatCoordinate(longitude)}`;
 
 export const coordsToPosition = ({latitude, longitude}: Coords): Position => [
   longitude,

--- a/dev-client/src/components/StaticMapView.tsx
+++ b/dev-client/src/components/StaticMapView.tsx
@@ -28,6 +28,7 @@ import {
 } from 'terraso-mobile-client/constants';
 import {Coords} from 'terraso-client-shared/types';
 import {formatCoordinate} from 'terraso-mobile-client/util';
+import i18n from 'terraso-mobile-client/translations';
 
 const coordsRegex = /^(-?\d+\.\d+)\s*[, ]\s*(-?\d+\.\d+)$/;
 export type CoordsParseErrorReason =
@@ -73,8 +74,12 @@ export const parseCoords = (coords: string) => {
   }
 };
 
-export const coordsToString = ({latitude, longitude}: Coords): string =>
-  `${formatCoordinate(latitude)},${formatCoordinate(longitude)}`;
+export const coordsToString = ({latitude, longitude}: Coords): string => {
+  return i18n.t('site.coords', {
+    lat: formatCoordinate(latitude),
+    lng: formatCoordinate(longitude),
+  });
+};
 
 export const coordsToPosition = ({latitude, longitude}: Coords): Position => [
   longitude,

--- a/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
+++ b/dev-client/src/screens/HomeScreen/HomeScreenCallout.ts
@@ -26,6 +26,7 @@ export type CalloutState =
   | {
       kind: 'location';
       coords: Coords;
+      isCurrentLocation: boolean;
     }
   | {
       kind: 'site_cluster';
@@ -45,8 +46,11 @@ export function siteClusterCallout(
   return {kind: 'site_cluster', coords, siteIds: Array.from(siteIds)};
 }
 
-export function locationCallout(coords: Coords): CalloutState {
-  return {kind: 'location', coords};
+export function locationCallout(
+  coords: Coords,
+  isCurrentLocation: boolean = false,
+): CalloutState {
+  return {kind: 'location', coords, isCurrentLocation};
 }
 
 export function noneCallout(): CalloutState {

--- a/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
+++ b/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import {useTranslation} from 'react-i18next';
+import {Coords} from 'terraso-client-shared/types';
+import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+
+type NewType = {
+  isCurrentLocation: boolean;
+  coords: Coords;
+};
+
+export const LatLngDetail = ({isCurrentLocation, coords}: NewType) => {
+  const {t} = useTranslation();
+
+  return (
+    <Box>
+      {isCurrentLocation && <Text bold>{t('site.your_location')}</Text>}
+      <Text variant="body2">
+        {t('site.coords', {
+          lat: coords.latitude.toFixed(5),
+          lng: coords.longitude.toFixed(5),
+        })}
+      </Text>
+    </Box>
+  );
+};

--- a/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
+++ b/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
@@ -20,12 +20,12 @@ import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useSelector} from 'terraso-mobile-client/store';
 import {formatCoordinate} from 'terraso-mobile-client/util';
 
-type NewType = {
+type Props = {
   isCurrentLocation: boolean;
   coords: Coords;
 };
 
-export const LatLngDetail = ({isCurrentLocation, coords}: NewType) => {
+export const LatLngDetail = ({isCurrentLocation, coords}: Props) => {
   const {t} = useTranslation();
   const {accuracyM} = useSelector(state => state.map.userLocation);
 

--- a/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
+++ b/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
@@ -18,6 +18,7 @@ import {useTranslation} from 'react-i18next';
 import {Coords} from 'terraso-client-shared/types';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useSelector} from 'terraso-mobile-client/store';
+import {formatCoordinate} from 'terraso-mobile-client/util';
 
 type NewType = {
   isCurrentLocation: boolean;
@@ -37,8 +38,8 @@ export const LatLngDetail = ({isCurrentLocation, coords}: NewType) => {
       )}
       <Text variant="body2">
         {t('site.coords', {
-          lat: coords.latitude.toFixed(5),
-          lng: coords.longitude.toFixed(5),
+          lat: formatCoordinate(coords.latitude),
+          lng: formatCoordinate(coords.longitude),
         })}
       </Text>
       {isCurrentLocation && (

--- a/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
+++ b/dev-client/src/screens/HomeScreen/components/LatLngDetail.tsx
@@ -17,6 +17,7 @@
 import {useTranslation} from 'react-i18next';
 import {Coords} from 'terraso-client-shared/types';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useSelector} from 'terraso-mobile-client/store';
 
 type NewType = {
   isCurrentLocation: boolean;
@@ -25,16 +26,28 @@ type NewType = {
 
 export const LatLngDetail = ({isCurrentLocation, coords}: NewType) => {
   const {t} = useTranslation();
+  const {accuracyM} = useSelector(state => state.map.userLocation);
 
   return (
     <Box>
-      {isCurrentLocation && <Text bold>{t('site.your_location')}</Text>}
+      {isCurrentLocation && (
+        <Text variant="body2" bold>
+          {t('site.your_location')}
+        </Text>
+      )}
       <Text variant="body2">
         {t('site.coords', {
           lat: coords.latitude.toFixed(5),
           lng: coords.longitude.toFixed(5),
         })}
       </Text>
+      {isCurrentLocation && (
+        <Text variant="body2">
+          {t('site.create.location_accuracy', {
+            accuracyM: accuracyM?.toFixed(0),
+          })}
+        </Text>
+      )}
     </Box>
   );
 };

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -192,7 +192,10 @@ export const SiteMap = memo(
       );
 
       const onPress = useCallback(
-        async (feature: GeoJSON.Feature) => {
+        async (
+          feature: GeoJSON.Feature,
+          isCurrentLocation: boolean = false,
+        ) => {
           if (
             calloutState.kind === 'none' &&
             feature.geometry?.type === 'Point'
@@ -211,7 +214,10 @@ export const SiteMap = memo(
               cameraRef: cameraRef,
             });
             setCalloutState(
-              locationCallout(positionToCoords(feature.geometry.coordinates)),
+              locationCallout(
+                positionToCoords(feature.geometry.coordinates),
+                isCurrentLocation,
+              ),
             );
           } else {
             Keyboard.dismiss();
@@ -225,7 +231,7 @@ export const SiteMap = memo(
         async (event?: GeoJSON.GeoJsonProperties) => {
           if (event?.features[0]) {
             const feature = event.features[0];
-            onPress(feature);
+            onPress(feature, true);
           }
         },
         [onPress],

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -103,8 +103,14 @@ const CalloutChild = (coords: Coords, {sites, state, setState}: Props) => {
         </Card>
       );
     default:
+      const isCurrentLocation =
+        state.kind === 'location' ? state.isCurrentLocation : false;
       return (
-        <TemporarySiteCallout coords={coords} closeCallout={closeCallout} />
+        <TemporarySiteCallout
+          coords={coords}
+          closeCallout={closeCallout}
+          isCurrentLocation={isCurrentLocation}
+        />
       );
   }
 };

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -31,7 +31,7 @@ import {Card} from 'terraso-mobile-client/components/Card';
 import {CloseButton} from 'terraso-mobile-client/components/buttons/CloseButton';
 import {SiteCard} from 'terraso-mobile-client/components/SiteCard';
 import {SiteClusterCalloutListItem} from 'terraso-mobile-client/screens/HomeScreen/components/SiteClusterCalloutListItem';
-import {TemporarySiteCallout} from 'terraso-mobile-client/screens/HomeScreen/components/TemporarySiteCallout';
+import {TemporaryLocationCallout} from 'terraso-mobile-client/screens/HomeScreen/components/TemporaryLocationCallout';
 import {Coords} from 'terraso-client-shared/types';
 
 type Props = {
@@ -106,7 +106,7 @@ const CalloutChild = (coords: Coords, {sites, state, setState}: Props) => {
       const isCurrentLocation =
         state.kind === 'location' ? state.isCurrentLocation : false;
       return (
-        <TemporarySiteCallout
+        <TemporaryLocationCallout
           coords={coords}
           closeCallout={closeCallout}
           isCurrentLocation={isCurrentLocation}

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -41,7 +41,7 @@ type Props = {
   isCurrentLocation: boolean;
 };
 
-export const TemporarySiteCallout = ({
+export const TemporaryLocationCallout = ({
   coords,
   closeCallout,
   isCurrentLocation,

--- a/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporarySiteCallout.tsx
@@ -30,6 +30,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {renderElevation} from 'terraso-mobile-client/components/util/site';
 import {Coords} from 'terraso-client-shared/types';
+import {LatLngDetail} from 'terraso-mobile-client/screens/HomeScreen/components/LatLngDetail';
 
 const TEMP_SOIL_ID_VALUE = 'Clifton';
 const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
@@ -37,9 +38,14 @@ const TEMP_ECO_SITE_PREDICTION = 'Loamy Upland';
 type Props = {
   coords: Coords;
   closeCallout: () => void;
+  isCurrentLocation: boolean;
 };
 
-export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
+export const TemporarySiteCallout = ({
+  coords,
+  closeCallout,
+  isCurrentLocation,
+}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
   const [siteElevationString, setSiteElevationString] = useState('');
@@ -61,14 +67,15 @@ export const TemporarySiteCallout = ({coords, closeCallout}: Props) => {
   return (
     <Card
       Header={
-        <CalloutDetail
-          label={t('site.soil_id_prediction')}
-          value={TEMP_SOIL_ID_VALUE}
-        />
+        <LatLngDetail isCurrentLocation={isCurrentLocation} coords={coords} />
       }
       buttons={<CloseButton onPress={closeCallout} />}
       isPopover={true}>
       <Column mt="12px" space="12px">
+        <CalloutDetail
+          label={t('site.soil_id_prediction')}
+          value={TEMP_SOIL_ID_VALUE}
+        />
         <Divider />
         <CalloutDetail
           label={t('site.ecological_site_prediction')}

--- a/dev-client/src/services.ts
+++ b/dev-client/src/services.ts
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {formatCoordinate} from 'terraso-mobile-client/util';
+
 export const getElevation = async (
   lat: number,
   lng: number,
@@ -23,8 +25,8 @@ export const getElevation = async (
   //    which is why we convert the floats to strings.
   // 2. This API uses X for longitude and Y for latitude. That's not a typo.
   const queryString = new URLSearchParams({
-    x: lng.toFixed(5),
-    y: lat.toFixed(5),
+    x: formatCoordinate(lng),
+    y: formatCoordinate(lat),
     units: 'Meters', // TODO: switch based on user preference
   });
   let elevation;

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -21,6 +21,8 @@
     "progress": "Progress: {{progress}}",
     "members": "{{members}} Members",
     "more_info": "Learn more",
+    "your_location": "Your location",
+    "coords": "{{lat}},{{lng}}",
     "soil_id_prediction": "Soil ID top match",
     "ecological_site_prediction": "Ecological site top match",
     "annual_precip_avg": "Annual precipitation avg",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -22,7 +22,7 @@
     "members": "{{members}} Members",
     "more_info": "Learn more",
     "your_location": "Your location",
-    "coords": "{{lat}},{{lng}}",
+    "coords": "{{lat}}, {{lng}}",
     "soil_id_prediction": "Soil ID top match",
     "ecological_site_prediction": "Ecological site top match",
     "annual_precip_avg": "Annual precipitation avg",

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -22,6 +22,7 @@ import {
   isValidLatitude,
   normalizeText,
 } from 'terraso-client-shared/utils';
+import {COORDINATE_PRECISION} from 'terraso-mobile-client/constants';
 
 export const getSystemLocale = () => {
   let locale;
@@ -52,7 +53,9 @@ export const formatPercent = (value: number) => {
 };
 
 export const formatCoordinate = (value: number) => {
-  return value.toLocaleString(undefined, {maximumFractionDigits: 5});
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: COORDINATE_PRECISION,
+  });
 };
 
 export const formatName = (firstName: string, lastName?: string) => {

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -51,6 +51,10 @@ export const formatPercent = (value: number) => {
   return value.toLocaleString(undefined, {style: 'percent'});
 };
 
+export const formatCoordinate = (value: number) => {
+  return value.toLocaleString(undefined, {maximumFractionDigits: 5});
+};
+
 export const formatName = (firstName: string, lastName?: string) => {
   return [lastName, firstName].filter(Boolean).join(', ');
 };


### PR DESCRIPTION
## Description
Add lat/lng to temporary site popover.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/720