### PR TITLE
fix: don't crash after deleting site

### DIFF
--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -46,6 +46,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
   const site = useSelector(state => state.site.sites[siteId]);
+  const [name, setName] = useState(site?.name);
 
   const onSave = useCallback(
     () => dispatch(updateSite({id: site.id, name})),
@@ -54,13 +55,15 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
 
   const onDelete = useCallback(async () => {
     await dispatch(deleteSite(site));
-    navigation.pop();
+    navigation.navigate('BOTTOM_TABS');
   }, [dispatch, navigation, site]);
 
+  if (!site) {
+    return null;
+  }
+
   return (
-    <ScreenScaffold
-      BottomNavigation={null}
-      AppBar={<AppBar title={site.name} />}>
+    <ScreenScaffold BottomNavigation={null} AppBar={<AppBar title={name} />}>
       <Column px="16px" py="22px" space="20px" alignItems="flex-start">
         <Input value={name} onChangeText={setName} />
         <ConfirmModal

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -44,15 +44,8 @@ type Props = {
 export const SiteSettingsScreen = ({siteId}: Props) => {
   const dispatch = useDispatch();
   const {t} = useTranslation();
-  // const {colors} = useTheme();
   const navigation = useNavigation();
   const site = useSelector(state => state.site.sites[siteId]);
-  const [name, setName] = useState(site.name);
-
-  // const onTeamPress = useCallback(
-  //   () => navigate('SITE_TEAM_SETTINGS', {siteId}),
-  //   [siteId, navigate],
-  // );
 
   const onSave = useCallback(
     () => dispatch(updateSite({id: site.id, name})),
@@ -70,44 +63,6 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
       AppBar={<AppBar title={site.name} />}>
       <Column px="16px" py="22px" space="20px" alignItems="flex-start">
         <Input value={name} onChangeText={setName} />
-        {/*
-          TODO: Uncomment button after feature is written.
-        <Pressable
-          variant="subtle"
-          w="full"
-          background={colors.grey[200]}
-          py="12px"
-          pl="16px"
-          pr="32px"
-          onPress={onTeamPress}>
-          <Row
-            size="container"
-            alignItems="center"
-            justifyContent="space-around">
-            <Icon name="people-alt" />
-            <Spacer flexGrow={0} w="16px" />
-            <Text>{t('site.dashboard.team_button')}</Text>
-            <Spacer />
-            <Icon name="arrow-forward-ios" />
-          </Row>
-        </Pressable>
-          */}
-        {/*
-          TODO: Uncomment button after archiving code is done.
-        <FormControl alignItems="flex-start">
-          <Button
-            pl={0}
-            variant="link"
-            _text={{textTransform: 'uppercase'}}
-            startIcon={<Icon name="archive" />}
-            endIcon={<Icon name="info" />}>
-            {t('site.dashboard.archive_button')}
-          </Button>
-          <FormControl.HelperText ml="26px" mt={0}>
-            {t('site.dashboard.archive_button_help_text')}
-          </FormControl.HelperText>
-        </FormControl>
-        */}
         <ConfirmModal
           trigger={onOpen => (
             <Button


### PR DESCRIPTION
## Description
Don't crash when deleting a site
- don't navigate to site dashboard or project screen via pop()
- avoid null deference on site settings screen

### Related Issues
Addresses #861.