### PR TITLE
fix: update string to match implementation (allow single email address)

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -308,7 +308,7 @@
     },
     "add_user": {
       "heading": "Add Team Members",
-      "help_text": "Enter single or multiple Terraso email addresses in the field below.",
+      "help_text": "Enter a Terraso email address",
       "user_does_not_exist": "User {{email}} is not a Terraso user, unable to add to project.",
       "user_in_project": "User {{email}} is already a member of this project.",
       "already_added": "User {{email}} already added to user list.",


### PR DESCRIPTION
## Description
On the projects > add team member screen, update the string to match implementation (allow single email address, not multiple).

### Related Issues
Request to support multiple email addresses: #731