### PR TITLE
fix: don’t sent client_id for google/ms SSO

### DIFF
--- a/dev-client/src/auth/index.ts
+++ b/dev-client/src/auth/index.ts
@@ -84,7 +84,7 @@ async function exchangeToken(
     provider,
     jwt: identityJwt,
   };
-  if (provider === 'apple') {
+  if (provider === 'apple' && Platform.OS === 'ios') {
     body.client_id = Constants.expoConfig!.ios?.bundleIdentifier;
   }
   const payload = await request<AuthTokens>({

--- a/dev-client/src/auth/index.ts
+++ b/dev-client/src/auth/index.ts
@@ -27,7 +27,6 @@ import {
   resolveDiscoveryAsync,
 } from 'expo-auth-session';
 import {AppleAuthenticationScope, signInAsync} from 'expo-apple-authentication';
-import Constants from 'expo-constants';
 
 type AuthConfig = AuthRequestConfig & {issuer: IssuerOrDiscovery};
 
@@ -85,7 +84,7 @@ async function exchangeToken(
     jwt: identityJwt,
   };
   if (provider === 'apple' && Platform.OS === 'ios') {
-    body.client_id = Constants.expoConfig!.ios?.bundleIdentifier;
+    body.client_id = configs.apple.clientId;
   }
   const payload = await request<AuthTokens>({
     path: '/auth/token-exchange',

--- a/dev-client/src/auth/index.ts
+++ b/dev-client/src/auth/index.ts
@@ -80,13 +80,16 @@ async function exchangeToken(
   identityJwt: string,
   provider: Omit<AuthProvider, 'google'> | `google-${'ios' | 'android'}`,
 ) {
+  let body: any = {
+    provider,
+    jwt: identityJwt,
+  };
+  if (provider === 'apple') {
+    body.client_id = Constants.expoConfig!.ios?.bundleIdentifier;
+  }
   const payload = await request<AuthTokens>({
     path: '/auth/token-exchange',
-    body: {
-      provider,
-      client_id: Constants.expoConfig!.ios?.bundleIdentifier,
-      jwt: identityJwt,
-    },
+    body: body,
     headers: {'content-type': 'application/json'},
   });
 

--- a/dev-client/src/screens/LoginScreen.tsx
+++ b/dev-client/src/screens/LoginScreen.tsx
@@ -38,6 +38,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {Platform, StyleSheet} from 'react-native';
 import Constants from 'expo-constants';
+import {APP_CONFIG} from 'terraso-mobile-client/config';
 
 export const LoginScreen = () => {
   const {t} = useTranslation();
@@ -127,7 +128,7 @@ export const LoginScreen = () => {
         </Text>
         {isDevelopmentMode && (
           <Text variant="caption" color="primary.contrast">
-            {Constants.expoConfig!.ios?.bundleIdentifier}
+            {APP_CONFIG.appleClientId}
           </Text>
         )}
       </Column>


### PR DESCRIPTION
## Description
Don’t sent client_id for google/ms SSO. Re-enables login for non-Apple providers.