### PR TITLE
fix: redo the text and search components based on React Native Paper

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -293,166 +293,428 @@ exports[`renders correctly 1`] = `
                                     "flexDirection": "column",
                                   },
                                   {
-                                    "rowGap": 12,
+                                    "rowGap": 20,
                                   },
                                 ]
                               }
                             >
                               <View
-                                dataSet={{}}
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-start",
-                                    "marginBottom": 4,
-                                    "marginTop": 4,
-                                  }
+                                  [
+                                    {
+                                      "backgroundColor": "rgba(231, 224, 236, 1)",
+                                      "borderTopLeftRadius": 4,
+                                      "borderTopRightRadius": 4,
+                                    },
+                                    {
+                                      "backgroundColor": "#e4e4e4",
+                                      "minHeight": undefined,
+                                      "width": "100%",
+                                    },
+                                  ]
                                 }
                               >
-                                <Text
-                                  dataSet={{}}
+                                <View
+                                  collapsable={false}
                                   style={
                                     {
-                                      "backgroundColor": undefined,
-                                      "color": "#1A202C",
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "700",
-                                      "letterSpacing": 0.15,
-                                      "lineHeight": 24,
-                                      "textDecorationLine": undefined,
+                                      "backgroundColor": "rgba(73, 69, 79, 1)",
+                                      "bottom": 0,
+                                      "height": 1,
+                                      "left": 0,
+                                      "position": "absolute",
+                                      "right": 0,
+                                      "transform": [
+                                        {
+                                          "scaleY": 0.5,
+                                        },
+                                      ],
+                                      "zIndex": 1,
                                     }
+                                  }
+                                  testID="text-input-underline"
+                                />
+                                <View
+                                  onLayout={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "paddingBottom": 0,
+                                        "paddingTop": 0,
+                                      },
+                                      {
+                                        "minHeight": 56,
+                                      },
+                                    ]
                                   }
                                 >
-                                  Project Name
-                                </Text>
+                                  <View
+                                    collapsable={false}
+                                    pointerEvents="none"
+                                    style={
+                                      {
+                                        "bottom": 0,
+                                        "left": 0,
+                                        "opacity": 1,
+                                        "position": "absolute",
+                                        "right": 0,
+                                        "top": 0,
+                                        "transform": [
+                                          {
+                                            "translateX": 0,
+                                          },
+                                        ],
+                                        "width": 750,
+                                        "zIndex": 3,
+                                      }
+                                    }
+                                  >
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      numberOfLines={1}
+                                      onLayout={[Function]}
+                                      onTextLayout={[Function]}
+                                      style={
+                                        {
+                                          "color": "#8B8B8B",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "left": 0,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "maxWidth": 73,
+                                          "opacity": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "absolute",
+                                          "textAlign": "left",
+                                          "top": 30,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                      testID="text-input-flat-label-active"
+                                    >
+                                      Project Name
+                                    </Text>
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      numberOfLines={1}
+                                      style={
+                                        {
+                                          "color": "rgba(73, 69, 79, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "left": 0,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "maxWidth": 73,
+                                          "opacity": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "absolute",
+                                          "textAlign": "left",
+                                          "top": 30,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                      testID="text-input-flat-label-inactive"
+                                    >
+                                      Project Name
+                                    </Text>
+                                  </View>
+                                  <TextInput
+                                    cursorColor="#8B8B8B"
+                                    editable={true}
+                                    maxFontSizeMultiplier={1.5}
+                                    multiline={false}
+                                    onBlur={[Function]}
+                                    onChangeText={[Function]}
+                                    onFocus={[Function]}
+                                    placeholder=" "
+                                    placeholderTextColor="rgba(73, 69, 79, 1)"
+                                    selectionColor="#8B8B8B"
+                                    style={
+                                      [
+                                        {
+                                          "margin": 0,
+                                        },
+                                        {
+                                          "height": 56,
+                                        },
+                                        {
+                                          "paddingBottom": 4,
+                                          "paddingTop": 24,
+                                        },
+                                        {
+                                          "color": "rgba(28, 27, 31, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "minWidth": 65,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "textAlign": "left",
+                                          "textAlignVertical": "center",
+                                        },
+                                        false,
+                                        [
+                                          {},
+                                        ],
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="text-input-flat"
+                                    underlineColorAndroid="transparent"
+                                  />
+                                </View>
                               </View>
                               <View
-                                dataSet={{}}
-                                isFocused={false}
                                 style={
-                                  {
-                                    "alignItems": "center",
-                                    "borderColor": "#d4d4d4",
-                                    "borderRadius": 4,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "overflow": "hidden",
-                                  }
-                                }
-                              >
-                                <TextInput
-                                  accessible={true}
-                                  autoCorrect={false}
-                                  dataSet={{}}
-                                  defaultValue=""
-                                  editable={true}
-                                  onBlur={[Function]}
-                                  onChangeText={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyPress={[Function]}
-                                  placeholder="Project Name"
-                                  placeholderTextColor="#a3a3a3"
-                                  scrollEnabled={false}
-                                  secureTextEntry={false}
-                                  style={
+                                  [
                                     {
-                                      "backgroundColor": "#00000000",
-                                      "color": "#171717",
-                                      "flex": 1,
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "height": "100%",
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 12,
-                                      "paddingRight": 12,
-                                      "paddingTop": 8,
+                                      "backgroundColor": "rgba(231, 224, 236, 1)",
+                                      "borderTopLeftRadius": 4,
+                                      "borderTopRightRadius": 4,
+                                    },
+                                    {
+                                      "backgroundColor": "#e4e4e4",
+                                      "minHeight": 100,
                                       "width": "100%",
-                                    }
-                                  }
-                                />
-                              </View>
-                              <View
-                                dataSet={{}}
-                                style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-start",
-                                    "marginBottom": 4,
-                                    "marginTop": 4,
-                                  }
+                                    },
+                                  ]
                                 }
                               >
-                                <Text
-                                  dataSet={{}}
+                                <View
+                                  collapsable={false}
                                   style={
                                     {
-                                      "backgroundColor": undefined,
-                                      "color": "#1A202C",
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "700",
-                                      "letterSpacing": 0.15,
-                                      "lineHeight": 24,
-                                      "textDecorationLine": undefined,
+                                      "backgroundColor": "rgba(73, 69, 79, 1)",
+                                      "bottom": 0,
+                                      "height": 1,
+                                      "left": 0,
+                                      "position": "absolute",
+                                      "right": 0,
+                                      "transform": [
+                                        {
+                                          "scaleY": 0.5,
+                                        },
+                                      ],
+                                      "zIndex": 1,
                                     }
+                                  }
+                                  testID="text-input-underline"
+                                />
+                                <View
+                                  onLayout={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "paddingBottom": 0,
+                                        "paddingTop": 0,
+                                      },
+                                      {
+                                        "minHeight": 56,
+                                      },
+                                    ]
                                   }
                                 >
-                                  Project Description
-                                </Text>
-                              </View>
-                              <View
-                                dataSet={{}}
-                                isFocused={false}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "borderColor": "#d4d4d4",
-                                    "borderRadius": 4,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "height": 80,
-                                    "overflow": "hidden",
-                                  }
-                                }
-                              >
-                                <TextInput
-                                  accessible={true}
-                                  autoCompleteType="off"
-                                  autoCorrect={false}
-                                  dataSet={{}}
-                                  editable={true}
-                                  multiline={true}
-                                  onBlur={[Function]}
-                                  onChangeText={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyPress={[Function]}
-                                  placeholder="Project Description"
-                                  placeholderTextColor="#a3a3a3"
-                                  secureTextEntry={false}
-                                  style={
-                                    {
-                                      "backgroundColor": "#00000000",
-                                      "color": "#171717",
-                                      "flex": 1,
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "height": "100%",
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 12,
-                                      "paddingRight": 12,
-                                      "paddingTop": 8,
-                                      "width": "100%",
+                                  <View
+                                    pointerEvents="none"
+                                    style={
+                                      [
+                                        {
+                                          "bottom": 0,
+                                          "left": 0,
+                                          "position": "absolute",
+                                          "right": 0,
+                                          "top": 0,
+                                        },
+                                        {
+                                          "height": 24,
+                                          "zIndex": 2,
+                                        },
+                                        {
+                                          "backgroundColor": "#e4e4e4",
+                                          "left": 16,
+                                          "right": 16,
+                                        },
+                                      ]
                                     }
-                                  }
-                                  textAlignVertical="top"
-                                />
+                                    testID="patch-container"
+                                  />
+                                  <View
+                                    collapsable={false}
+                                    pointerEvents="none"
+                                    style={
+                                      {
+                                        "bottom": 0,
+                                        "left": 0,
+                                        "opacity": 1,
+                                        "position": "absolute",
+                                        "right": 0,
+                                        "top": 0,
+                                        "transform": [
+                                          {
+                                            "translateX": 0,
+                                          },
+                                        ],
+                                        "width": 750,
+                                        "zIndex": 3,
+                                      }
+                                    }
+                                  >
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      numberOfLines={1}
+                                      onLayout={[Function]}
+                                      onTextLayout={[Function]}
+                                      style={
+                                        {
+                                          "color": "#8B8B8B",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "left": 0,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "maxWidth": 73,
+                                          "opacity": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "absolute",
+                                          "textAlign": "left",
+                                          "top": 30,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                      testID="text-input-flat-label-active"
+                                    >
+                                      Project Description
+                                    </Text>
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      numberOfLines={1}
+                                      style={
+                                        {
+                                          "color": "rgba(73, 69, 79, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "left": 0,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "maxWidth": 73,
+                                          "opacity": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "absolute",
+                                          "textAlign": "left",
+                                          "top": 30,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                      testID="text-input-flat-label-inactive"
+                                    >
+                                      Project Description
+                                    </Text>
+                                  </View>
+                                  <TextInput
+                                    cursorColor="#8B8B8B"
+                                    editable={true}
+                                    maxFontSizeMultiplier={1.5}
+                                    multiline={true}
+                                    onBlur={[Function]}
+                                    onChangeText={[Function]}
+                                    onFocus={[Function]}
+                                    placeholder=" "
+                                    placeholderTextColor="rgba(73, 69, 79, 1)"
+                                    selectionColor="#8B8B8B"
+                                    style={
+                                      [
+                                        {
+                                          "margin": 0,
+                                        },
+                                        {},
+                                        {
+                                          "paddingBottom": 4,
+                                          "paddingTop": 31,
+                                        },
+                                        {
+                                          "color": "rgba(28, 27, 31, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "minWidth": 65,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "textAlign": "left",
+                                          "textAlignVertical": "top",
+                                        },
+                                        false,
+                                        [
+                                          {},
+                                        ],
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="text-input-flat"
+                                    underlineColorAndroid="transparent"
+                                  />
+                                </View>
                               </View>
                               <View
                                 dataSet={{}}
@@ -502,8 +764,8 @@ exports[`renders correctly 1`] = `
                                       style={
                                         {
                                           "color": "#1A202C",
-                                          "fontSize": 14,
-                                          "fontWeight": "500",
+                                          "fontSize": 16,
+                                          "fontWeight": "bold",
                                         }
                                       }
                                     >

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -302,52 +302,6 @@ exports[`renders correctly 1`] = `
                               }
                             >
                               <View
-<<<<<<< HEAD
-                                dataSet={{}}
-                                isFocused={false}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "borderColor": "#d4d4d4",
-                                    "borderRadius": 4,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "overflow": "hidden",
-                                  }
-                                }
-                              >
-                                <TextInput
-                                  accessible={true}
-                                  dataSet={{}}
-                                  disabled={false}
-                                  editable={true}
-                                  isRequired={false}
-                                  nativeID="field-5-input"
-                                  onBlur={[Function]}
-                                  onChangeText={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyPress={[Function]}
-                                  placeholder="Site name"
-                                  placeholderTextColor="#a3a3a3"
-                                  readOnly={false}
-                                  required={false}
-                                  secureTextEntry={false}
-                                  style={
-                                    {
-                                      "backgroundColor": "#00000000",
-                                      "color": "#171717",
-                                      "flex": 1,
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "height": "100%",
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 12,
-                                      "paddingRight": 12,
-                                      "paddingTop": 8,
-                                      "width": "100%",
-=======
                                 style={
                                   [
                                     {
@@ -416,7 +370,6 @@ exports[`renders correctly 1`] = `
                                         "width": 750,
                                         "zIndex": 3,
                                       }
->>>>>>> a4aa8fe (test: update test snapshots)
                                     }
                                   >
                                     <Text
@@ -499,7 +452,7 @@ exports[`renders correctly 1`] = `
                                     </Text>
                                   </View>
                                   <TextInput
-                                    cursorColor="#8B8B8B"
+                                    cursorColor="#028843"
                                     editable={true}
                                     maxFontSizeMultiplier={1.5}
                                     multiline={false}
@@ -601,54 +554,103 @@ exports[`renders correctly 1`] = `
                               }
                             >
                               <View
-                                dataSet={{}}
-                                isFocused={false}
                                 style={
-                                  {
-                                    "alignItems": "center",
-                                    "borderColor": "#d4d4d4",
-                                    "borderRadius": 4,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "overflow": "hidden",
-                                  }
+                                  [
+                                    {
+                                      "backgroundColor": "rgba(231, 224, 236, 1)",
+                                      "borderTopLeftRadius": 4,
+                                      "borderTopRightRadius": 4,
+                                    },
+                                    {
+                                      "backgroundColor": "#e4e4e4",
+                                      "minHeight": undefined,
+                                      "width": "100%",
+                                    },
+                                  ]
                                 }
                               >
-                                <TextInput
-                                  accessible={true}
-                                  dataSet={{}}
-                                  disabled={false}
-                                  editable={true}
-                                  isRequired={false}
-                                  keyboardType="decimal-pad"
-                                  nativeID="field-6-input"
-                                  onBlur={[Function]}
-                                  onChangeText={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyPress={[Function]}
-                                  placeholderTextColor="#a3a3a3"
-                                  readOnly={false}
-                                  required={false}
-                                  secureTextEntry={false}
+                                <View
+                                  collapsable={false}
                                   style={
                                     {
-                                      "backgroundColor": "#00000000",
-                                      "color": "#171717",
-                                      "flex": 1,
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "height": "100%",
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 12,
-                                      "paddingRight": 12,
-                                      "paddingTop": 8,
-                                      "width": "100%",
+                                      "backgroundColor": "rgba(73, 69, 79, 1)",
+                                      "bottom": 0,
+                                      "height": 1,
+                                      "left": 0,
+                                      "position": "absolute",
+                                      "right": 0,
+                                      "transform": [
+                                        {
+                                          "scaleY": 0.5,
+                                        },
+                                      ],
+                                      "zIndex": 1,
                                     }
                                   }
-                                  value="0"
+                                  testID="text-input-underline"
                                 />
+                                <View
+                                  onLayout={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "paddingBottom": 0,
+                                        "paddingTop": 0,
+                                      },
+                                      {
+                                        "minHeight": 56,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <TextInput
+                                    cursorColor="#028843"
+                                    editable={true}
+                                    keyboardType="decimal-pad"
+                                    maxFontSizeMultiplier={1.5}
+                                    multiline={false}
+                                    onBlur={[Function]}
+                                    onChangeText={[Function]}
+                                    onFocus={[Function]}
+                                    placeholderTextColor="rgba(73, 69, 79, 1)"
+                                    selectionColor="#8B8B8B"
+                                    style={
+                                      [
+                                        {
+                                          "margin": 0,
+                                        },
+                                        {
+                                          "height": 56,
+                                        },
+                                        {
+                                          "paddingBottom": 0,
+                                          "paddingTop": 0,
+                                        },
+                                        {
+                                          "color": "rgba(28, 27, 31, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "minWidth": 65,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "textAlign": "left",
+                                          "textAlignVertical": "center",
+                                        },
+                                        false,
+                                        [
+                                          {},
+                                        ],
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="text-input-flat"
+                                    underlineColorAndroid="transparent"
+                                    value="0"
+                                  />
+                                </View>
                               </View>
                             </View>
                             <View
@@ -693,11 +695,7 @@ exports[`renders correctly 1`] = `
                                       "zIndex": 1,
                                     }
                                   }
-<<<<<<< HEAD
-                                  value="0"
-=======
                                   testID="text-input-underline"
->>>>>>> a4aa8fe (test: update test snapshots)
                                 />
                                 <View
                                   onLayout={[Function]}
@@ -714,7 +712,7 @@ exports[`renders correctly 1`] = `
                                   }
                                 >
                                   <TextInput
-                                    cursorColor="#8B8B8B"
+                                    cursorColor="#028843"
                                     editable={true}
                                     keyboardType="decimal-pad"
                                     maxFontSizeMultiplier={1.5}
@@ -758,7 +756,7 @@ exports[`renders correctly 1`] = `
                                     }
                                     testID="text-input-flat"
                                     underlineColorAndroid="transparent"
-                                    value=""
+                                    value="0"
                                   />
                                 </View>
                               </View>
@@ -810,427 +808,6 @@ exports[`renders correctly 1`] = `
                                     }
                                   }
                                 >
-<<<<<<< HEAD
-=======
-                                  Add to Project
-                                </Text>
-                                <View
-                                  dataSet={{}}
-                                  style={{}}
-                                >
-                                  <View
-                                    accessibilityRole="button"
-                                    accessibilityState={
-                                      {
-                                        "busy": undefined,
-                                        "checked": undefined,
-                                        "disabled": undefined,
-                                        "expanded": undefined,
-                                        "selected": undefined,
-                                      }
-                                    }
-                                    accessibilityValue={
-                                      {
-                                        "max": undefined,
-                                        "min": undefined,
-                                        "now": undefined,
-                                        "text": undefined,
-                                      }
-                                    }
-                                    accessible={true}
-                                    collapsable={false}
-                                    colorScheme="primary"
-                                    dataSet={{}}
-                                    focusable={true}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onResponderGrant={[Function]}
-                                    onResponderMove={[Function]}
-                                    onResponderRelease={[Function]}
-                                    onResponderTerminate={[Function]}
-                                    onResponderTerminationRequest={[Function]}
-                                    onStartShouldSetResponder={[Function]}
-                                    style={
-                                      {
-                                        "alignItems": "center",
-                                        "borderRadius": 4,
-                                        "flexDirection": "row",
-                                        "justifyContent": "center",
-                                        "marginLeft": 6,
-                                        "paddingBottom": 0,
-                                        "paddingLeft": 0,
-                                        "paddingRight": 0,
-                                        "paddingTop": 0,
-                                      }
-                                    }
-                                  >
-                                    <Icon
-                                      color="#1A202CB2"
-                                      name="help"
-                                      size={24}
-                                      style={{}}
-                                    />
-                                  </View>
-                                </View>
-                              </View>
-                              <View
-                                accessibilityState={
-                                  {
-                                    "busy": undefined,
-                                    "checked": undefined,
-                                    "disabled": undefined,
-                                    "expanded": undefined,
-                                    "selected": undefined,
-                                  }
-                                }
-                                accessibilityValue={
-                                  {
-                                    "max": undefined,
-                                    "min": undefined,
-                                    "now": undefined,
-                                    "text": undefined,
-                                  }
-                                }
-                                accessible={true}
-                                collapsable={false}
-                                focusable={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onResponderGrant={[Function]}
-                                onResponderMove={[Function]}
-                                onResponderRelease={[Function]}
-                                onResponderTerminate={[Function]}
-                                onResponderTerminationRequest={[Function]}
-                                onStartShouldSetResponder={[Function]}
-                              >
-                                <View
-                                  accessibilityState={
-                                    {
-                                      "busy": undefined,
-                                      "checked": undefined,
-                                      "disabled": false,
-                                      "expanded": undefined,
-                                      "selected": undefined,
-                                    }
-                                  }
-                                  accessibilityValue={
-                                    {
-                                      "max": undefined,
-                                      "min": undefined,
-                                      "now": undefined,
-                                      "text": undefined,
-                                    }
-                                  }
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                >
-                                  <View
-                                    style={
-                                      [
-                                        {
-                                          "flexDirection": "row",
-                                        },
-                                        [
-                                          {
-                                            "borderBottomWidth": 0.5,
-                                          },
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#e4e4e4",
-                                            "borderBottomColor": "#8B8B8B",
-                                            "justifyContent": "space-between",
-                                            "padding": 10,
-                                          },
-                                        ],
-                                      ]
-                                    }
-                                  >
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "flexDirection": "column",
-                                          },
-                                          {
-                                            "justifyContent": "center",
-                                          },
-                                        ]
-                                      }
-                                    >
-                                      <Text
-                                        letterSpacing="0.15px"
-                                        lineHeight="24px"
-                                        style={
-                                          {
-                                            "color": "#1A202C",
-                                            "fontSize": 16,
-                                            "fontWeight": "400",
-                                          }
-                                        }
-                                      />
-                                    </View>
-                                    <Icon
-                                      color="#1A202C"
-                                      name="arrow-drop-down"
-                                      size={24}
-                                      style={{}}
-                                    />
-                                  </View>
-                                </View>
-                              </View>
-                              <RCTScrollView
-                                ListHeaderComponent={
-                                  <Memo(Pressable)
-                                    onPress={[Function]}
-                                  >
-                                    <Row
-                                      alignItems="center"
-                                      backgroundColor="primary.main"
-                                      justifyContent="flex-end"
-                                      padding="md"
-                                    >
-                                      <Text
-                                        color="primary.contrast"
-                                        textTransform="uppercase"
-                                        variant="body1-strong"
-                                      >
-                                        Done
-                                      </Text>
-                                    </Row>
-                                  </Memo(Pressable)>
-                                }
-                                data={
-                                  [
-                                    null,
-                                  ]
-                                }
-                                getItem={[Function]}
-                                getItemCount={[Function]}
-                                keyExtractor={[Function]}
-                                onContentSizeChange={[Function]}
-                                onLayout={[Function]}
-                                onMomentumScrollBegin={[Function]}
-                                onMomentumScrollEnd={[Function]}
-                                onScroll={[Function]}
-                                onScrollBeginDrag={[Function]}
-                                onScrollEndDrag={[Function]}
-                                removeClippedSubviews={false}
-                                renderItem={[Function]}
-                                scrollEventThrottle={0.0001}
-                                stickyHeaderIndices={[]}
-                                viewabilityConfigCallbackPairs={[]}
-                              >
-                                <View>
-                                  <View
-                                    collapsable={false}
-                                    onLayout={[Function]}
-                                  >
-                                    <View
-                                      accessibilityState={
-                                        {
-                                          "busy": undefined,
-                                          "checked": undefined,
-                                          "disabled": undefined,
-                                          "expanded": undefined,
-                                          "selected": undefined,
-                                        }
-                                      }
-                                      accessibilityValue={
-                                        {
-                                          "max": undefined,
-                                          "min": undefined,
-                                          "now": undefined,
-                                          "text": undefined,
-                                        }
-                                      }
-                                      accessible={true}
-                                      collapsable={false}
-                                      focusable={true}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onFocus={[Function]}
-                                      onResponderGrant={[Function]}
-                                      onResponderMove={[Function]}
-                                      onResponderRelease={[Function]}
-                                      onResponderTerminate={[Function]}
-                                      onResponderTerminationRequest={[Function]}
-                                      onStartShouldSetResponder={[Function]}
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "flexDirection": "row",
-                                            },
-                                            {
-                                              "alignItems": "center",
-                                              "backgroundColor": "#028843",
-                                              "justifyContent": "flex-end",
-                                              "padding": 16,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          lineHeight="24px"
-                                          style={
-                                            {
-                                              "color": "#FFFFFF",
-                                              "fontSize": 16,
-                                              "fontWeight": "700",
-                                              "textTransform": "uppercase",
-                                            }
-                                          }
-                                        >
-                                          Done
-                                        </Text>
-                                      </View>
-                                    </View>
-                                  </View>
-                                  <View
-                                    onFocusCapture={[Function]}
-                                    onLayout={[Function]}
-                                    style={null}
-                                  >
-                                    <View
-                                      accessibilityState={
-                                        {
-                                          "busy": undefined,
-                                          "checked": undefined,
-                                          "disabled": undefined,
-                                          "expanded": undefined,
-                                          "selected": true,
-                                        }
-                                      }
-                                      accessibilityValue={
-                                        {
-                                          "max": undefined,
-                                          "min": undefined,
-                                          "now": undefined,
-                                          "text": undefined,
-                                        }
-                                      }
-                                      accessible={true}
-                                      collapsable={false}
-                                      focusable={true}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onFocus={[Function]}
-                                      onResponderGrant={[Function]}
-                                      onResponderMove={[Function]}
-                                      onResponderRelease={[Function]}
-                                      onResponderTerminate={[Function]}
-                                      onResponderTerminationRequest={[Function]}
-                                      onStartShouldSetResponder={[Function]}
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "flexDirection": "row",
-                                            },
-                                            {
-                                              "alignItems": "center",
-                                              "backgroundColor": "#e4e4e4",
-                                              "justifyContent": "flex-start",
-                                              "paddingHorizontal": 8,
-                                              "paddingVertical": 8,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <Icon
-                                          color="#1A202C"
-                                          name="check"
-                                          size={20}
-                                          style={{}}
-                                        />
-                                        <View
-                                          style={
-                                            {
-                                              "width": 8,
-                                            }
-                                          }
-                                        />
-                                        <Text
-                                          letterSpacing="0.15px"
-                                          lineHeight="24px"
-                                          style={
-                                            {
-                                              "color": "#1A202C",
-                                              "fontSize": 16,
-                                              "fontWeight": "400",
-                                            }
-                                          }
-                                        >
-                                          None
-                                        </Text>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </RCTScrollView>
-                            </View>
-                            <View
-                              dataSet={{}}
-                              style={
-                                {
-                                  "width": "100%",
-                                }
-                              }
-                            >
-                              <View
-                                dataSet={{}}
-                                feedbackId="field-10-feedback"
-                                hasFeedbackText={false}
-                                hasHelpText={false}
-                                helpTextId="field-10-helptext"
-                                isDisabled={false}
-                                isInvalid={false}
-                                isReadOnly={false}
-                                isRequired={false}
-                                labelId="field-10-label"
-                                nativeID="field-10-label"
-                                setHasFeedbackText={[Function]}
-                                setHasHelpText={[Function]}
-                                style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-start",
-                                    "marginBottom": 4,
-                                    "marginTop": 4,
-                                  }
-                                }
-                              >
-                                <Text
-                                  dataSet={{}}
-                                  style={
-                                    {
-                                      "backgroundColor": undefined,
-                                      "color": "#1A202C",
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "700",
-                                      "letterSpacing": 0.15,
-                                      "lineHeight": 24,
-                                      "textDecorationLine": undefined,
-                                    }
-                                  }
-                                >
->>>>>>> a4aa8fe (test: update test snapshots)
                                   Data Privacy
                                 </Text>
                                 <View

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -302,6 +302,7 @@ exports[`renders correctly 1`] = `
                               }
                             >
                               <View
+<<<<<<< HEAD
                                 dataSet={{}}
                                 isFocused={false}
                                 style={
@@ -346,10 +347,206 @@ exports[`renders correctly 1`] = `
                                       "paddingRight": 12,
                                       "paddingTop": 8,
                                       "width": "100%",
+=======
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "rgba(231, 224, 236, 1)",
+                                      "borderTopLeftRadius": 4,
+                                      "borderTopRightRadius": 4,
+                                    },
+                                    {
+                                      "backgroundColor": "#e4e4e4",
+                                      "minHeight": undefined,
+                                      "width": "100%",
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  collapsable={false}
+                                  style={
+                                    {
+                                      "backgroundColor": "rgba(73, 69, 79, 1)",
+                                      "bottom": 0,
+                                      "height": 1,
+                                      "left": 0,
+                                      "position": "absolute",
+                                      "right": 0,
+                                      "transform": [
+                                        {
+                                          "scaleY": 0.5,
+                                        },
+                                      ],
+                                      "zIndex": 1,
                                     }
                                   }
-                                  value=""
+                                  testID="text-input-underline"
                                 />
+                                <View
+                                  onLayout={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "paddingBottom": 0,
+                                        "paddingTop": 0,
+                                      },
+                                      {
+                                        "minHeight": 56,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    collapsable={false}
+                                    pointerEvents="none"
+                                    style={
+                                      {
+                                        "bottom": 0,
+                                        "left": 0,
+                                        "opacity": 1,
+                                        "position": "absolute",
+                                        "right": 0,
+                                        "top": 0,
+                                        "transform": [
+                                          {
+                                            "translateX": 0,
+                                          },
+                                        ],
+                                        "width": 750,
+                                        "zIndex": 3,
+                                      }
+>>>>>>> a4aa8fe (test: update test snapshots)
+                                    }
+                                  >
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      numberOfLines={1}
+                                      onLayout={[Function]}
+                                      onTextLayout={[Function]}
+                                      style={
+                                        {
+                                          "color": "#8B8B8B",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "left": 0,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "maxWidth": 73,
+                                          "opacity": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "absolute",
+                                          "textAlign": "left",
+                                          "top": 30,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                      testID="text-input-flat-label-active"
+                                    >
+                                      Site Name
+                                    </Text>
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      numberOfLines={1}
+                                      style={
+                                        {
+                                          "color": "rgba(73, 69, 79, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "left": 0,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "maxWidth": 73,
+                                          "opacity": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "absolute",
+                                          "textAlign": "left",
+                                          "top": 30,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                      testID="text-input-flat-label-inactive"
+                                    >
+                                      Site Name
+                                    </Text>
+                                  </View>
+                                  <TextInput
+                                    cursorColor="#8B8B8B"
+                                    editable={true}
+                                    maxFontSizeMultiplier={1.5}
+                                    multiline={false}
+                                    onBlur={[Function]}
+                                    onChangeText={[Function]}
+                                    onFocus={[Function]}
+                                    placeholder=" "
+                                    placeholderTextColor="rgba(73, 69, 79, 1)"
+                                    selectionColor="#8B8B8B"
+                                    style={
+                                      [
+                                        {
+                                          "margin": 0,
+                                        },
+                                        {
+                                          "height": 56,
+                                        },
+                                        {
+                                          "paddingBottom": 4,
+                                          "paddingTop": 24,
+                                        },
+                                        {
+                                          "color": "rgba(28, 27, 31, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "minWidth": 65,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "textAlign": "left",
+                                          "textAlignVertical": "center",
+                                        },
+                                        false,
+                                        [
+                                          {},
+                                        ],
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="text-input-flat"
+                                    textInputLabel="Site Name"
+                                    underlineColorAndroid="transparent"
+                                    value=""
+                                  />
+                                </View>
                               </View>
                             </View>
                             <View
@@ -463,54 +660,107 @@ exports[`renders correctly 1`] = `
                               }
                             >
                               <View
-                                dataSet={{}}
-                                isFocused={false}
                                 style={
-                                  {
-                                    "alignItems": "center",
-                                    "borderColor": "#d4d4d4",
-                                    "borderRadius": 4,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "overflow": "hidden",
-                                  }
+                                  [
+                                    {
+                                      "backgroundColor": "rgba(231, 224, 236, 1)",
+                                      "borderTopLeftRadius": 4,
+                                      "borderTopRightRadius": 4,
+                                    },
+                                    {
+                                      "backgroundColor": "#e4e4e4",
+                                      "minHeight": undefined,
+                                      "width": "100%",
+                                    },
+                                  ]
                                 }
                               >
-                                <TextInput
-                                  accessible={true}
-                                  dataSet={{}}
-                                  disabled={false}
-                                  editable={true}
-                                  isRequired={false}
-                                  keyboardType="decimal-pad"
-                                  nativeID="field-7-input"
-                                  onBlur={[Function]}
-                                  onChangeText={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyPress={[Function]}
-                                  placeholderTextColor="#a3a3a3"
-                                  readOnly={false}
-                                  required={false}
-                                  secureTextEntry={false}
+                                <View
+                                  collapsable={false}
                                   style={
                                     {
-                                      "backgroundColor": "#00000000",
-                                      "color": "#171717",
-                                      "flex": 1,
-                                      "fontFamily": undefined,
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "height": "100%",
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 12,
-                                      "paddingRight": 12,
-                                      "paddingTop": 8,
-                                      "width": "100%",
+                                      "backgroundColor": "rgba(73, 69, 79, 1)",
+                                      "bottom": 0,
+                                      "height": 1,
+                                      "left": 0,
+                                      "position": "absolute",
+                                      "right": 0,
+                                      "transform": [
+                                        {
+                                          "scaleY": 0.5,
+                                        },
+                                      ],
+                                      "zIndex": 1,
                                     }
                                   }
+<<<<<<< HEAD
                                   value="0"
+=======
+                                  testID="text-input-underline"
+>>>>>>> a4aa8fe (test: update test snapshots)
                                 />
+                                <View
+                                  onLayout={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "paddingBottom": 0,
+                                        "paddingTop": 0,
+                                      },
+                                      {
+                                        "minHeight": 56,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <TextInput
+                                    cursorColor="#8B8B8B"
+                                    editable={true}
+                                    keyboardType="decimal-pad"
+                                    maxFontSizeMultiplier={1.5}
+                                    multiline={false}
+                                    onBlur={[Function]}
+                                    onChangeText={[Function]}
+                                    onFocus={[Function]}
+                                    placeholderTextColor="rgba(73, 69, 79, 1)"
+                                    selectionColor="#8B8B8B"
+                                    style={
+                                      [
+                                        {
+                                          "margin": 0,
+                                        },
+                                        {
+                                          "height": 56,
+                                        },
+                                        {
+                                          "paddingBottom": 0,
+                                          "paddingTop": 0,
+                                        },
+                                        {
+                                          "color": "rgba(28, 27, 31, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 16,
+                                          "fontWeight": undefined,
+                                          "letterSpacing": 0.15,
+                                          "lineHeight": undefined,
+                                          "minWidth": 65,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "textAlign": "left",
+                                          "textAlignVertical": "center",
+                                        },
+                                        false,
+                                        [
+                                          {},
+                                        ],
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="text-input-flat"
+                                    underlineColorAndroid="transparent"
+                                    value=""
+                                  />
+                                </View>
                               </View>
                             </View>
                             <View
@@ -560,6 +810,427 @@ exports[`renders correctly 1`] = `
                                     }
                                   }
                                 >
+<<<<<<< HEAD
+=======
+                                  Add to Project
+                                </Text>
+                                <View
+                                  dataSet={{}}
+                                  style={{}}
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "marginLeft": 6,
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#1A202CB2"
+                                      name="help"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <View
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "row",
+                                        },
+                                        [
+                                          {
+                                            "borderBottomWidth": 0.5,
+                                          },
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#e4e4e4",
+                                            "borderBottomColor": "#8B8B8B",
+                                            "justifyContent": "space-between",
+                                            "padding": 10,
+                                          },
+                                        ],
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "column",
+                                          },
+                                          {
+                                            "justifyContent": "center",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        letterSpacing="0.15px"
+                                        lineHeight="24px"
+                                        style={
+                                          {
+                                            "color": "#1A202C",
+                                            "fontSize": 16,
+                                            "fontWeight": "400",
+                                          }
+                                        }
+                                      />
+                                    </View>
+                                    <Icon
+                                      color="#1A202C"
+                                      name="arrow-drop-down"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                </View>
+                              </View>
+                              <RCTScrollView
+                                ListHeaderComponent={
+                                  <Memo(Pressable)
+                                    onPress={[Function]}
+                                  >
+                                    <Row
+                                      alignItems="center"
+                                      backgroundColor="primary.main"
+                                      justifyContent="flex-end"
+                                      padding="md"
+                                    >
+                                      <Text
+                                        color="primary.contrast"
+                                        textTransform="uppercase"
+                                        variant="body1-strong"
+                                      >
+                                        Done
+                                      </Text>
+                                    </Row>
+                                  </Memo(Pressable)>
+                                }
+                                data={
+                                  [
+                                    null,
+                                  ]
+                                }
+                                getItem={[Function]}
+                                getItemCount={[Function]}
+                                keyExtractor={[Function]}
+                                onContentSizeChange={[Function]}
+                                onLayout={[Function]}
+                                onMomentumScrollBegin={[Function]}
+                                onMomentumScrollEnd={[Function]}
+                                onScroll={[Function]}
+                                onScrollBeginDrag={[Function]}
+                                onScrollEndDrag={[Function]}
+                                removeClippedSubviews={false}
+                                renderItem={[Function]}
+                                scrollEventThrottle={0.0001}
+                                stickyHeaderIndices={[]}
+                                viewabilityConfigCallbackPairs={[]}
+                              >
+                                <View>
+                                  <View
+                                    collapsable={false}
+                                    onLayout={[Function]}
+                                  >
+                                    <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "flexDirection": "row",
+                                            },
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#028843",
+                                              "justifyContent": "flex-end",
+                                              "padding": 16,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <Text
+                                          lineHeight="24px"
+                                          style={
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontSize": 16,
+                                              "fontWeight": "700",
+                                              "textTransform": "uppercase",
+                                            }
+                                          }
+                                        >
+                                          Done
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <View
+                                    onFocusCapture={[Function]}
+                                    onLayout={[Function]}
+                                    style={null}
+                                  >
+                                    <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": true,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "flexDirection": "row",
+                                            },
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#e4e4e4",
+                                              "justifyContent": "flex-start",
+                                              "paddingHorizontal": 8,
+                                              "paddingVertical": 8,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <Icon
+                                          color="#1A202C"
+                                          name="check"
+                                          size={20}
+                                          style={{}}
+                                        />
+                                        <View
+                                          style={
+                                            {
+                                              "width": 8,
+                                            }
+                                          }
+                                        />
+                                        <Text
+                                          letterSpacing="0.15px"
+                                          lineHeight="24px"
+                                          style={
+                                            {
+                                              "color": "#1A202C",
+                                              "fontSize": 16,
+                                              "fontWeight": "400",
+                                            }
+                                          }
+                                        >
+                                          None
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </RCTScrollView>
+                            </View>
+                            <View
+                              dataSet={{}}
+                              style={
+                                {
+                                  "width": "100%",
+                                }
+                              }
+                            >
+                              <View
+                                dataSet={{}}
+                                feedbackId="field-10-feedback"
+                                hasFeedbackText={false}
+                                hasHelpText={false}
+                                helpTextId="field-10-helptext"
+                                isDisabled={false}
+                                isInvalid={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                labelId="field-10-label"
+                                nativeID="field-10-label"
+                                setHasFeedbackText={[Function]}
+                                setHasHelpText={[Function]}
+                                style={
+                                  {
+                                    "flexDirection": "row",
+                                    "justifyContent": "flex-start",
+                                    "marginBottom": 4,
+                                    "marginTop": 4,
+                                  }
+                                }
+                              >
+                                <Text
+                                  dataSet={{}}
+                                  style={
+                                    {
+                                      "backgroundColor": undefined,
+                                      "color": "#1A202C",
+                                      "fontFamily": undefined,
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.15,
+                                      "lineHeight": 24,
+                                      "textDecorationLine": undefined,
+                                    }
+                                  }
+                                >
+>>>>>>> a4aa8fe (test: update test snapshots)
                                   Data Privacy
                                 </Text>
                                 <View

--- a/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
@@ -554,8 +554,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -597,8 +597,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -640,8 +640,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -683,8 +683,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -726,8 +726,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -769,8 +769,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -812,8 +812,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -855,8 +855,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -916,7 +916,7 @@ exports[`renders correctly 1`] = `
                                       "flexDirection": "row",
                                       "justifyContent": "flex-start",
                                       "marginBottom": 4,
-                                      "marginLeft": 10,
+                                      "marginLeft": 8,
                                       "marginTop": 4,
                                     }
                                   }
@@ -1709,8 +1709,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -1752,8 +1752,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -1795,8 +1795,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -1838,8 +1838,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -1881,8 +1881,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -1924,8 +1924,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -1967,8 +1967,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -2010,8 +2010,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -2071,7 +2071,7 @@ exports[`renders correctly 1`] = `
                                       "flexDirection": "row",
                                       "justifyContent": "flex-start",
                                       "marginBottom": 4,
-                                      "marginLeft": 10,
+                                      "marginLeft": 8,
                                       "marginTop": 4,
                                     }
                                   }
@@ -2864,8 +2864,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -2907,8 +2907,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -2950,8 +2950,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -2993,8 +2993,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -3036,8 +3036,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -3079,8 +3079,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -3122,8 +3122,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -3165,8 +3165,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -3226,7 +3226,7 @@ exports[`renders correctly 1`] = `
                                       "flexDirection": "row",
                                       "justifyContent": "flex-start",
                                       "marginBottom": 4,
-                                      "marginLeft": 10,
+                                      "marginLeft": 8,
                                       "marginTop": 4,
                                     }
                                   }
@@ -4019,8 +4019,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4062,8 +4062,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4105,8 +4105,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4148,8 +4148,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4191,8 +4191,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4234,8 +4234,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4277,8 +4277,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4320,8 +4320,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -4381,7 +4381,7 @@ exports[`renders correctly 1`] = `
                                       "flexDirection": "row",
                                       "justifyContent": "flex-start",
                                       "marginBottom": 4,
-                                      "marginLeft": 10,
+                                      "marginLeft": 8,
                                       "marginTop": 4,
                                     }
                                   }
@@ -5174,8 +5174,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5217,8 +5217,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5260,8 +5260,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5303,8 +5303,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5346,8 +5346,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5389,8 +5389,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5432,8 +5432,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5475,8 +5475,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -5536,7 +5536,7 @@ exports[`renders correctly 1`] = `
                                       "flexDirection": "row",
                                       "justifyContent": "flex-start",
                                       "marginBottom": 4,
-                                      "marginLeft": 10,
+                                      "marginLeft": 8,
                                       "marginTop": 4,
                                     }
                                   }
@@ -6329,8 +6329,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6372,8 +6372,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6415,8 +6415,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#9EA8AB",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6458,8 +6458,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6501,8 +6501,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6544,8 +6544,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6587,8 +6587,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6630,8 +6630,8 @@ exports[`renders correctly 1`] = `
                                         "color": "#1A202C",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "marginLeft": 10,
-                                        "marginTop": 5,
+                                        "marginLeft": 8,
+                                        "marginTop": 4,
                                       }
                                     }
                                   >
@@ -6691,7 +6691,7 @@ exports[`renders correctly 1`] = `
                                       "flexDirection": "row",
                                       "justifyContent": "flex-start",
                                       "marginBottom": 4,
-                                      "marginLeft": 10,
+                                      "marginLeft": 8,
                                       "marginTop": 4,
                                     }
                                   }

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -49,7 +49,7 @@ export const IntervalForm = () => {
           })}
         </FormControl.HelperText>
       </FormControl>
-      <Row justifyContent="space-between" space="40px">
+      <Row justifyContent="space-between" space={10} pt={5}>
         <Box flex={1}>
           <FormInput
             name="start"

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -48,7 +48,7 @@ export const IntervalForm = () => {
           })}
         </FormControl.HelperText>
       </FormControl>
-      <Row justifyContent="space-between" space="20px" pt="10px">
+      <Row justifyContent="space-between" space="40px" pt="20px">
         <Box flex={1}>
           <FormInput
             name="start"

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -48,7 +48,7 @@ export const IntervalForm = () => {
           })}
         </FormControl.HelperText>
       </FormControl>
-      <Row justifyContent="space-between" space={10} pt={5}>
+      <Row justifyContent="space-between" space="20px" pt="10px">
         <Box flex={1}>
           <FormInput
             name="start"

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -39,7 +39,6 @@ export const IntervalForm = () => {
         <FormInput
           name="label"
           placeholder={t('soil.depth_interval.label_placeholder')}
-          variant="underlined"
           maxLength={FORM_LABEL_MAX}
         />
         <FormControl.HelperText>
@@ -53,7 +52,6 @@ export const IntervalForm = () => {
         <Box flex={1}>
           <FormInput
             name="start"
-            variant="underlined"
             placeholder={t('soil.depth_interval.start_label', {
               units: 'cm',
             })}
@@ -62,7 +60,6 @@ export const IntervalForm = () => {
         <Box flex={1}>
           <FormInput
             name="end"
-            variant="underlined"
             placeholder={t('soil.depth_interval.end_label', {
               units: 'cm',
             })}

--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -336,20 +336,6 @@ type TextInputProps = {
   name: string;
 };
 
-export const searchFilterStyles = StyleSheet.create({
-  search: {
-    width: '85%',
-    padding: 0,
-    borderWidth: StyleSheet.hairlineWidth,
-    backgroundColor: theme.colors.background.default,
-    height: 40,
-    justifyContent: 'center',
-  },
-  input: {
-    minHeight: 40,
-  },
-});
-
 export const TextInputFilter = ({placeholder, label, name}: TextInputProps) => {
   const ref = useRef<TextInput>(null);
   const {value, setValue} = useListFilter<any>(name);
@@ -486,3 +472,17 @@ export const ListFilterModal = ({searchInput, children}: ModalProps) => {
     </Modal>
   );
 };
+
+export const searchFilterStyles = StyleSheet.create({
+  search: {
+    width: '85%',
+    padding: 0,
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: theme.colors.background.default,
+    height: 40,
+    justifyContent: 'center',
+  },
+  input: {
+    minHeight: 40,
+  },
+});

--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+
 import {
   createContext,
   useCallback,
@@ -23,13 +24,12 @@ import {
   useState,
 } from 'react';
 import {useTranslation} from 'react-i18next';
-import {Keyboard, TextInput} from 'react-native';
+import {Keyboard, StyleSheet, TextInput} from 'react-native';
+import {Searchbar} from 'react-native-paper';
 
-import {Button, FormControl, Input, Radio} from 'native-base';
+import {Button, FormControl, Radio} from 'native-base';
 
 import BadgedIcon from 'terraso-mobile-client/components/BadgedIcon';
-import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
 import {
   Select,
   SelectProps,
@@ -44,6 +44,7 @@ import {
   Text,
   VStack,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {theme} from 'terraso-mobile-client/theme';
 import {sortCompare} from 'terraso-mobile-client/util';
 
 type Lookup<Item, RecordValue = string> = {
@@ -335,8 +336,21 @@ type TextInputProps = {
   name: string;
 };
 
+export const searchFilterStyles = StyleSheet.create({
+  search: {
+    width: '85%',
+    padding: 0,
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: theme.colors.background.default,
+    height: 40,
+    justifyContent: 'center',
+  },
+  input: {
+    minHeight: 40,
+  },
+});
+
 export const TextInputFilter = ({placeholder, label, name}: TextInputProps) => {
-  const {t} = useTranslation();
   const ref = useRef<TextInput>(null);
   const {value, setValue} = useListFilter<any>(name);
 
@@ -345,34 +359,15 @@ export const TextInputFilter = ({placeholder, label, name}: TextInputProps) => {
     [setValue],
   );
 
-  const onClear = useCallback(() => {
-    setValue('', true);
-    ref?.current?.clear();
-  }, [setValue]);
-
   return (
-    <Input
+    <Searchbar
       ref={ref}
+      value={value !== undefined ? value : ''}
       onChangeText={onChangeText}
       placeholder={placeholder}
-      accessibilityLabel={label}
-      flex={1}
-      bg="background.default"
-      pl="8px"
-      py="6px"
-      InputLeftElement={<Icon ml="16px" name="search" />}
-      InputRightElement={
-        value !== undefined && value.length ? (
-          <IconButton
-            name="close"
-            onPress={onClear}
-            accessibilityLabel={t('listfilter.clear_search_label')}
-            _icon={{
-              color: 'action.active',
-            }}
-          />
-        ) : undefined
-      }
+      searchAccessibilityLabel={label}
+      style={searchFilterStyles.search}
+      inputStyle={searchFilterStyles.input}
     />
   );
 };
@@ -442,7 +437,7 @@ export const FilterModalTrigger = ({
   const {numFilters} = useListFilter<any>();
 
   return (
-    <HStack space="20px" mb="15px">
+    <HStack space="20px" mb="15px" alignItems="center">
       <BadgedIcon
         iconName="filter-list"
         onPress={() => {

--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -352,8 +352,8 @@ export const TextInputFilter = ({placeholder, label, name}: TextInputProps) => {
       onChangeText={onChangeText}
       placeholder={placeholder}
       searchAccessibilityLabel={label}
-      style={searchFilterStyles.search}
-      inputStyle={searchFilterStyles.input}
+      style={searchBarStyles.search}
+      inputStyle={searchBarStyles.input}
     />
   );
 };
@@ -473,7 +473,7 @@ export const ListFilterModal = ({searchInput, children}: ModalProps) => {
   );
 };
 
-export const searchFilterStyles = StyleSheet.create({
+export const searchBarStyles = StyleSheet.create({
   search: {
     width: '85%',
     padding: 0,

--- a/dev-client/src/components/SiteNoteForm.tsx
+++ b/dev-client/src/components/SiteNoteForm.tsx
@@ -17,7 +17,7 @@
 
 import {useEffect, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
-import {TextInput} from 'react-native';
+import {StyleSheet, TextInput} from 'react-native';
 
 import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
 
@@ -35,21 +35,26 @@ export const SiteNoteForm = ({content}: Props) => {
     }
   }, []);
 
+  const styles = StyleSheet.create({
+    box: {
+      backgroundColor: 'transparent',
+    },
+    content: {
+      marginVertical: -20,
+      marginHorizontal: -15,
+    },
+  });
+
   return (
     <FormInput
-      pt={2}
-      pb={4}
       ref={formInputRef}
-      padding={0}
-      borderWidth={0}
-      backgroundColor="transparent"
       name="content"
       placeholder={t('site.notes.placeholder_text')}
       value={content}
-      multiline
-      maxHeight={200}
-      overflow="scroll"
-      textAlignVertical="top"
+      multiline={true}
+      activeUnderlineColor="transparent"
+      style={styles.box}
+      contentStyle={styles.content}
     />
   );
 };

--- a/dev-client/src/components/SiteNoteForm.tsx
+++ b/dev-client/src/components/SiteNoteForm.tsx
@@ -53,6 +53,7 @@ export const SiteNoteForm = ({content}: Props) => {
       value={content}
       multiline={true}
       activeUnderlineColor="transparent"
+      underlineColor="transparent"
       style={styles.box}
       contentStyle={styles.content}
     />

--- a/dev-client/src/components/form/FormInput.tsx
+++ b/dev-client/src/components/form/FormInput.tsx
@@ -16,22 +16,27 @@
  */
 
 import {forwardRef, memo, useImperativeHandle, useRef} from 'react';
-import {TextInput} from 'react-native';
-
-import {Input} from 'native-base';
+import {TextInput as RNTextInput} from 'react-native';
 
 import {
   FormFieldWrapper,
   Props as FormFieldWrapperProps,
 } from 'terraso-mobile-client/components/form/FormFieldWrapper';
 import {useFieldContext} from 'terraso-mobile-client/components/form/hooks/useFieldContext';
+import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 
-type Props = FormFieldWrapperProps & React.ComponentProps<typeof Input>;
+export type FormInputProps = {
+  textInputLabel?: string;
+};
+
+type Props = FormFieldWrapperProps &
+  FormInputProps &
+  React.ComponentProps<typeof TextInput>;
 
 export const FormInput = memo(
   forwardRef((props: Props, ref) => {
     const {value, onChange, onBlur} = useFieldContext(props.name);
-    const inputRef = useRef<TextInput>(null);
+    const inputRef = useRef<RNTextInput>(null);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
@@ -43,11 +48,12 @@ export const FormInput = memo(
 
     return (
       <FormFieldWrapper {...props}>
-        <Input
+        <TextInput
           ref={inputRef}
           value={value}
           onChangeText={onChange}
           onBlur={onBlur}
+          label={props?.textInputLabel}
           {...props}
         />
       </FormFieldWrapper>

--- a/dev-client/src/components/form/FormInput.tsx
+++ b/dev-client/src/components/form/FormInput.tsx
@@ -24,6 +24,7 @@ import {
 } from 'terraso-mobile-client/components/form/FormFieldWrapper';
 import {useFieldContext} from 'terraso-mobile-client/components/form/hooks/useFieldContext';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
+import {theme} from 'terraso-mobile-client/theme';
 
 export type FormInputProps = {
   textInputLabel?: string;
@@ -54,6 +55,7 @@ export const FormInput = memo(
           onChangeText={onChange}
           onBlur={onBlur}
           label={props?.textInputLabel}
+          cursorColor={theme.colors.primary.main}
           {...props}
         />
       </FormFieldWrapper>

--- a/dev-client/src/components/form/FormSwitch.tsx
+++ b/dev-client/src/components/form/FormSwitch.tsx
@@ -23,7 +23,10 @@ import {
 } from 'terraso-mobile-client/components/form/FormFieldWrapper';
 import {useFieldContext} from 'terraso-mobile-client/components/form/hooks/useFieldContext';
 import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {SWITCH_PADDING} from 'terraso-mobile-client/constants';
+import {
+  SWITCH_PADDING,
+  SWITCH_VERTICAL_PADDING,
+} from 'terraso-mobile-client/constants';
 import {theme} from 'terraso-mobile-client/theme';
 
 type Props = FormFieldWrapperProps &
@@ -44,7 +47,7 @@ export const FormSwitch = memo(
           />
           <Text
             ml={SWITCH_PADDING}
-            mt="5px"
+            mt={SWITCH_VERTICAL_PADDING}
             color={
               props.disabled
                 ? theme.colors.text.disabled

--- a/dev-client/src/components/form/FormSwitch.tsx
+++ b/dev-client/src/components/form/FormSwitch.tsx
@@ -26,8 +26,8 @@ import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SWITCH_PADDING,
   SWITCH_VERTICAL_PADDING,
-} from 'terraso-mobile-client/constants';
-import {theme} from 'terraso-mobile-client/theme';
+  theme,
+} from 'terraso-mobile-client/theme';
 
 type Props = FormFieldWrapperProps &
   Omit<React.ComponentProps<typeof Switch>, 'onChange' | 'onValueChange'> & {

--- a/dev-client/src/components/form/FormSwitch.tsx
+++ b/dev-client/src/components/form/FormSwitch.tsx
@@ -23,6 +23,7 @@ import {
 } from 'terraso-mobile-client/components/form/FormFieldWrapper';
 import {useFieldContext} from 'terraso-mobile-client/components/form/hooks/useFieldContext';
 import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {SWITCH_PADDING} from 'terraso-mobile-client/constants';
 import {theme} from 'terraso-mobile-client/theme';
 
 type Props = FormFieldWrapperProps &
@@ -42,7 +43,7 @@ export const FormSwitch = memo(
             {...props}
           />
           <Text
-            ml="10px"
+            ml={SWITCH_PADDING}
             mt="5px"
             color={
               props.disabled

--- a/dev-client/src/components/inputs/Select.tsx
+++ b/dev-client/src/components/inputs/Select.tsx
@@ -31,6 +31,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {OverlaySheet} from 'terraso-mobile-client/components/sheets/OverlaySheet';
 import {theme} from 'terraso-mobile-client/theme';
+import {StyleSheet} from 'react-native';
 
 // utility type so we can strictly validate the types of inputs/callbacks
 // based on whether the select is nullable

--- a/dev-client/src/components/inputs/Select.tsx
+++ b/dev-client/src/components/inputs/Select.tsx
@@ -31,7 +31,6 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {OverlaySheet} from 'terraso-mobile-client/components/sheets/OverlaySheet';
 import {theme} from 'terraso-mobile-client/theme';
-import {StyleSheet} from 'react-native';
 
 // utility type so we can strictly validate the types of inputs/callbacks
 // based on whether the select is nullable

--- a/dev-client/src/components/inputs/Text.tsx
+++ b/dev-client/src/components/inputs/Text.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {ViewStyle} from 'react-native';
+import {TextInput} from 'react-native-paper';
+import {theme} from 'terraso-mobile-client/theme';
+import {StyleSheet} from 'react-native';
+
+export type TextProps = {
+  value?: string;
+  label?: string;
+  onChangeText?: (a: string) => void;
+  disabled?: boolean;
+} & ViewStyle;
+
+const styles = StyleSheet.create({
+  text: {
+    width: '100%',
+    backgroundColor: theme.colors.input.filled.enabledFill,
+  },
+});
+
+export const Text = ({
+  value,
+  label,
+  onChangeText,
+  disabled = false,
+  ...style
+}: TextProps) => {
+  return (
+    <TextInput
+      label={label}
+      value={value}
+      onChangeText={onChangeText}
+      disabled={disabled}
+      style={{...styles.text, ...style}}
+    />
+  );
+};

--- a/dev-client/src/components/inputs/Text.tsx
+++ b/dev-client/src/components/inputs/Text.tsx
@@ -16,38 +16,53 @@
  */
 
 import {ViewStyle} from 'react-native';
-import {TextInput} from 'react-native-paper';
+import {Props as TextInputProps, TextInput} from 'react-native-paper';
 import {theme} from 'terraso-mobile-client/theme';
 import {StyleSheet} from 'react-native';
 
 export type TextProps = {
+  ref?: string;
   value?: string;
   label?: string;
+  placeholder?: string;
   onChangeText?: (a: string) => void;
+  onBlur?: (args: any) => void;
+  style?: any;
   disabled?: boolean;
+  textInputProps?: Omit<TextInputProps, 'label'>;
 } & ViewStyle;
 
 const styles = StyleSheet.create({
   text: {
     width: '100%',
+    padding: 0,
     backgroundColor: theme.colors.input.filled.enabledFill,
   },
 });
 
 export const Text = ({
+  ref,
   value,
   label,
+  placeholder,
   onChangeText,
+  onBlur,
   disabled = false,
-  ...style
+  style,
+  textInputProps,
 }: TextProps) => {
   return (
     <TextInput
+      ref={ref}
       label={label}
       value={value}
+      placeholder={placeholder}
       onChangeText={onChangeText}
+      onBlur={onBlur}
       disabled={disabled}
+      activeUnderlineColor={theme.colors.input.standard.enabledBorder}
       style={{...styles.text, ...style}}
+      {...textInputProps}
     />
   );
 };

--- a/dev-client/src/components/inputs/Text.tsx
+++ b/dev-client/src/components/inputs/Text.tsx
@@ -16,12 +16,13 @@
  */
 
 import {ViewStyle} from 'react-native';
-import {Props as TextInputProps, TextInput} from 'react-native-paper';
+import {TextInputProps, TextInput} from 'react-native-paper';
 import {theme} from 'terraso-mobile-client/theme';
 import {StyleSheet} from 'react-native';
 
 export type TextProps = {
   ref?: string;
+  mode?: TextInputProps['mode'];
   value?: string;
   label?: string;
   placeholder?: string;
@@ -41,6 +42,7 @@ const styles = StyleSheet.create({
 });
 
 export const Text = ({
+  mode,
   ref,
   value,
   label,
@@ -54,6 +56,7 @@ export const Text = ({
   return (
     <TextInput
       ref={ref}
+      mode={mode}
       label={label}
       value={value}
       placeholder={placeholder}

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -15,13 +15,14 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {StyleSheet, TextInput as RNTextInput} from 'react-native';
-import {
-  TextInputProps as RNPTextInputProps,
-  TextInput as RNPTextInput,
-} from 'react-native-paper';
-import {theme} from 'terraso-mobile-client/theme';
 import {forwardRef} from 'react';
+import {TextInput as RNTextInput, StyleSheet} from 'react-native';
+import {
+  TextInput as RNPTextInput,
+  TextInputProps as RNPTextInputProps,
+} from 'react-native-paper';
+
+import {theme} from 'terraso-mobile-client/theme';
 
 export type TextInputProps = RNPTextInputProps;
 

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -15,72 +15,40 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {ViewStyle} from 'react-native';
+import {StyleSheet, TextInput as RNTextInput} from 'react-native';
 import {
   TextInputProps as RNPTextInputProps,
   TextInput as RNPTextInput,
 } from 'react-native-paper';
 import {theme} from 'terraso-mobile-client/theme';
-import {StyleSheet} from 'react-native';
+import {forwardRef} from 'react';
 
-export type TextInputProps = {
-  ref?: string;
-  mode?: RNPTextInputProps['mode'];
-  multiline?: boolean;
-  value?: string;
-  label?: string;
-  placeholder?: string;
-  onChangeText?: (a: string) => void;
-  onBlur?: (args: any) => void;
-  onSubmitEditing?: (args: any) => void;
-  style?: any;
-  disabled?: boolean;
-  textInputProps?: Omit<RNPTextInputProps, 'label'>;
-} & ViewStyle;
+export type TextInputProps = RNPTextInputProps;
 
-const styles = StyleSheet.create({
-  text: {
-    width: '100%',
-    padding: 0,
-    backgroundColor: theme.colors.input.filled.enabledFill,
+export const TextInput = forwardRef<RNTextInput, TextInputProps>(
+  ({mode, multiline, disabled = false, style, ...props}, ref) => {
+    const styles = StyleSheet.create({
+      text: {
+        width: mode === 'outlined' ? '85%' : '100%',
+        padding: 0,
+        minHeight: multiline ? 100 : undefined,
+        backgroundColor:
+          mode === 'outlined'
+            ? theme.colors.background.default
+            : theme.colors.input.filled.enabledFill,
+      },
+    });
+
+    return (
+      <RNPTextInput
+        ref={ref}
+        mode={mode}
+        multiline={multiline}
+        disabled={disabled}
+        activeUnderlineColor={theme.colors.input.standard.enabledBorder}
+        style={[styles.text, style]}
+        {...props}
+      />
+    );
   },
-});
-
-export const TextInput = ({
-  mode,
-  multiline,
-  ref,
-  value,
-  label,
-  placeholder,
-  onChangeText,
-  onBlur,
-  onSubmitEditing,
-  disabled = false,
-  style,
-  textInputProps,
-}: TextInputProps) => {
-  if (multiline) {
-    style = {
-      minHeight: 100,
-    };
-  }
-
-  return (
-    <RNPTextInput
-      ref={ref}
-      mode={mode}
-      label={label}
-      value={value}
-      placeholder={placeholder}
-      multiline={multiline}
-      onChangeText={onChangeText}
-      onBlur={onBlur}
-      onSubmitEditing={onSubmitEditing}
-      disabled={disabled}
-      activeUnderlineColor={theme.colors.input.standard.enabledBorder}
-      style={{...styles.text, ...style}}
-      {...textInputProps}
-    />
-  );
-};
+);

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -30,7 +30,6 @@ export const TextInput = forwardRef<RNTextInput, TextInputProps>(
     const styles = StyleSheet.create({
       text: {
         width: mode === 'outlined' ? '85%' : '100%',
-        padding: 0,
         minHeight: multiline ? 100 : undefined,
         backgroundColor:
           mode === 'outlined'

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -29,6 +29,7 @@ export type TextProps = {
   placeholder?: string;
   onChangeText?: (a: string) => void;
   onBlur?: (args: any) => void;
+  onSubmitEditing?: (args: any) => void;
   style?: any;
   disabled?: boolean;
   textInputProps?: Omit<TextInputProps, 'label'>;
@@ -51,6 +52,7 @@ export const TextInput = ({
   placeholder,
   onChangeText,
   onBlur,
+  onSubmitEditing,
   disabled = false,
   style,
   textInputProps,
@@ -71,6 +73,7 @@ export const TextInput = ({
       multiline={multiline}
       onChangeText={onChangeText}
       onBlur={onBlur}
+      onSubmitEditing={onSubmitEditing}
       disabled={disabled}
       activeUnderlineColor={theme.colors.input.standard.enabledBorder}
       style={{...styles.text, ...style}}

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -16,13 +16,16 @@
  */
 
 import {ViewStyle} from 'react-native';
-import {TextInputProps, TextInput as RNPTextInput} from 'react-native-paper';
+import {
+  TextInputProps as RNPTextInputProps,
+  TextInput as RNPTextInput,
+} from 'react-native-paper';
 import {theme} from 'terraso-mobile-client/theme';
 import {StyleSheet} from 'react-native';
 
-export type TextProps = {
+export type TextInputProps = {
   ref?: string;
-  mode?: TextInputProps['mode'];
+  mode?: RNPTextInputProps['mode'];
   multiline?: boolean;
   value?: string;
   label?: string;
@@ -32,7 +35,7 @@ export type TextProps = {
   onSubmitEditing?: (args: any) => void;
   style?: any;
   disabled?: boolean;
-  textInputProps?: Omit<TextInputProps, 'label'>;
+  textInputProps?: Omit<RNPTextInputProps, 'label'>;
 } & ViewStyle;
 
 const styles = StyleSheet.create({
@@ -56,7 +59,7 @@ export const TextInput = ({
   disabled = false,
   style,
   textInputProps,
-}: TextProps) => {
+}: TextInputProps) => {
   if (multiline) {
     style = {
       minHeight: 100,

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -23,6 +23,7 @@ import {StyleSheet} from 'react-native';
 export type TextProps = {
   ref?: string;
   mode?: TextInputProps['mode'];
+  multiline?: boolean;
   value?: string;
   label?: string;
   placeholder?: string;
@@ -43,6 +44,7 @@ const styles = StyleSheet.create({
 
 export const TextInput = ({
   mode,
+  multiline,
   ref,
   value,
   label,
@@ -53,6 +55,12 @@ export const TextInput = ({
   style,
   textInputProps,
 }: TextProps) => {
+  if (multiline) {
+    style = {
+      minHeight: 100,
+    };
+  }
+
   return (
     <RNPTextInput
       ref={ref}
@@ -60,6 +68,7 @@ export const TextInput = ({
       label={label}
       value={value}
       placeholder={placeholder}
+      multiline={multiline}
       onChangeText={onChangeText}
       onBlur={onBlur}
       disabled={disabled}

--- a/dev-client/src/components/inputs/TextInput.tsx
+++ b/dev-client/src/components/inputs/TextInput.tsx
@@ -16,7 +16,7 @@
  */
 
 import {ViewStyle} from 'react-native';
-import {TextInputProps, TextInput} from 'react-native-paper';
+import {TextInputProps, TextInput as RNPTextInput} from 'react-native-paper';
 import {theme} from 'terraso-mobile-client/theme';
 import {StyleSheet} from 'react-native';
 
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export const Text = ({
+export const TextInput = ({
   mode,
   ref,
   value,
@@ -54,7 +54,7 @@ export const Text = ({
   textInputProps,
 }: TextProps) => {
   return (
-    <TextInput
+    <RNPTextInput
       ref={ref}
       mode={mode}
       label={label}

--- a/dev-client/src/screens/AddUserToProjectScreen/components/FreeformTextInput.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/FreeformTextInput.tsx
@@ -16,13 +16,16 @@
  */
 
 import {useCallback, useState} from 'react';
+import {TextInputProps} from 'react-native-paper';
 
-import {FormControl, IInputProps, Input} from 'native-base';
+import {FormControl} from 'native-base';
+
+import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 
 type Props = {
   validationFunc: (input: string) => Promise<null | string>;
   placeholder?: string;
-  inputProps?: IInputProps;
+  inputProps?: TextInputProps;
 };
 
 /**
@@ -50,12 +53,12 @@ export const FreeformTextInput = ({
 
   return (
     <FormControl isInvalid={hasError !== null}>
-      <Input
-        placeholder={placeholder !== undefined ? placeholder : ''}
+      <TextInput
+        placeholder={placeholder}
         onSubmitEditing={handleSubmit}
         onChangeText={text => setTextValue(text)}
         value={textValue}
-        {...inputProps}
+        textInputProps={inputProps}
       />
       <FormControl.ErrorMessage>{hasError}</FormControl.ErrorMessage>
     </FormControl>

--- a/dev-client/src/screens/AddUserToProjectScreen/components/FreeformTextInput.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/FreeformTextInput.tsx
@@ -58,7 +58,7 @@ export const FreeformTextInput = ({
         onSubmitEditing={handleSubmit}
         onChangeText={text => setTextValue(text)}
         value={textValue}
-        textInputProps={inputProps}
+        {...inputProps}
       />
       <FormControl.ErrorMessage>{hasError}</FormControl.ErrorMessage>
     </FormControl>

--- a/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
@@ -102,7 +102,7 @@ const FormContainer = React.memo(
     return (
       <KeyboardAvoidingView flex={1}>
         <ScrollView bg="background.default">
-          <Box pt={4} mx={5}>
+          <Box pt="16px" mx="20px">
             <ProjectForm
               onInfoPress={onInfoPress}
               handleChange={handleChange}

--- a/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
@@ -102,7 +102,7 @@ const FormContainer = React.memo(
     return (
       <KeyboardAvoidingView flex={1}>
         <ScrollView bg="background.default">
-          <Box pt="md" mx={5}>
+          <Box pt={4} mx={5}>
             <ProjectForm
               onInfoPress={onInfoPress}
               handleChange={handleChange}

--- a/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
@@ -19,7 +19,7 @@ import {useTranslation} from 'react-i18next';
 
 import {Formik, FormikProps} from 'formik';
 import {TFunction} from 'i18next';
-import {Button, Input, TextArea} from 'native-base';
+import {Button} from 'native-base';
 import * as yup from 'yup';
 
 import {
@@ -31,6 +31,7 @@ import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
 import {FormLabel} from 'terraso-mobile-client/components/form/FormLabel';
 import {FormTextArea} from 'terraso-mobile-client/components/form/FormTextArea';
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
+import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {
   Box,
   Heading,
@@ -178,32 +179,28 @@ export default function ProjectForm({
   );
 
   return (
-    <VStack space={3}>
+    <VStack space={2}>
       {EditHeader}
       <FormLabel>{t('projects.create.name_label')}</FormLabel>
-      <Input
+      <TextInput
         placeholder={t('projects.add.name')}
-        defaultValue=""
-        autoCorrect={false}
-        scrollEnabled={false}
         {...inputParams('name')}
       />
       <ErrorMessage fieldName="name" />
 
       <FormLabel>{t('projects.create.description_label')}</FormLabel>
-      <TextArea
+      <TextInput
         placeholder={t('projects.add.description')}
-        numberOfLines={3}
-        fontSize={16}
-        autoCompleteType="off"
-        autoCorrect={false}
+        multiline={true}
         {...inputParams('description')}
       />
       <ErrorMessage fieldName="description" />
       <RadioBlock
         label={
           <HStack alignItems="center">
-            <Heading size="sm">{t('projects.create.privacy_label')}</Heading>
+            <Heading bold size="md">
+              {t('projects.create.privacy_label')}
+            </Heading>
             <IconButton
               name="info"
               onPress={onInfoPress}

--- a/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
@@ -28,8 +28,7 @@ import {
 } from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
-import {FormLabel} from 'terraso-mobile-client/components/form/FormLabel';
-import {FormTextArea} from 'terraso-mobile-client/components/form/FormTextArea';
+import {FormRadioGroup} from 'terraso-mobile-client/components/form/FormRadioGroup';
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {
@@ -90,29 +89,6 @@ type Props = {
   onInfoPress: () => void;
 };
 
-const SharedFormComponents = (showPlaceholders: boolean, t: TFunction) => {
-  return [
-    <FormInput
-      key="name"
-      name="name"
-      placeholder={showPlaceholders ? t('projects.add.name') : undefined}
-      variant="outline"
-      id="project-form-name"
-      label={t('projects.add.name')}
-    />,
-    <FormTextArea
-      key="description"
-      name="description"
-      placeholder={showPlaceholders ? t('projects.add.description') : undefined}
-      variant="outline"
-      fontSize={16}
-      numberOfLines={3}
-      autoCompleteType="off"
-      label={t('projects.add.description')}
-    />,
-  ];
-};
-
 type FormValues = Omit<ProjectUpdateMutationInput, 'id'>;
 
 type FormProps = FormValues & {
@@ -128,6 +104,11 @@ export const EditProjectForm = ({
 }: Omit<FormProps, 'privacy'>) => {
   const {t} = useTranslation();
 
+  // We are using a special textInputLabel prop instead of label. This is passed
+  // from FormInput to TextInput.
+  //
+  // If label is present, Formik adds a label above the text field.
+  // If label is absent, then TextInput doesn't get a needed label.
   return (
     <Formik<FormValues>
       validationSchema={editProjectValidationSchema(t)}
@@ -136,7 +117,32 @@ export const EditProjectForm = ({
       onSubmit={onSubmit}>
       {({handleSubmit, isValid, isSubmitting}) => (
         <>
-          {SharedFormComponents(false, t)}
+          <FormInput
+            key="name"
+            name="name"
+            placeholder={t('projects.create.name_label')}
+            id="project-form-name"
+            textInputLabel={t('projects.create.name_label')}
+          />
+          <FormInput
+            key="description"
+            name="description"
+            placeholder={t('projects.create.description_label')}
+            numberOfLines={3}
+            multiline={true}
+            autoComplete="off"
+            textInputLabel={t('projects.create.description_label')}
+          />
+          <FormRadioGroup
+            label={t('projects.settings.measurement_units')}
+            name="measurementUnits"
+            values={MEASUREMENT_UNITS}
+            renderRadio={value => (
+              <Radio value={value} key={value}>
+                {t(`general.measurement_units.${value}`)}
+              </Radio>
+            )}
+          />
           {userRole === 'MANAGER' && (
             <Box position="absolute" bottom={0} right={0}>
               <Button
@@ -157,7 +163,6 @@ export const EditProjectForm = ({
 };
 
 export default function ProjectForm({
-  editForm = false,
   onInfoPress,
   handleChange,
   handleBlur,
@@ -172,25 +177,18 @@ export default function ProjectForm({
     onBlur: handleBlur(field),
   });
 
-  const EditHeader = editForm ? (
-    <Heading size="sm">{t('projects.edit.input_header')}</Heading>
-  ) : (
-    <></>
-  );
-
   return (
-    <VStack space={2}>
-      {EditHeader}
-      <FormLabel>{t('projects.create.name_label')}</FormLabel>
+    <VStack space={5}>
       <TextInput
-        placeholder={t('projects.add.name')}
+        placeholder={t('projects.create.name_label')}
+        label={t('projects.create.name_label')}
         {...inputParams('name')}
       />
       <ErrorMessage fieldName="name" />
 
-      <FormLabel>{t('projects.create.description_label')}</FormLabel>
       <TextInput
-        placeholder={t('projects.add.description')}
+        placeholder={t('projects.create.description_label')}
+        label={t('projects.create.description_label')}
         multiline={true}
         {...inputParams('description')}
       />

--- a/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
@@ -19,13 +19,14 @@ import {useTranslation} from 'react-i18next';
 
 import {Formik, FormikProps} from 'formik';
 import {TFunction} from 'i18next';
-import {Button} from 'native-base';
+import {Button, Radio} from 'native-base';
 import * as yup from 'yup';
 
 import {
   ProjectMembershipProjectRoleChoices,
   ProjectUpdateMutationInput,
 } from 'terraso-client-shared/graphqlSchema/graphql';
+import {MEASUREMENT_UNITS} from 'terraso-client-shared/project/projectSlice';
 
 import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
 import {FormRadioGroup} from 'terraso-mobile-client/components/form/FormRadioGroup';

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -74,7 +74,10 @@ export const CreateSiteForm = ({
       <ScrollView>
         <VStack p="16px" pt="30px" space="18px">
           <FormField name="name">
-            <FormInput placeholder={t('site.create.name_placeholder')} />
+            <FormInput
+              placeholder={t('site.create.name_placeholder')}
+              textInputLabel={t('site.create.name_placeholder')}
+            />
           </FormField>
 
           <FormLabel>{t('site.create.location_label')}</FormLabel>

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -75,8 +75,8 @@ export const CreateSiteForm = ({
         <VStack p="16px" pt="30px" space="18px">
           <FormField name="name">
             <FormInput
-              placeholder={t('site.create.name_placeholder')}
-              textInputLabel={t('site.create.name_placeholder')}
+              placeholder={t('site.create.name_label')}
+              textInputLabel={t('site.create.name_label')}
             />
           </FormField>
 

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -19,13 +19,14 @@ import {useCallback, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Keyboard} from 'react-native';
 import Autocomplete from 'react-native-autocomplete-input';
+import {Searchbar} from 'react-native-paper';
 
-import {Input, Pressable} from 'native-base';
+import {Pressable} from 'native-base';
 
 import {Coords} from 'terraso-client-shared/types';
 
-import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
+import {searchFilterStyles} from 'terraso-mobile-client/components/ListFilter';
 import {
   Box,
   HStack,
@@ -138,11 +139,6 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
     Keyboard.dismiss();
   };
 
-  const clearQuery = () => {
-    setQuery('');
-    setHideResults(true);
-  };
-
   async function lookupFeature(mapboxId: string) {
     let {features} = await retrieveFeature(mapboxId);
     // TODO: For now we are just going to zoom to the first feature
@@ -182,9 +178,7 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
             }}
             inputContainerStyle={{borderWidth: 0}} // eslint-disable-line react-native/no-inline-styles
             renderTextInput={() => (
-              <Input
-                borderRadius={10}
-                bgColor="white"
+              <Searchbar
                 onChangeText={newText => {
                   setQuery(newText);
                   querySuggestions(newText);
@@ -198,12 +192,8 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
                 }}
                 value={query}
                 placeholder={t('search.placeholder')}
-                InputLeftElement={<Icon ml={3} name="search" size="md" />}
-                InputRightElement={
-                  query.length > 0 ? (
-                    <Icon mr={3} name="close" size="sm" onPress={clearQuery} />
-                  ) : undefined
-                }
+                style={searchFilterStyles.search}
+                inputStyle={searchFilterStyles.input}
               />
             )}
           />

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -26,7 +26,7 @@ import {Pressable} from 'native-base';
 import {Coords} from 'terraso-client-shared/types';
 
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
-import {searchFilterStyles} from 'terraso-mobile-client/components/ListFilter';
+import {searchBarStyles} from 'terraso-mobile-client/components/ListFilter';
 import {
   Box,
   HStack,
@@ -192,8 +192,8 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
                 }}
                 value={query}
                 placeholder={t('search.placeholder')}
-                style={searchFilterStyles.search}
-                inputStyle={searchFilterStyles.input}
+                style={searchBarStyles.search}
+                inputStyle={searchBarStyles.input}
               />
             )}
           />

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -108,7 +108,7 @@ export const ProjectInputScreen = ({
               groupProps={{
                 name: 'project-privacy',
                 onChange: onProjectPrivacyChanged,
-                value: project.privacy,
+                value: project?.privacy,
                 ml: '0',
               }}
               allDisabled={!allowEditing}

--- a/dev-client/src/screens/ProjectInputScreen/RequiredDataSettings.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/RequiredDataSettings.tsx
@@ -33,8 +33,8 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {SWITCH_PADDING} from 'terraso-mobile-client/constants';
 import {useDispatch} from 'terraso-mobile-client/store';
+import {SWITCH_PADDING} from 'terraso-mobile-client/theme';
 
 export const RequiredDataSettings = ({
   projectId,

--- a/dev-client/src/screens/ProjectInputScreen/RequiredDataSettings.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/RequiredDataSettings.tsx
@@ -33,6 +33,7 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {SWITCH_PADDING} from 'terraso-mobile-client/constants';
 import {useDispatch} from 'terraso-mobile-client/store';
 
 export const RequiredDataSettings = ({
@@ -78,7 +79,7 @@ export const RequiredDataSettings = ({
                   );
                 }}
               />
-              <Text variant="body1" bold pl={2}>
+              <Text variant="body1" bold pl={SWITCH_PADDING}>
                 {t(`soil.collection_method.${method}`)}
               </Text>
             </Row>

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -131,7 +131,7 @@ export const ProjectListScreen = () => {
                 <TextInputFilter
                   name="search"
                   label={t('projects.search_label')}
-                  placeholder={t('projects.search_placeholder')}
+                  placeholder={t('projects.search.placeholder')}
                 />
               }>
               <SelectFilter

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -29,10 +29,7 @@ import {selectProject} from 'terraso-client-shared/selectors';
 
 import IconLink from 'terraso-mobile-client/components/icons/IconLink';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
-import {
-  Text,
-  VStack,
-} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {VStack} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {
@@ -78,13 +75,6 @@ export function ProjectSettingsScreen({
           userRole={userRole}
         />
         <VStack space={1}>
-          <IconLink iconName="content-copy" isUnderlined={false}>
-            {t('projects.settings.copy_download_link')}
-          </IconLink>
-          <Text ml={10}>
-            {t('projects.settings.download_link_description')}
-          </Text>
-
           <RestrictByProjectRole role="MANAGER">
             <ConfirmModal
               title={t('projects.settings.delete_button_prompt')}

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -173,7 +173,7 @@ const selectProjectSites = createSelector(
     projectId: string,
   ) => {
     let project = projects[projectId];
-    return Object.keys(project.sites)
+    return Object.keys(project?.sites)
       .map(id => sites[id])
       .filter(site => site);
   },

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -57,7 +57,12 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   return (
     <ScreenScaffold BottomNavigation={null} AppBar={<AppBar title={name} />}>
       <Column px="16px" py="22px" space="20px" alignItems="flex-start">
-        <TextInput value={name} onChangeText={setName} />
+        <TextInput
+          value={name}
+          onChangeText={setName}
+          label={t('site.create.name_label')}
+          placeholder={t('site.create.name_label')}
+        />
         <ConfirmModal
           trigger={onOpen => (
             <Button

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -23,7 +23,7 @@ import {Button, Fab} from 'native-base';
 import {deleteSite, updateSite} from 'terraso-client-shared/site/siteSlice';
 
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {Text} from 'terraso-mobile-client/components/inputs/Text';
+import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -57,7 +57,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   return (
     <ScreenScaffold BottomNavigation={null} AppBar={<AppBar title={name} />}>
       <Column px="16px" py="22px" space="20px" alignItems="flex-start">
-        <Text value={name} onChangeText={setName} />
+        <TextInput value={name} onChangeText={setName} />
         <ConfirmModal
           trigger={onOpen => (
             <Button

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -18,16 +18,7 @@
 import {useCallback, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {
-  Button,
-  Fab,
-  Input,
-  // useTheme,
-  // Row,
-  // Text,
-  // Spacer,
-  // Pressable,
-} from 'native-base';
+import {Button, Fab, Input} from 'native-base';
 
 import {deleteSite, updateSite} from 'terraso-client-shared/site/siteSlice';
 

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -26,7 +26,9 @@ import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
 type Props = {

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -18,16 +18,15 @@
 import {useCallback, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {Button, Fab, Input} from 'native-base';
+import {Button, Fab} from 'native-base';
 
 import {deleteSite, updateSite} from 'terraso-client-shared/site/siteSlice';
 
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {Text} from 'terraso-mobile-client/components/inputs/Text';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
 type Props = {
@@ -58,7 +57,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   return (
     <ScreenScaffold BottomNavigation={null} AppBar={<AppBar title={name} />}>
       <Column px="16px" py="22px" space="20px" alignItems="flex-start">
-        <Input value={name} onChangeText={setName} />
+        <Text value={name} onChangeText={setName} />
         <ConfirmModal
           trigger={onOpen => (
             <Button

--- a/dev-client/src/screens/SiteTransferProjectScreen/components/CheckboxGroup.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/components/CheckboxGroup.tsx
@@ -26,6 +26,10 @@ import {
   HStack,
   VStack,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {
+  SWITCH_PADDING,
+  SWITCH_VERTICAL_PADDING,
+} from 'terraso-mobile-client/constants';
 
 type CheckboxProps = {
   label: string;
@@ -65,23 +69,32 @@ export const CheckboxGroup = ({
     <Box>
       <HStack>
         <CheckBox
-          id={'select-all-' + groupName}
+          id={`select-all-${groupName}`}
           onValueChange={onSelectAll}
           value={selectAllChecked}
         />
-        <FormControl.Label htmlFor={'select-all-' + groupName} variant="body1">
+        <FormControl.Label
+          htmlFor={`select-all-${groupName}`}
+          variant="body1"
+          pl={SWITCH_PADDING}>
           {t('general.select_all')}
         </FormControl.Label>
       </HStack>
       <VStack px="20px">
         {checkboxes.map(({label, id, checked}) => (
-          <HStack key={id}>
+          <HStack
+            key={id}
+            mt={SWITCH_VERTICAL_PADDING}
+            mb={SWITCH_VERTICAL_PADDING}>
             <CheckBox
               id={'checkbox-' + id}
               onValueChange={onChangeValue(groupId, id)}
               value={checked}
             />
-            <FormControl.Label htmlFor={'checkbox-' + id} variant="body1">
+            <FormControl.Label
+              htmlFor={'checkbox-' + id}
+              variant="body1"
+              pl={SWITCH_PADDING}>
               {label}
             </FormControl.Label>
           </HStack>

--- a/dev-client/src/screens/SiteTransferProjectScreen/components/CheckboxGroup.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/components/CheckboxGroup.tsx
@@ -29,7 +29,7 @@ import {
 import {
   SWITCH_PADDING,
   SWITCH_VERTICAL_PADDING,
-} from 'terraso-mobile-client/constants';
+} from 'terraso-mobile-client/theme';
 
 type CheckboxProps = {
   label: string;

--- a/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
@@ -16,14 +16,15 @@
  */
 import {memo} from 'react';
 import {useTranslation} from 'react-i18next';
+import {Searchbar} from 'react-native-paper';
 
+import {searchFilterStyles} from 'terraso-mobile-client/components/ListFilter';
 import {
   Heading,
   HStack,
   Text,
   VStack,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {SearchBar} from 'terraso-mobile-client/components/SearchBar';
 import {HelpTooltipButton} from 'terraso-mobile-client/components/tooltips/HelpTooltipButton';
 
 type Props = {query: string; setQuery: (query: string) => void};
@@ -31,18 +32,20 @@ type Props = {query: string; setQuery: (query: string) => void};
 export const ListHeader = memo(({query, setQuery}: Props) => {
   const {t} = useTranslation();
   return (
-    <VStack space="10px" px="12px" pt="5%">
+    <VStack space="10px" px="12px" pt={5} pb={5}>
       <HStack>
-        <Heading>{t('projects.transfer_sites.heading', '')}</Heading>
+        <Heading>{t('projects.transfer_sites.heading')}</Heading>
         <HelpTooltipButton>
           {t('projects.transfer_sites.tooltip')}
         </HelpTooltipButton>
       </HStack>
-      <Text>{t('projects.transfer_sites.description', '')}</Text>
-      <SearchBar
-        query={query}
-        setQuery={setQuery}
+      <Text>{t('projects.transfer_sites.description')}</Text>
+      <Searchbar
+        value={query !== undefined ? query : ''}
+        onChangeText={setQuery}
         placeholder={t('site.search.placeholder')}
+        style={searchFilterStyles.search}
+        inputStyle={searchFilterStyles.input}
       />
     </VStack>
   );

--- a/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
@@ -32,7 +32,7 @@ type Props = {query: string; setQuery: (query: string) => void};
 export const ListHeader = memo(({query, setQuery}: Props) => {
   const {t} = useTranslation();
   return (
-    <VStack space="10px" px="12px" pt={5} pb={5}>
+    <VStack space="10px" px="12px" pt="10px" pb="10px">
       <HStack>
         <Heading>{t('projects.transfer_sites.heading')}</Heading>
         <HelpTooltipButton>

--- a/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
@@ -18,7 +18,7 @@ import {memo} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Searchbar} from 'react-native-paper';
 
-import {searchFilterStyles} from 'terraso-mobile-client/components/ListFilter';
+import {searchBarStyles} from 'terraso-mobile-client/components/ListFilter';
 import {
   Heading,
   HStack,
@@ -44,8 +44,8 @@ export const ListHeader = memo(({query, setQuery}: Props) => {
         value={query !== undefined ? query : ''}
         onChangeText={setQuery}
         placeholder={t('site.search.placeholder')}
-        style={searchFilterStyles.search}
-        inputStyle={searchFilterStyles.input}
+        style={searchBarStyles.search}
+        inputStyle={searchBarStyles.input}
       />
     </VStack>
   );

--- a/dev-client/src/screens/SlopeScreen/components/ManualSteepnessModal.tsx
+++ b/dev-client/src/screens/SlopeScreen/components/ManualSteepnessModal.tsx
@@ -136,7 +136,6 @@ export const ManualSteepnessModal = ({siteId}: Props) => {
               <FormInput
                 keyboardType="numeric"
                 name="slopeSteepnessPercent"
-                variant="underlined"
                 helpText={t('slope.steepness.percentage_help')}
                 placeholder={t('slope.steepness.percentage_placeholder')}
                 onChangeText={text => {
@@ -161,7 +160,6 @@ export const ManualSteepnessModal = ({siteId}: Props) => {
               <FormInput
                 keyboardType="numeric"
                 name="slopeSteepnessDegree"
-                variant="underlined"
                 helpText={t('slope.steepness.degree_help')}
                 placeholder={t('slope.steepness.degree_placeholder')}
                 onChangeText={text => {

--- a/dev-client/src/screens/SoilScreen/components/EditIntervalModal.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditIntervalModal.tsx
@@ -55,10 +55,10 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {OverlaySheet} from 'terraso-mobile-client/components/sheets/OverlaySheet';
-import {SWITCH_PADDING} from 'terraso-mobile-client/constants';
 import {intervalSchema} from 'terraso-mobile-client/schemas/intervalSchema';
 import {renderDepthInterval} from 'terraso-mobile-client/screens/SoilScreen/components/RenderValues';
 import {useDispatch} from 'terraso-mobile-client/store';
+import {SWITCH_PADDING} from 'terraso-mobile-client/theme';
 
 type EditIntervalFormInput = IntervalFormInput &
   Omit<SoilDataDepthInterval, 'label' | 'depthInterval'> & {

--- a/dev-client/src/screens/SoilScreen/components/EditIntervalModal.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditIntervalModal.tsx
@@ -55,6 +55,7 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {OverlaySheet} from 'terraso-mobile-client/components/sheets/OverlaySheet';
+import {SWITCH_PADDING} from 'terraso-mobile-client/constants';
 import {intervalSchema} from 'terraso-mobile-client/schemas/intervalSchema';
 import {renderDepthInterval} from 'terraso-mobile-client/screens/SoilScreen/components/RenderValues';
 import {useDispatch} from 'terraso-mobile-client/store';
@@ -214,7 +215,7 @@ export const EditIntervalModal = ({
 
             <Row mb="12px">
               <FormCheckbox name="applyToAll" />
-              <FormLabel variant="body1" ml="10px">
+              <FormLabel variant="body1" ml={SWITCH_PADDING}>
                 {t('soil.depth_interval.apply_to_all_label')}
               </FormLabel>
             </Row>

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -70,7 +70,7 @@ export const theme = extendTheme({
     },
     input: {
       standard: {
-        enabledBorder: '#0000006B',
+        enabledBorder: '#8B8B8B',
       },
       filled: {
         enabledFill: '#0000000F',

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -73,7 +73,7 @@ export const theme = extendTheme({
         enabledBorder: '#8B8B8B',
       },
       filled: {
-        enabledFill: '#0000000F',
+        enabledFill: '#e4e4e4',
       },
     },
     transparent: '#00000000',

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -17,6 +17,9 @@
 
 import {extendTheme} from 'native-base';
 
+export const SWITCH_PADDING = 2;
+export const SWITCH_VERTICAL_PADDING = 1;
+
 export const theme = extendTheme({
   colors: {
     primary: {

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -308,10 +308,6 @@
         "distanceAsc": "Distance (nearest to me)"
       }
     },
-    "add": {
-      "name": "Project Name",
-      "description": "Project Description"
-    },
     "add_user": {
       "heading": "Add Team Members",
       "help_text": "Enter a Terraso email address",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -47,7 +47,6 @@
       "location_accuracy": "GPS accuracy: {{accuracyM}} m",
       "coords_label": "Latitude, Longitude",
       "coords_help": "Enter decimal degrees, with latitude and longitude separated by a comma.",
-      "name_placeholder": "Site name",
       "add_to_project_label": "Add to Project",
       "add_to_project_caption": "Project",
       "add_to_project_tooltip": "The site will inherit the settings of the project, including data collection requirements and team members. Create new projects using the Projects tab in the bottom navigation.",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -199,7 +199,6 @@
     "learn_more": "Learn more about using projects",
     "create_button": "Create project",
     "go_to": "Go to Project",
-    "search_placeholder": "Search",
     "search_label": "Enter text to filter projects by name",
     "role_filter_label": "Filter projects by role",
     "create": {


### PR DESCRIPTION
## Description
Redo the text and search components based on React Native Paper
- remove old SearchBar and FormTextArea components
- create new TextInputComponent
- eliminates our own code for adding search icons and clearing searches
- remove some duplicate string entries for project name/description/search
- refactored the ProjectForm code to get rid of SharedFormComponents (which wasn't shared) and EditHeader (which never appeared)
- use consistent spacing on lists of checkboxes and switches
- remove nonfunctional download link from project settings

Courtney approved the use of the rounded corner search field.

### Related Issues
Corresponding Select box fix https://github.com/techmatters/terraso-mobile-client/pull/1443
Addresses https://github.com/techmatters/terraso-mobile-client/issues/688.