### PR TITLE
fix: text and table width for soil info sheets

### DIFF
--- a/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
@@ -68,10 +68,10 @@ type Props = {
 export const SoilPropertiesDataTable = ({rows}: Props) => {
   const {t} = useTranslation();
 
-  const columnWidthDepth: NBDimensionValue = '85px';
-  const columnWidthTexture: NBDimensionValue = '115px';
-  const columnWidthColor: NBDimensionValue = '110px';
-  const columnWidthRockFragment: NBDimensionValue = '110px';
+  const columnWidthDepth: NBDimensionValue = '90px';
+  const columnWidthTexture: NBDimensionValue = '120px';
+  const columnWidthColor: NBDimensionValue = '120px';
+  const columnWidthRockFragment: NBDimensionValue = '120px';
 
   // React wants a `key` prop on components rendered with map, for DOM reconciliation purposes.
   // However, using the index alone for the key is an anti-pattern,

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -127,7 +127,7 @@
         "eco_name_label": "<bold>Ecological Site Name:</bold> {{name}}",
         "eco_id_label": "<bold>Ecological Site ID:</bold> {{id}}",
         "land_class_label": "<bold>Land Capability Class:</bold> {{land}}",
-        "data_source_label": "<bold>Ecological Site Name:</bold> {{source}}",
+        "data_source_label": "<bold>Data Source:</bold> {{source}}",
         "location_url": "View location on soil web",
         "inside_map_label": "In soil map unit",
         "outside_map_label": "In adjacent map unit, {{distance}} {{units}} distance",


### PR DESCRIPTION
## Description
Fixes incorrect "data source" label text and expands width of table columns per feedback on #1156 and #1158.

### Verification steps

Open application and navigated to soil info sheets. Verify that label is fixed and columns (other than Texture) are wide enough for their content.