### PR TITLE
Feat: Create soil match tiles using data from soil id API

### DIFF
--- a/dev-client/src/model/soilId/soilIdRanking.ts
+++ b/dev-client/src/model/soilId/soilIdRanking.ts
@@ -49,3 +49,13 @@ export const getBetterLocationMatch = (
 ): LocationBasedSoilMatch => {
   return a.match.rank < b.match.rank ? a : b;
 };
+
+export const getSortedDataBasedMatches = (soilIdData: SoilIdResults) =>
+  [...soilIdData.dataBasedMatches].sort(
+    (a, b) => b.combinedMatch.score - a.combinedMatch.score,
+  );
+
+export const getSortedLocationBasedMatches = (soilIdData: SoilIdResults) =>
+  [...soilIdData.locationBasedMatches].sort(
+    (a, b) => b.match.score - a.match.score,
+  );

--- a/dev-client/src/model/soilId/soilIdRanking.ts
+++ b/dev-client/src/model/soilId/soilIdRanking.ts
@@ -52,10 +52,10 @@ export const getBetterLocationMatch = (
 
 export const getSortedDataBasedMatches = (soilIdData: SoilIdResults) =>
   [...soilIdData.dataBasedMatches].sort(
-    (a, b) => b.combinedMatch.score - a.combinedMatch.score,
+    (a, b) => a.combinedMatch.rank - b.combinedMatch.rank,
   );
 
 export const getSortedLocationBasedMatches = (soilIdData: SoilIdResults) =>
   [...soilIdData.locationBasedMatches].sort(
-    (a, b) => b.match.score - a.match.score,
+    (a, b) => a.match.rank - b.match.rank,
   );

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -75,9 +75,9 @@ const LocationPrediction = ({
   const {t} = useTranslation();
 
   return (
-    <Column
-      backgroundColor="background.secondary"
-      borderRadius="4px"
+    <Box
+      variant="tile"
+      flexDirection="column"
       alignItems="flex-start"
       py="18px"
       pl="16px">
@@ -112,7 +112,7 @@ const LocationPrediction = ({
         onPress={onExploreDataPress}>
         {t('soil.explore_data')}
       </Button>
-    </Column>
+    </Box>
   );
 };
 

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -29,6 +29,7 @@ import {
 import {InfoOverlaySheet} from 'terraso-mobile-client/components/sheets/InfoOverlaySheet';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
 import {useSoilIdData} from 'terraso-mobile-client/hooks/soilIdHooks';
+import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {TempScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/TempScoreInfoContent';
 import {TopSoilMatchesInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/TopSoilMatchesInfoContent';
@@ -45,7 +46,7 @@ export const SoilIdMatchesSection = ({
 
   return (
     <ScreenContentSection backgroundColor="grey.200">
-      <Row alignItems="center">
+      <Row alignItems="center" pb="12px">
         <Heading variant="h6">{t('site.soil_id.matches.title')}</Heading>
         <InfoOverlaySheetButton Header={t('site.soil_id.matches.info.title')}>
           <TopSoilMatchesInfoContent isSite={isSite} />
@@ -57,9 +58,11 @@ export const SoilIdMatchesSection = ({
               key={dataMatch.soilInfo.soilSeries.name}
               Header={dataMatch.soilInfo.soilSeries.name}
               trigger={onOpen => (
-                <Button backgroundColor="background.secondary" onPress={onOpen}>
-                  {dataMatch.soilInfo.soilSeries.name}
-                </Button>
+                <SoilMatchTile
+                  soil_name={dataMatch.soilInfo.soilSeries.name}
+                  score={dataMatch.combinedMatch.score} //TODO-cknipe: Also sort by combinedMatch.rank
+                  onPress={onOpen}
+                />
               )}>
               <SiteScoreInfoContent dataMatch={dataMatch} coords={coords} />
             </InfoOverlaySheet>
@@ -69,9 +72,11 @@ export const SoilIdMatchesSection = ({
               key={locationMatch.soilInfo.soilSeries.name}
               Header={locationMatch.soilInfo.soilSeries.name}
               trigger={onOpen => (
-                <Button backgroundColor="background.secondary" onPress={onOpen}>
-                  {locationMatch.soilInfo.soilSeries.name}
-                </Button>
+                <SoilMatchTile
+                  soil_name={locationMatch.soilInfo.soilSeries.name}
+                  score={locationMatch.match.score} //TODO-cknipe: Sort them by match.rank
+                  onPress={onOpen}
+                />
               )}>
               <TempScoreInfoContent
                 locationMatch={locationMatch}

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -29,6 +29,10 @@ import {
 import {InfoOverlaySheet} from 'terraso-mobile-client/components/sheets/InfoOverlaySheet';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
 import {useSoilIdData} from 'terraso-mobile-client/hooks/soilIdHooks';
+import {
+  getSortedDataBasedMatches,
+  getSortedLocationBasedMatches,
+} from 'terraso-mobile-client/model/soilId/soilIdRanking';
 import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {TempScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/TempScoreInfoContent';
@@ -53,28 +57,28 @@ export const SoilIdMatchesSection = ({
         </InfoOverlaySheetButton>
       </Row>
       {isSite
-        ? soilIdData.dataBasedMatches.map(dataMatch => (
+        ? getSortedDataBasedMatches(soilIdData).map(dataMatch => (
             <InfoOverlaySheet
               key={dataMatch.soilInfo.soilSeries.name}
               Header={dataMatch.soilInfo.soilSeries.name}
               trigger={onOpen => (
                 <SoilMatchTile
                   soil_name={dataMatch.soilInfo.soilSeries.name}
-                  score={dataMatch.combinedMatch.score} //TODO-cknipe: Also sort by combinedMatch.rank
+                  score={dataMatch.combinedMatch.score}
                   onPress={onOpen}
                 />
               )}>
               <SiteScoreInfoContent dataMatch={dataMatch} coords={coords} />
             </InfoOverlaySheet>
           ))
-        : soilIdData.locationBasedMatches.map(locationMatch => (
+        : getSortedLocationBasedMatches(soilIdData).map(locationMatch => (
             <InfoOverlaySheet
               key={locationMatch.soilInfo.soilSeries.name}
               Header={locationMatch.soilInfo.soilSeries.name}
               trigger={onOpen => (
                 <SoilMatchTile
                   soil_name={locationMatch.soilInfo.soilSeries.name}
-                  score={locationMatch.match.score} //TODO-cknipe: Sort them by match.rank
+                  score={locationMatch.match.score}
                   onPress={onOpen}
                 />
               )}>

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -17,8 +17,6 @@
 
 import {useTranslation} from 'react-i18next';
 
-import {Button} from 'native-base';
-
 import {Coords} from 'terraso-client-shared/types';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {Pressable} from 'react-native';
+
+import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {formatPercent} from 'terraso-mobile-client/util';
+
+type Props = {soil_name: string; score: number; onPress: () => void};
+
+export const SoilMatchTile = ({soil_name, score, onPress}: Props) => {
+  const {t} = useTranslation();
+  // TODO-cknipe: dp versus px?
+
+  return (
+    <Pressable onPress={onPress}>
+      <Box
+        backgroundColor="background.secondary"
+        borderRadius="4px"
+        alignItems="center"
+        flexDirection="row"
+        justifyContent="space-between"
+        my="4px"
+        py="4px">
+        <Box marginHorizontal="16px" width="74px" justifyContent="center">
+          <Text
+            size="30px"
+            fontWeight={400}
+            color="primary.lighter"
+            textAlign="center"
+            mb="-6px">
+            {formatPercent(score)}
+          </Text>
+          <Text
+            variant="body2"
+            color="primary.lighter"
+            textAlign="center"
+            mb="6px">
+            {t('site.soil_id.matches.match')}
+          </Text>
+        </Box>
+
+        <Box flex={1} mr="12px" my="8px" flexDirection="row">
+          <Text variant="match-tile-name" color="primary.contrast">
+            {soil_name}
+          </Text>
+        </Box>
+
+        <Icon name="chevron-right" color="primary.contrast" mr="12px" />
+      </Box>
+    </Pressable>
+  );
+};

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
@@ -31,8 +31,7 @@ export const SoilMatchTile = ({soil_name, score, onPress}: Props) => {
   return (
     <Pressable onPress={onPress}>
       <Box
-        backgroundColor="background.secondary"
-        borderRadius="4px"
+        variant="tile"
         alignItems="center"
         flexDirection="row"
         justifyContent="space-between"

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/ScoreTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/ScoreTile.tsx
@@ -27,8 +27,7 @@ export function ScoreTile({score}: ScoreTileProps) {
     <Box
       width="94px"
       height="54px"
-      borderRadius="4px"
-      backgroundColor="background.secondary"
+      variant="tile"
       justifyContent="center"
       alignItems="center">
       <Text variant="score-tile" color="primary.lighter">

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -393,6 +393,12 @@ export const theme = extendTheme({
           fontSize: '30px',
           lineHeight: '48px',
         },
+        'match-tile-name': {
+          fontWeight: 700,
+          fontSize: '18px',
+          lineHeight: '27px',
+          letterSpacing: '0.15px',
+        },
       },
     },
     Heading: {

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -95,6 +95,10 @@ export const theme = extendTheme({
           padding: '16px',
           shadow: 1,
         },
+        tile: {
+          borderRadius: '4px',
+          backgroundColor: 'background.secondary',
+        },
       },
     },
     Badge: {

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -101,7 +101,8 @@
             "site": "The soils listed are the most likely to be found at the site based on USDA NRCS soil maps for this location.\n\nEnter the recommended slope and soil data to improve accuracy of the match scores. When this data is entered, the list will automatically update.",
             "temp_location": "The soils listed are the most likely to be found at this location based on USDA NRCS soil maps.\n\nCreate a site here and enter the recommended data to improve accuracy of the match scores. "
           }
-        }
+        },
+        "match": "match"
       },
       "site_data": {
         "title": "Site Data",


### PR DESCRIPTION
## Description
Soil ID page for a site and a temporary location should show tiles with match percentage and soil name.
NOTE: This builds off the feat/soil-id-data branch that is not yet submitted. Please let me know if there's a standard workflow for this.

### Related Issues
Implements #1197
