### PR TITLE
fix: set max height of bottom sheet to 75% and default height to 50%

### DIFF
--- a/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
@@ -76,7 +76,7 @@ export const SiteListBottomSheet = memo(
         () => [
           `${getStartingSnapValue(deviceBottomInsets)}%`,
           sites.length === 0 ? '50%' : '75%',
-          '100%',
+          '75%',
         ],
         [sites.length, deviceBottomInsets],
       );

--- a/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
@@ -73,12 +73,8 @@ export const SiteListBottomSheet = memo(
       );
 
       const snapPoints = useMemo(
-        () => [
-          `${getStartingSnapValue(deviceBottomInsets)}%`,
-          sites.length === 0 ? '50%' : '75%',
-          '75%',
-        ],
-        [sites.length, deviceBottomInsets],
+        () => [`${getStartingSnapValue(deviceBottomInsets)}%`, '50%', '75%'],
+        [deviceBottomInsets],
       );
 
       const {colors} = useTheme();


### PR DESCRIPTION
## Description
Set max height of bottom sheet to 75%. Set default height to 50%, whether or not sites are present.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1485 and https://github.com/techmatters/terraso-mobile-client/issues/1483