### PR TITLE
fix: hide bottom sheet when interacting with map

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -44,9 +44,9 @@ import * as Sentry from '@sentry/react-native';
 
 import {APP_CONFIG} from 'terraso-mobile-client/config';
 import {GeospatialProvider} from 'terraso-mobile-client/context/GeospatialContext';
+import {HomeScreenContextProvider} from 'terraso-mobile-client/context/HomeScreenContext';
 import {checkAndroidPermissions} from 'terraso-mobile-client/native/checkAndroidPermissions';
 import {RootNavigator} from 'terraso-mobile-client/navigation/navigators/RootNavigator';
-import {HomeScreenContextProvider} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {Toasts} from 'terraso-mobile-client/screens/Toasts';
 import {createStore} from 'terraso-mobile-client/store';
 import {theme} from 'terraso-mobile-client/theme';

--- a/dev-client/src/constants.ts
+++ b/dev-client/src/constants.ts
@@ -35,3 +35,4 @@ export const PROJECT_DEFAULT_MEASUREMENT_UNITS: MeasurementUnit = 'METRIC';
 export const GEOSPATIAL_CONTEXT_USER_DISTANCE_CACHE = 5;
 export const SITE_NOTE_MIN_LENGTH = 3;
 export const LOCALE = 'en-US';
+export const MAP_QUERY_MIN_LENGTH = 2;

--- a/dev-client/src/context/HomeScreenContext.tsx
+++ b/dev-client/src/context/HomeScreenContext.tsx
@@ -24,7 +24,9 @@ type HomeScreenRef = {
   collapseBottomSheet: () => void;
 };
 
-const HomeScreenContext = createContext<RefObject<HomeScreenRef> | null>(null);
+export const HomeScreenContext = createContext<RefObject<HomeScreenRef> | null>(
+  null,
+);
 
 export const HomeScreenContextProvider = memo(
   ({children}: React.PropsWithChildren<{}>) => (

--- a/dev-client/src/context/HomeScreenContext.tsx
+++ b/dev-client/src/context/HomeScreenContext.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {createContext, memo, RefObject, useContext, useRef} from 'react';
+
+import {Site} from 'terraso-client-shared/site/siteSlice';
+
+type HomeScreenRef = {
+  showSiteOnMap: (site: Site) => void;
+  collapseBottomSheet: () => void;
+};
+
+const HomeScreenContext = createContext<RefObject<HomeScreenRef> | null>(null);
+
+export const HomeScreenContextProvider = memo(
+  ({children}: React.PropsWithChildren<{}>) => (
+    <HomeScreenContext.Provider value={useRef<HomeScreenRef>(null)}>
+      {children}
+    </HomeScreenContext.Provider>
+  ),
+);
+
+export const useHomeScreenContext = () =>
+  useContext(HomeScreenContext)?.current ?? undefined;

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -24,13 +24,13 @@ import {SiteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql'
 import {Site} from 'terraso-client-shared/site/siteSlice';
 import {Coords} from 'terraso-client-shared/types';
 
+import {useHomeScreenContext} from 'terraso-mobile-client/context/HomeScreenContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {siteValidationSchema} from 'terraso-mobile-client/schemas/siteValidationSchema';
 import {
   CreateSiteForm,
   FormState,
 } from 'terraso-mobile-client/screens/CreateSiteScreen/components/CreateSiteForm';
-import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {useSelector} from 'terraso-mobile-client/store';
 
 type Props = {

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -60,6 +60,7 @@ import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
 type HomeScreenRef = {
   showSiteOnMap: (site: Site) => void;
+  collapseBottomSheet: () => void;
 };
 
 const HomeScreenContext = createContext<RefObject<HomeScreenRef> | null>(null);
@@ -99,12 +100,17 @@ export const HomeScreen = memo(() => {
     [setCalloutState],
   );
 
+  const collapseBottomSheet = useCallback(() => {
+    siteListBottomSheetRef.current?.collapse();
+  }, []);
+
   useImperativeHandle(
     homeScreenContext,
     () => ({
       showSiteOnMap,
+      collapseBottomSheet,
     }),
-    [showSiteOnMap],
+    [showSiteOnMap, collapseBottomSheet],
   );
 
   useEffect(() => {

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -37,7 +37,7 @@ import {Coords} from 'terraso-client-shared/types';
 import {ListFilterProvider} from 'terraso-mobile-client/components/ListFilter';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
-import {HomeScreenContextProvider} from 'terraso-mobile-client/context/HomeScreenContext';
+import {HomeScreenContext} from 'terraso-mobile-client/context/HomeScreenContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {LandPKSInfoModal} from 'terraso-mobile-client/screens/HomeScreen/components/LandPKSInfoModal';
@@ -70,7 +70,7 @@ export const HomeScreen = memo(() => {
   const dispatch = useDispatch();
   const mapRef = useRef<MapRef>(null);
   const siteProjectRoles = useSelector(state => selectSitesAndUserRoles(state));
-  const homeScreenContext = useContext(HomeScreenContextProvider);
+  const homeScreenContext = useContext(HomeScreenContext);
 
   const showSiteOnMap = useCallback(
     (targetSite: Site) => {

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -16,9 +16,7 @@
  */
 
 import {
-  createContext,
   memo,
-  RefObject,
   useCallback,
   useContext,
   useEffect,
@@ -39,6 +37,7 @@ import {Coords} from 'terraso-client-shared/types';
 import {ListFilterProvider} from 'terraso-mobile-client/components/ListFilter';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
+import {HomeScreenContextProvider} from 'terraso-mobile-client/context/HomeScreenContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {LandPKSInfoModal} from 'terraso-mobile-client/screens/HomeScreen/components/LandPKSInfoModal';
@@ -58,24 +57,6 @@ import {getHomeScreenFilters} from 'terraso-mobile-client/screens/HomeScreen/uti
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
-type HomeScreenRef = {
-  showSiteOnMap: (site: Site) => void;
-  collapseBottomSheet: () => void;
-};
-
-const HomeScreenContext = createContext<RefObject<HomeScreenRef> | null>(null);
-
-export const HomeScreenContextProvider = memo(
-  ({children}: React.PropsWithChildren<{}>) => (
-    <HomeScreenContext.Provider value={useRef<HomeScreenRef>(null)}>
-      {children}
-    </HomeScreenContext.Provider>
-  ),
-);
-
-export const useHomeScreenContext = () =>
-  useContext(HomeScreenContext)?.current ?? undefined;
-
 export const HomeScreen = memo(() => {
   const infoBottomSheetRef = useRef<BottomSheetModal>(null);
   const siteListBottomSheetRef = useRef<BottomSheet>(null);
@@ -89,7 +70,7 @@ export const HomeScreen = memo(() => {
   const dispatch = useDispatch();
   const mapRef = useRef<MapRef>(null);
   const siteProjectRoles = useSelector(state => selectSitesAndUserRoles(state));
-  const homeScreenContext = useContext(HomeScreenContext);
+  const homeScreenContext = useContext(HomeScreenContextProvider);
 
   const showSiteOnMap = useCallback(
     (targetSite: Site) => {

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -34,7 +34,7 @@ import {
   VStack,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {MAP_QUERY_MIN_LENGTH} from 'terraso-mobile-client/constants';
-import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
+import {useHomeScreenContext} from 'terraso-mobile-client/context/HomeScreenContext';
 import {
   initMapSearch,
   Suggestion,

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Keyboard} from 'react-native';
 import Autocomplete from 'react-native-autocomplete-input';
@@ -33,6 +33,8 @@ import {
   View,
   VStack,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {MAP_QUERY_MIN_LENGTH} from 'terraso-mobile-client/constants';
+import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {
   initMapSearch,
   Suggestion,
@@ -76,6 +78,13 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [, setAbortController] = useState<AbortController | null>(null);
   const [hideResults, setHideResults] = useState(false);
+  const homeScreen = useHomeScreenContext();
+
+  useEffect(() => {
+    if (query.length >= MAP_QUERY_MIN_LENGTH) {
+      homeScreen?.collapseBottomSheet();
+    }
+  }, [homeScreen, query]);
 
   async function makeSuggestionsApiCall(queryText: string) {
     const newAbortController = new AbortController();
@@ -98,7 +107,7 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
       const [latitude, longitude] = queryText.split(',').map(Number);
       zoomTo && zoomTo({latitude, longitude});
     } else {
-      if (queryText.length >= 2) {
+      if (queryText.length >= MAP_QUERY_MIN_LENGTH) {
         try {
           const {suggestions: newSuggestions} =
             await makeSuggestionsApiCall(queryText);

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -37,9 +37,9 @@ import {
   coordsToPosition,
   positionToCoords,
 } from 'terraso-mobile-client/components/StaticMapView';
+import {useHomeScreenContext} from 'terraso-mobile-client/context/HomeScreenContext';
 import {CustomUserLocation} from 'terraso-mobile-client/screens/HomeScreen/components/CustomUserLocation';
 import {SiteMapCallout} from 'terraso-mobile-client/screens/HomeScreen/components/SiteMapCallout';
-import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {
   CalloutState,
   getCalloutSite,

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -191,7 +191,6 @@ export const SiteMap = memo(
               cameraRef: cameraRef,
             });
             setCalloutState(siteCallout(feature.id as string));
-            console.warn({homeScreen});
             homeScreen?.collapseBottomSheet();
           }
         },

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -39,6 +39,7 @@ import {
 } from 'terraso-mobile-client/components/StaticMapView';
 import {CustomUserLocation} from 'terraso-mobile-client/screens/HomeScreen/components/CustomUserLocation';
 import {SiteMapCallout} from 'terraso-mobile-client/screens/HomeScreen/components/SiteMapCallout';
+import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {
   CalloutState,
   getCalloutSite,
@@ -90,6 +91,7 @@ export const SiteMap = memo(
           });
         },
       }));
+      const homeScreen = useHomeScreenContext();
 
       const {filteredItems: filteredSites} = useListFilter<Site>();
       const sites = Object.fromEntries(
@@ -189,9 +191,11 @@ export const SiteMap = memo(
               cameraRef: cameraRef,
             });
             setCalloutState(siteCallout(feature.id as string));
+            console.warn({homeScreen});
+            homeScreen?.collapseBottomSheet();
           }
         },
-        [setCalloutState, handleClusterPress],
+        [setCalloutState, handleClusterPress, homeScreen],
       );
 
       const onPress = useCallback(

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -29,6 +29,7 @@ import {SiteCard} from 'terraso-mobile-client/components/SiteCard';
 import {coordsToPosition} from 'terraso-mobile-client/components/StaticMapView';
 import {SiteClusterCalloutListItem} from 'terraso-mobile-client/screens/HomeScreen/components/SiteClusterCalloutListItem';
 import {TemporaryLocationCallout} from 'terraso-mobile-client/screens/HomeScreen/components/TemporaryLocationCallout';
+import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {
   CalloutState,
   getCalloutCoords,
@@ -66,6 +67,7 @@ export const SiteMapCallout = ({sites, state, setState}: Props) => {
 
 const CalloutChild = (coords: Coords, {sites, state, setState}: Props) => {
   const closeCallout = useCallback(() => setState(noneCallout()), [setState]);
+  const homeScreen = useHomeScreenContext();
 
   switch (state.kind) {
     case 'site':
@@ -108,6 +110,7 @@ const CalloutChild = (coords: Coords, {sites, state, setState}: Props) => {
     default:
       const isCurrentLocation =
         state.kind === 'location' ? state.isCurrentLocation : false;
+      homeScreen?.collapseBottomSheet();
       return (
         <TemporaryLocationCallout
           coords={coords}

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -27,9 +27,9 @@ import {CloseButton} from 'terraso-mobile-client/components/buttons/CloseButton'
 import {Card} from 'terraso-mobile-client/components/Card';
 import {SiteCard} from 'terraso-mobile-client/components/SiteCard';
 import {coordsToPosition} from 'terraso-mobile-client/components/StaticMapView';
+import {useHomeScreenContext} from 'terraso-mobile-client/context/HomeScreenContext';
 import {SiteClusterCalloutListItem} from 'terraso-mobile-client/screens/HomeScreen/components/SiteClusterCalloutListItem';
 import {TemporaryLocationCallout} from 'terraso-mobile-client/screens/HomeScreen/components/TemporaryLocationCallout';
-import {useHomeScreenContext} from 'terraso-mobile-client/screens/HomeScreen/HomeScreen';
 import {
   CalloutState,
   getCalloutCoords,


### PR DESCRIPTION
## Description
The bottom sheet now hides when:
- you tap on the map and get a temporary location callout ([1482](https://github.com/techmatters/terraso-mobile-client/issues/1482))
- you tap on the pin icon in the site list to bring up a site callout
- you start searching the map (this is better experience than what is suggested in [871](https://github.com/techmatters/terraso-mobile-client/issues/871))
- move HomeScreenContext to its own component

### Related Issues
See also https://github.com/techmatters/terraso-mobile-client/issues/753