### PR TITLE
Fix: Minor UX updates to site data section on soil id screen 

### DIFF
--- a/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
@@ -92,6 +92,15 @@ export const SoilPropertiesDataTable = ({rows}: Props) => {
     );
   };
 
+  const emptyRow = (
+    <Row justifyContent="flex-start">
+      <DataTableCell text="" width={columnWidthDepth} />
+      <DataTableCell text="" width={columnWidthTexture} />
+      <DataTableCell text="" width={columnWidthRockFragment} />
+      <DataTableCell text="" width={columnWidthColor} />
+    </Row>
+  );
+
   return (
     <ScrollView horizontal={true}>
       <Box>
@@ -117,6 +126,7 @@ export const SoilPropertiesDataTable = ({rows}: Props) => {
         </Row>
 
         <Box borderTopWidth="1px" borderLeftWidth="1px">
+          {rows.length === 0 && emptyRow}
           {rows.map((row: (typeof rows)[number], i: number) => (
             <Row justifyContent="flex-start" key={uniqueKeyForRow(row, i)}>
               <DataTableCell

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSlopeDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSlopeDataSection.tsx
@@ -32,7 +32,6 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 import {
   renderSlopeSteepnessDegree,
   renderSlopeSteepnessPercent,
@@ -47,10 +46,7 @@ export const SiteSlopeDataSection = ({siteId}: Props) => {
   const soilData = useSelector(selectSoilData(siteId));
 
   const onAddSoilDataPress = useCallback(() => {
-    navigation.push('LOCATION_DASHBOARD', {
-      siteId: siteId,
-      initialTab: 'SLOPE' as SiteTabName,
-    });
+    navigation.push('SLOPE_STEEPNESS', {siteId});
   }, [navigation, siteId]);
 
   const imageSrc = getSlopeSteepnessImageSource(soilData);

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSlopeDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSlopeDataSection.tsx
@@ -50,6 +50,10 @@ export const SiteSlopeDataSection = ({siteId}: Props) => {
   }, [navigation, siteId]);
 
   const imageSrc = getSlopeSteepnessImageSource(soilData);
+  const shouldShowNumberInBox =
+    imageSrc === undefined &&
+    (soilData.slopeSteepnessDegree !== undefined ||
+      soilData.slopeSteepnessPercent !== undefined);
 
   return (
     <>
@@ -58,12 +62,21 @@ export const SiteSlopeDataSection = ({siteId}: Props) => {
       </Heading>
 
       <Box flexDirection="row">
-        <Box borderWidth="2px" width="85px" height="85px" mr="md">
+        <Box
+          borderWidth="2px"
+          width="85px"
+          height="85px"
+          mr="md"
+          justifyContent="center"
+          alignItems="center">
           {imageSrc && <Image style={styles.image} source={imageSrc} />}
+          {shouldShowNumberInBox && <SlopeSteepnessTextSection {...soilData} />}
         </Box>
 
         <Box flex={1}>
-          <SlopeSteepnessTextSection {...soilData} />
+          {!shouldShowNumberInBox && (
+            <SlopeSteepnessTextSection {...soilData} />
+          )}
         </Box>
 
         <RestrictBySiteRole

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -107,7 +107,7 @@
         "title": "Site Data",
         "description": "Improve Soil ID results by entering some data for this site using the helpful guides along the way.",
         "slope": {
-          "title": "Slope",
+          "title": "Slope Steepness",
           "add_data": "Add slope"
         },
         "soil_properties": {


### PR DESCRIPTION
## Description
- Put steepness number inside box if steepness is represented by a number, not an image
- "Add slope" button goes to Slope Steepness screen instead of general Slope screen 
- "Slope" title changes to "Slope Steepness"
- If there are no depth intervals for a site, show a single empty row in the soil properties data table 

### Related Issues
This is follow-up work for #1200, #1230
