### PR TITLE
fix: make OverlaySheet and SoilPropertiesDataTable correctly interact

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/SlopeScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SlopeScreen-test.tsx.snap
@@ -223,7 +223,9 @@ exports[`renders correctly 1`] = `
                       />
                     </View>
                   </View>
-                  <RCTScrollView>
+                  <RCTScrollView
+                    focusHook={[Function]}
+                  >
                     <View>
                       <View
                         style={

--- a/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
@@ -390,7 +390,9 @@ exports[`renders correctly 1`] = `
                           />
                         </View>
                       </View>
-                      <RCTScrollView>
+                      <RCTScrollView
+                        focusHook={[Function]}
+                      >
                         <View>
                           <View
                             style={
@@ -1543,7 +1545,9 @@ exports[`renders correctly 1`] = `
                           />
                         </View>
                       </View>
-                      <RCTScrollView>
+                      <RCTScrollView
+                        focusHook={[Function]}
+                      >
                         <View>
                           <View
                             style={
@@ -2696,7 +2700,9 @@ exports[`renders correctly 1`] = `
                           />
                         </View>
                       </View>
-                      <RCTScrollView>
+                      <RCTScrollView
+                        focusHook={[Function]}
+                      >
                         <View>
                           <View
                             style={
@@ -3849,7 +3855,9 @@ exports[`renders correctly 1`] = `
                           />
                         </View>
                       </View>
-                      <RCTScrollView>
+                      <RCTScrollView
+                        focusHook={[Function]}
+                      >
                         <View>
                           <View
                             style={
@@ -5002,7 +5010,9 @@ exports[`renders correctly 1`] = `
                           />
                         </View>
                       </View>
-                      <RCTScrollView>
+                      <RCTScrollView
+                        focusHook={[Function]}
+                      >
                         <View>
                           <View
                             style={
@@ -6155,7 +6165,9 @@ exports[`renders correctly 1`] = `
                           />
                         </View>
                       </View>
-                      <RCTScrollView>
+                      <RCTScrollView
+                        focusHook={[Function]}
+                      >
                         <View>
                           <View
                             style={

--- a/dev-client/src/components/sheets/OverlaySheet.tsx
+++ b/dev-client/src/components/sheets/OverlaySheet.tsx
@@ -22,6 +22,7 @@ import {
   BottomSheetScrollView,
   BottomSheetModal as GorhomBottomSheetModal,
 } from '@gorhom/bottom-sheet';
+import {useFocusEffect} from '@react-navigation/native';
 
 import {BackdropComponent} from 'terraso-mobile-client/components/BackdropComponent';
 import {BigCloseButton} from 'terraso-mobile-client/components/buttons/BigCloseButton';
@@ -105,7 +106,9 @@ export const OverlaySheet = forwardRef<
           maxDynamicContentSize={fullHeight ? undefined : maxHeight}>
           <ModalContext.Provider value={methods}>
             {scrollable ? (
-              <BottomSheetScrollView>{contents}</BottomSheetScrollView>
+              <BottomSheetScrollView focusHook={useFocusEffect}>
+                {contents}
+              </BottomSheetScrollView>
             ) : (
               contents
             )}

--- a/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
@@ -16,8 +16,7 @@
  */
 
 import {useTranslation} from 'react-i18next';
-
-import {ScrollView} from 'native-base';
+import {ScrollView} from 'react-native-gesture-handler';
 
 import {
   Box,


### PR DESCRIPTION
## Description

Due to an oversight in implementation, `SoilPropertiesDataTable` and `OverlaySheet` did not scroll correctly when used together. Apply a fix from the`gorhom` sheet documentation (https://ui.gorhom.dev/components/bottom-sheet/troubleshooting/#adding-horizontal-flatlist-or-scrollview-is-not-working-properly-on-android) and use a suitable configuration of `ScrollView` and the `gorhom` properties.

### Related Issues
Fixes #1397

### Verification steps

- Open soil ID info sheets. Verify that both table and sheet can scroll.
- Open location dashboard screen. Verify that both table and screen can scroll.