### PR TITLE
fix: use react-native-paper spinner instead of NativeBase

### DIFF
--- a/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteListBottomSheet.tsx
@@ -17,11 +17,12 @@
 
 import {forwardRef, memo, useCallback, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
+import {ActivityIndicator} from 'react-native-paper';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import BottomSheet, {BottomSheetFlatList} from '@gorhom/bottom-sheet';
 import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
-import {Spinner, useTheme} from 'native-base';
+import {useTheme} from 'native-base';
 
 import {Site} from 'terraso-client-shared/site/siteSlice';
 
@@ -109,7 +110,7 @@ export const SiteListBottomSheet = memo(
             {sites.length >= 0 && <SiteFilterModal useDistance={useDistance} />}
           </Column>
           {isLoadingData ? (
-            <Spinner size="lg" />
+            <ActivityIndicator size="large" />
           ) : sites.length === 0 ? (
             <EmptySiteMessage />
           ) : (

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -17,8 +17,9 @@
 
 import {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
+import {ActivityIndicator} from 'react-native-paper';
 
-import {Button, Divider, Spinner} from 'native-base';
+import {Button, Divider} from 'native-base';
 
 import {Coords} from 'terraso-client-shared/types';
 
@@ -91,7 +92,7 @@ export const TemporaryLocationCallout = ({
             value={siteElevationString}
           />
         ) : (
-          <Spinner size="sm" />
+          <ActivityIndicator size="small" />
         )}
         <Divider />
         <Row justifyContent="flex-end">

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -17,8 +17,7 @@
 
 import {useCallback, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
-
-import {Spinner} from 'native-base';
+import {ActivityIndicator} from 'react-native-paper';
 
 import {PROJECT_ROLES} from 'terraso-client-shared/project/projectSlice';
 import {selectProjectUserRolesMap} from 'terraso-client-shared/selectors';
@@ -82,7 +81,7 @@ export const ProjectListScreen = () => {
         flexBasis="70%"
         space="10px">
         {isLoadingData ? (
-          <Spinner size="lg" />
+          <ActivityIndicator size="large" />
         ) : (
           activeProjects.length === 0 && (
             <Box mb="md">


### PR DESCRIPTION
## Description
Use react-native-paper spinner instead of NativeBase.

### Related Issues
Part of https://github.com/techmatters/terraso-product/issues/742.