### PR TITLE
fix: on home screen, hide keyboard when interacting with map or search filter

### DIFF
--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -23,7 +23,7 @@ import {
   useState,
 } from 'react';
 import {useTranslation} from 'react-i18next';
-import {TextInput} from 'react-native';
+import {Keyboard, TextInput} from 'react-native';
 
 import {Button, FormControl, Input, Radio} from 'native-base';
 
@@ -445,7 +445,10 @@ export const FilterModalTrigger = ({
     <HStack space="20px" mb="15px">
       <BadgedIcon
         iconName="filter-list"
-        onPress={onOpen}
+        onPress={() => {
+          Keyboard.dismiss();
+          onOpen();
+        }}
         badgeNum={numFilters}
         accessibilityLabel={t('listfilter.open_modal_label')}
         _badge={{

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -126,7 +126,6 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
     if (zoomTo) {
       lookupFeature(mapboxId);
     }
-    // close keyboard
     Keyboard.dismiss();
   };
 

--- a/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMap.tsx
@@ -199,6 +199,7 @@ export const SiteMap = memo(
           feature: GeoJSON.Feature,
           isCurrentLocation: boolean = false,
         ) => {
+          Keyboard.dismiss();
           if (
             calloutState.kind === 'none' &&
             feature.geometry?.type === 'Point'
@@ -223,7 +224,6 @@ export const SiteMap = memo(
               ),
             );
           } else {
-            Keyboard.dismiss();
             setCalloutState(noneCallout());
           }
         },


### PR DESCRIPTION
## Description
On home screen hide keyboard when tapping on map (after searching for places) or tapping on search filter icon in sites list.