### PR TITLE
fix: info overlay sheet crashes

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -1230,479 +1230,479 @@ exports[`renders correctly 1`] = `
                         </View>
                       </View>
                     </View>
+                    <RCTScrollView>
+                      <View>
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "column",
+                              },
+                              {
+                                "marginTop": 48,
+                                "paddingBottom": "65%",
+                                "paddingHorizontal": 20,
+                                "paddingTop": 20,
+                                "rowGap": 12,
+                              },
+                            ]
+                          }
+                        >
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                                "textAlign": "left",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            LandPKS Data Privacy
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              The data visible in public sites
+                            </Text>
+                             includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Public sites
+                            </Text>
+                             are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Data Portal
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Unaffiliated private sites
+                            </Text>
+                             are only visible to you. You can change the privacy of the site at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              A project’s privacy setting determines the privacy of its affiliated sites.
+                            </Text>
+                             Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              When a site is transferred to a project,
+                            </Text>
+                             the project will determine the site’s privacy setting.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            Read more about our data privacy policy:
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Privacy Policy
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </RCTScrollView>
+                    <View
+                      style={
+                        {
+                          "position": "absolute",
+                          "right": 23,
+                          "top": 18,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityRole="button"
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        colorScheme="primary"
+                        dataSet={{}}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#EEEEEE",
+                            "borderRadius": 9999,
+                            "flexDirection": "row",
+                            "justifyContent": "center",
+                            "paddingBottom": 4,
+                            "paddingLeft": 4,
+                            "paddingRight": 4,
+                            "paddingTop": 4,
+                          }
+                        }
+                      >
+                        <Icon
+                          color="#1A202C"
+                          name="close"
+                          size={24}
+                          style={{}}
+                        />
+                      </View>
+                    </View>
                   </View>
                 </View>
               </RNCSafeAreaView>
-              <RCTScrollView>
-                <View>
-                  <View
-                    style={
-                      [
-                        {
-                          "flexDirection": "column",
-                        },
-                        {
-                          "marginTop": 48,
-                          "paddingBottom": "65%",
-                          "paddingHorizontal": 20,
-                          "paddingTop": 20,
-                          "rowGap": 12,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      lineHeight="32px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 20,
-                          "fontWeight": "500",
-                          "textAlign": "left",
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      LandPKS Data Privacy
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        The data visible in public sites
-                      </Text>
-                       includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        Public sites
-                      </Text>
-                       are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
-                    </Text>
-                    <View
-                      style={
-                        {
-                          "paddingBottom": 4,
-                          "paddingTop": 4,
-                        }
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                      >
-                        <View
-                          style={{}}
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "flexDirection": "row",
-                                },
-                                {},
-                              ]
-                            }
-                          >
-                            <View
-                              accessibilityRole="button"
-                              accessibilityState={
-                                {
-                                  "busy": undefined,
-                                  "checked": undefined,
-                                  "disabled": undefined,
-                                  "expanded": undefined,
-                                  "selected": undefined,
-                                }
-                              }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              colorScheme="primary"
-                              dataSet={{}}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 4,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 0,
-                                  "paddingLeft": 0,
-                                  "paddingRight": 0,
-                                  "paddingTop": 0,
-                                }
-                              }
-                            >
-                              <Icon
-                                color="#028843"
-                                name="open-in-new"
-                                size={24}
-                                style={{}}
-                              />
-                            </View>
-                            <Text
-                              letterSpacing="0.15px"
-                              lineHeight="24px"
-                              style={
-                                {
-                                  "color": "#028843",
-                                  "fontSize": 16,
-                                  "fontWeight": "400",
-                                  "paddingLeft": 4,
-                                  "textTransform": "uppercase",
-                                }
-                              }
-                            >
-                              LandPKS Data Portal
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        Unaffiliated private sites
-                      </Text>
-                       are only visible to you. You can change the privacy of the site at any time.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        A project’s privacy setting determines the privacy of its affiliated sites.
-                      </Text>
-                       Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        When a site is transferred to a project,
-                      </Text>
-                       the project will determine the site’s privacy setting.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      Read more about our data privacy policy:
-                    </Text>
-                    <View
-                      style={
-                        {
-                          "paddingBottom": 4,
-                          "paddingTop": 4,
-                        }
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                      >
-                        <View
-                          style={{}}
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "flexDirection": "row",
-                                },
-                                {},
-                              ]
-                            }
-                          >
-                            <View
-                              accessibilityRole="button"
-                              accessibilityState={
-                                {
-                                  "busy": undefined,
-                                  "checked": undefined,
-                                  "disabled": undefined,
-                                  "expanded": undefined,
-                                  "selected": undefined,
-                                }
-                              }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              colorScheme="primary"
-                              dataSet={{}}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 4,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 0,
-                                  "paddingLeft": 0,
-                                  "paddingRight": 0,
-                                  "paddingTop": 0,
-                                }
-                              }
-                            >
-                              <Icon
-                                color="#028843"
-                                name="open-in-new"
-                                size={24}
-                                style={{}}
-                              />
-                            </View>
-                            <Text
-                              letterSpacing="0.15px"
-                              lineHeight="24px"
-                              style={
-                                {
-                                  "color": "#028843",
-                                  "fontSize": 16,
-                                  "fontWeight": "400",
-                                  "paddingLeft": 4,
-                                  "textTransform": "uppercase",
-                                }
-                              }
-                            >
-                              LandPKS Privacy Policy
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </RCTScrollView>
-              <View
-                style={
-                  {
-                    "position": "absolute",
-                    "right": 23,
-                    "top": 18,
-                  }
-                }
-              >
-                <View
-                  accessibilityRole="button"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  colorScheme="primary"
-                  dataSet={{}}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#EEEEEE",
-                      "borderRadius": 9999,
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                      "paddingBottom": 4,
-                      "paddingLeft": 4,
-                      "paddingRight": 4,
-                      "paddingTop": 4,
-                    }
-                  }
-                >
-                  <Icon
-                    color="#1A202C"
-                    name="close"
-                    size={24}
-                    style={{}}
-                  />
-                </View>
-              </View>
             </View>
           </View>
           <RNSScreenStackHeaderConfig

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -1290,479 +1290,479 @@ exports[`renders correctly 1`] = `
                         </View>
                       </View>
                     </View>
+                    <RCTScrollView>
+                      <View>
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "column",
+                              },
+                              {
+                                "marginTop": 48,
+                                "paddingBottom": "65%",
+                                "paddingHorizontal": 20,
+                                "paddingTop": 20,
+                                "rowGap": 12,
+                              },
+                            ]
+                          }
+                        >
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                                "textAlign": "left",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            LandPKS Data Privacy
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              The data visible in public sites
+                            </Text>
+                             includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Public sites
+                            </Text>
+                             are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Data Portal
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Unaffiliated private sites
+                            </Text>
+                             are only visible to you. You can change the privacy of the site at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              A project’s privacy setting determines the privacy of its affiliated sites.
+                            </Text>
+                             Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              When a site is transferred to a project,
+                            </Text>
+                             the project will determine the site’s privacy setting.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            Read more about our data privacy policy:
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Privacy Policy
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </RCTScrollView>
+                    <View
+                      style={
+                        {
+                          "position": "absolute",
+                          "right": 23,
+                          "top": 18,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityRole="button"
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        colorScheme="primary"
+                        dataSet={{}}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#EEEEEE",
+                            "borderRadius": 9999,
+                            "flexDirection": "row",
+                            "justifyContent": "center",
+                            "paddingBottom": 4,
+                            "paddingLeft": 4,
+                            "paddingRight": 4,
+                            "paddingTop": 4,
+                          }
+                        }
+                      >
+                        <Icon
+                          color="#1A202C"
+                          name="close"
+                          size={24}
+                          style={{}}
+                        />
+                      </View>
+                    </View>
                   </View>
                 </View>
               </RNCSafeAreaView>
-              <RCTScrollView>
-                <View>
-                  <View
-                    style={
-                      [
-                        {
-                          "flexDirection": "column",
-                        },
-                        {
-                          "marginTop": 48,
-                          "paddingBottom": "65%",
-                          "paddingHorizontal": 20,
-                          "paddingTop": 20,
-                          "rowGap": 12,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      lineHeight="32px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 20,
-                          "fontWeight": "500",
-                          "textAlign": "left",
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      LandPKS Data Privacy
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        The data visible in public sites
-                      </Text>
-                       includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        Public sites
-                      </Text>
-                       are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
-                    </Text>
-                    <View
-                      style={
-                        {
-                          "paddingBottom": 4,
-                          "paddingTop": 4,
-                        }
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                      >
-                        <View
-                          style={{}}
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "flexDirection": "row",
-                                },
-                                {},
-                              ]
-                            }
-                          >
-                            <View
-                              accessibilityRole="button"
-                              accessibilityState={
-                                {
-                                  "busy": undefined,
-                                  "checked": undefined,
-                                  "disabled": undefined,
-                                  "expanded": undefined,
-                                  "selected": undefined,
-                                }
-                              }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              colorScheme="primary"
-                              dataSet={{}}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 4,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 0,
-                                  "paddingLeft": 0,
-                                  "paddingRight": 0,
-                                  "paddingTop": 0,
-                                }
-                              }
-                            >
-                              <Icon
-                                color="#028843"
-                                name="open-in-new"
-                                size={24}
-                                style={{}}
-                              />
-                            </View>
-                            <Text
-                              letterSpacing="0.15px"
-                              lineHeight="24px"
-                              style={
-                                {
-                                  "color": "#028843",
-                                  "fontSize": 16,
-                                  "fontWeight": "400",
-                                  "paddingLeft": 4,
-                                  "textTransform": "uppercase",
-                                }
-                              }
-                            >
-                              LandPKS Data Portal
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        Unaffiliated private sites
-                      </Text>
-                       are only visible to you. You can change the privacy of the site at any time.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        A project’s privacy setting determines the privacy of its affiliated sites.
-                      </Text>
-                       Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        When a site is transferred to a project,
-                      </Text>
-                       the project will determine the site’s privacy setting.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      Read more about our data privacy policy:
-                    </Text>
-                    <View
-                      style={
-                        {
-                          "paddingBottom": 4,
-                          "paddingTop": 4,
-                        }
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                      >
-                        <View
-                          style={{}}
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "flexDirection": "row",
-                                },
-                                {},
-                              ]
-                            }
-                          >
-                            <View
-                              accessibilityRole="button"
-                              accessibilityState={
-                                {
-                                  "busy": undefined,
-                                  "checked": undefined,
-                                  "disabled": undefined,
-                                  "expanded": undefined,
-                                  "selected": undefined,
-                                }
-                              }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              colorScheme="primary"
-                              dataSet={{}}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 4,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 0,
-                                  "paddingLeft": 0,
-                                  "paddingRight": 0,
-                                  "paddingTop": 0,
-                                }
-                              }
-                            >
-                              <Icon
-                                color="#028843"
-                                name="open-in-new"
-                                size={24}
-                                style={{}}
-                              />
-                            </View>
-                            <Text
-                              letterSpacing="0.15px"
-                              lineHeight="24px"
-                              style={
-                                {
-                                  "color": "#028843",
-                                  "fontSize": 16,
-                                  "fontWeight": "400",
-                                  "paddingLeft": 4,
-                                  "textTransform": "uppercase",
-                                }
-                              }
-                            >
-                              LandPKS Privacy Policy
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </RCTScrollView>
-              <View
-                style={
-                  {
-                    "position": "absolute",
-                    "right": 23,
-                    "top": 18,
-                  }
-                }
-              >
-                <View
-                  accessibilityRole="button"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  colorScheme="primary"
-                  dataSet={{}}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#EEEEEE",
-                      "borderRadius": 9999,
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                      "paddingBottom": 4,
-                      "paddingLeft": 4,
-                      "paddingRight": 4,
-                      "paddingTop": 4,
-                    }
-                  }
-                >
-                  <Icon
-                    color="#1A202C"
-                    name="close"
-                    size={24}
-                    style={{}}
-                  />
-                </View>
-              </View>
             </View>
           </View>
           <RNSScreenStackHeaderConfig

--- a/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -2134,479 +2134,479 @@ exports[`renders correctly 1`] = `
                         </View>
                       </LEGACY_RNCViewPager>
                     </View>
+                    <RCTScrollView>
+                      <View>
+                        <View
+                          style={
+                            [
+                              {
+                                "flexDirection": "column",
+                              },
+                              {
+                                "marginTop": 48,
+                                "paddingBottom": "65%",
+                                "paddingHorizontal": 20,
+                                "paddingTop": 20,
+                                "rowGap": 12,
+                              },
+                            ]
+                          }
+                        >
+                          <Text
+                            lineHeight="32px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 20,
+                                "fontWeight": "500",
+                                "textAlign": "left",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            LandPKS Data Privacy
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              The data visible in public sites
+                            </Text>
+                             includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Public sites
+                            </Text>
+                             are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Data Portal
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              Unaffiliated private sites
+                            </Text>
+                             are only visible to you. You can change the privacy of the site at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              A project’s privacy setting determines the privacy of its affiliated sites.
+                            </Text>
+                             Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                {
+                                  "fontWeight": "bold",
+                                }
+                              }
+                            >
+                              When a site is transferred to a project,
+                            </Text>
+                             the project will determine the site’s privacy setting.
+                          </Text>
+                          <Text
+                            letterSpacing="0.15px"
+                            lineHeight="24px"
+                            style={
+                              {
+                                "color": "#1A202C",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                              }
+                            }
+                          >
+                            Read more about our data privacy policy:
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "paddingBottom": 4,
+                                "paddingTop": 4,
+                              }
+                            }
+                          >
+                            <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                            >
+                              <View
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "flexDirection": "row",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    accessibilityRole="button"
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    colorScheme="primary"
+                                    dataSet={{}}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 4,
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "paddingBottom": 0,
+                                        "paddingLeft": 0,
+                                        "paddingRight": 0,
+                                        "paddingTop": 0,
+                                      }
+                                    }
+                                  >
+                                    <Icon
+                                      color="#028843"
+                                      name="open-in-new"
+                                      size={24}
+                                      style={{}}
+                                    />
+                                  </View>
+                                  <Text
+                                    letterSpacing="0.15px"
+                                    lineHeight="24px"
+                                    style={
+                                      {
+                                        "color": "#028843",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "paddingLeft": 4,
+                                        "textTransform": "uppercase",
+                                      }
+                                    }
+                                  >
+                                    LandPKS Privacy Policy
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </RCTScrollView>
+                    <View
+                      style={
+                        {
+                          "position": "absolute",
+                          "right": 23,
+                          "top": 18,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityRole="button"
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        colorScheme="primary"
+                        dataSet={{}}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#EEEEEE",
+                            "borderRadius": 9999,
+                            "flexDirection": "row",
+                            "justifyContent": "center",
+                            "paddingBottom": 4,
+                            "paddingLeft": 4,
+                            "paddingRight": 4,
+                            "paddingTop": 4,
+                          }
+                        }
+                      >
+                        <Icon
+                          color="#1A202C"
+                          name="close"
+                          size={24}
+                          style={{}}
+                        />
+                      </View>
+                    </View>
                   </View>
                 </View>
               </RNCSafeAreaView>
-              <RCTScrollView>
-                <View>
-                  <View
-                    style={
-                      [
-                        {
-                          "flexDirection": "column",
-                        },
-                        {
-                          "marginTop": 48,
-                          "paddingBottom": "65%",
-                          "paddingHorizontal": 20,
-                          "paddingTop": 20,
-                          "rowGap": 12,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      lineHeight="32px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 20,
-                          "fontWeight": "500",
-                          "textAlign": "left",
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      LandPKS Data Privacy
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        The data visible in public sites
-                      </Text>
-                       includes all data entered into the LandPKS mobile app except for personally identifiable information (PII).
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        Public sites
-                      </Text>
-                       are visible to anyone on the LandPKS data portal. This means anyone can view information about this site.
-                    </Text>
-                    <View
-                      style={
-                        {
-                          "paddingBottom": 4,
-                          "paddingTop": 4,
-                        }
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                      >
-                        <View
-                          style={{}}
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "flexDirection": "row",
-                                },
-                                {},
-                              ]
-                            }
-                          >
-                            <View
-                              accessibilityRole="button"
-                              accessibilityState={
-                                {
-                                  "busy": undefined,
-                                  "checked": undefined,
-                                  "disabled": undefined,
-                                  "expanded": undefined,
-                                  "selected": undefined,
-                                }
-                              }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              colorScheme="primary"
-                              dataSet={{}}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 4,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 0,
-                                  "paddingLeft": 0,
-                                  "paddingRight": 0,
-                                  "paddingTop": 0,
-                                }
-                              }
-                            >
-                              <Icon
-                                color="#028843"
-                                name="open-in-new"
-                                size={24}
-                                style={{}}
-                              />
-                            </View>
-                            <Text
-                              letterSpacing="0.15px"
-                              lineHeight="24px"
-                              style={
-                                {
-                                  "color": "#028843",
-                                  "fontSize": 16,
-                                  "fontWeight": "400",
-                                  "paddingLeft": 4,
-                                  "textTransform": "uppercase",
-                                }
-                              }
-                            >
-                              LandPKS Data Portal
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        Unaffiliated private sites
-                      </Text>
-                       are only visible to you. You can change the privacy of the site at any time.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        A project’s privacy setting determines the privacy of its affiliated sites.
-                      </Text>
-                       Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      <Text
-                        style={
-                          {
-                            "fontWeight": "bold",
-                          }
-                        }
-                      >
-                        When a site is transferred to a project,
-                      </Text>
-                       the project will determine the site’s privacy setting.
-                    </Text>
-                    <Text
-                      letterSpacing="0.15px"
-                      lineHeight="24px"
-                      style={
-                        {
-                          "color": "#1A202C",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                        }
-                      }
-                    >
-                      Read more about our data privacy policy:
-                    </Text>
-                    <View
-                      style={
-                        {
-                          "paddingBottom": 4,
-                          "paddingTop": 4,
-                        }
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                      >
-                        <View
-                          style={{}}
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "flexDirection": "row",
-                                },
-                                {},
-                              ]
-                            }
-                          >
-                            <View
-                              accessibilityRole="button"
-                              accessibilityState={
-                                {
-                                  "busy": undefined,
-                                  "checked": undefined,
-                                  "disabled": undefined,
-                                  "expanded": undefined,
-                                  "selected": undefined,
-                                }
-                              }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              colorScheme="primary"
-                              dataSet={{}}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 4,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 0,
-                                  "paddingLeft": 0,
-                                  "paddingRight": 0,
-                                  "paddingTop": 0,
-                                }
-                              }
-                            >
-                              <Icon
-                                color="#028843"
-                                name="open-in-new"
-                                size={24}
-                                style={{}}
-                              />
-                            </View>
-                            <Text
-                              letterSpacing="0.15px"
-                              lineHeight="24px"
-                              style={
-                                {
-                                  "color": "#028843",
-                                  "fontSize": 16,
-                                  "fontWeight": "400",
-                                  "paddingLeft": 4,
-                                  "textTransform": "uppercase",
-                                }
-                              }
-                            >
-                              LandPKS Privacy Policy
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </RCTScrollView>
-              <View
-                style={
-                  {
-                    "position": "absolute",
-                    "right": 23,
-                    "top": 18,
-                  }
-                }
-              >
-                <View
-                  accessibilityRole="button"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  colorScheme="primary"
-                  dataSet={{}}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#EEEEEE",
-                      "borderRadius": 9999,
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                      "paddingBottom": 4,
-                      "paddingLeft": 4,
-                      "paddingRight": 4,
-                      "paddingTop": 4,
-                    }
-                  }
-                >
-                  <Icon
-                    color="#1A202C"
-                    name="close"
-                    size={24}
-                    style={{}}
-                  />
-                </View>
-              </View>
             </View>
           </View>
           <RNSScreenStackHeaderConfig

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -40,7 +40,6 @@ import 'terraso-mobile-client/config';
 import {Portal} from 'react-native-paper';
 import {enableFreeze} from 'react-native-screens';
 
-import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import * as Sentry from '@sentry/react-native';
 
 import {APP_CONFIG} from 'terraso-mobile-client/config';
@@ -80,18 +79,16 @@ function App(): React.JSX.Element {
     <GestureHandlerRootView style={style}>
       <Provider store={store}>
         <NativeBaseProvider theme={theme}>
-          <BottomSheetModalProvider>
-            <Portal.Host>
-              <NavigationContainer>
-                <GeospatialProvider>
-                  <Toasts />
-                  <HomeScreenContextProvider>
-                    <RootNavigator />
-                  </HomeScreenContextProvider>
-                </GeospatialProvider>
-              </NavigationContainer>
-            </Portal.Host>
-          </BottomSheetModalProvider>
+          <Portal.Host>
+            <NavigationContainer>
+              <GeospatialProvider>
+                <Toasts />
+                <HomeScreenContextProvider>
+                  <RootNavigator />
+                </HomeScreenContextProvider>
+              </GeospatialProvider>
+            </NavigationContainer>
+          </Portal.Host>
         </NativeBaseProvider>
       </Provider>
     </GestureHandlerRootView>

--- a/dev-client/src/navigation/navigators/SiteLocationDashboardTabNavigator.tsx
+++ b/dev-client/src/navigation/navigators/SiteLocationDashboardTabNavigator.tsx
@@ -18,7 +18,6 @@
 import {memo, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 
 import {useDefaultTabOptions} from 'terraso-mobile-client/navigation/hooks/useDefaultTabOptions';
@@ -66,10 +65,6 @@ export const SiteLocationDashboardTabNavigator = memo(
       [siteId, t, defaultOptions],
     );
 
-    return (
-      <BottomSheetModalProvider>
-        <Tab.Navigator initialRouteName={initialTab}>{tabs}</Tab.Navigator>
-      </BottomSheetModalProvider>
-    );
+    return <Tab.Navigator initialRouteName={initialTab}>{tabs}</Tab.Navigator>;
   },
 );

--- a/dev-client/src/screens/CreateProjectScreen/CreateProjectScreen.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/CreateProjectScreen.tsx
@@ -17,7 +17,7 @@
 
 import {useCallback, useRef} from 'react';
 
-import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {BottomSheetModal} from '@gorhom/bottom-sheet';
 
 import {PrivacyInfoModal} from 'terraso-mobile-client/components/modals/privacy/PrivacyInfoModal';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -38,11 +38,9 @@ export const CreateProjectScreen = () => {
   );
 
   return (
-    <BottomSheetModalProvider>
-      <ScreenScaffold AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
-        <CreateProjectForm onInfoPress={onInfoPress} />
-      </ScreenScaffold>
+    <ScreenScaffold AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
+      <CreateProjectForm onInfoPress={onInfoPress} />
       <PrivacyInfoModal ref={infoModalRef} onClose={onInfoClose} />
-    </BottomSheetModalProvider>
+    </ScreenScaffold>
   );
 };

--- a/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
@@ -17,7 +17,7 @@
 
 import {useCallback, useRef} from 'react';
 
-import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {BottomSheetModal} from '@gorhom/bottom-sheet';
 
 import {SiteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 import {
@@ -73,18 +73,16 @@ export const CreateSiteScreen = (props: Props = {}) => {
   );
 
   return (
-    <BottomSheetModalProvider>
-      <ScreenScaffold
-        BottomNavigation={null}
-        AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
-        <CreateSiteView
-          createSiteCallback={createSiteCallback}
-          defaultProjectId={'projectId' in props ? props.projectId : undefined}
-          sitePin={'coords' in props ? props.coords : undefined}
-          onInfoPress={onInfo}
-        />
-      </ScreenScaffold>
+    <ScreenScaffold
+      BottomNavigation={null}
+      AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
+      <CreateSiteView
+        createSiteCallback={createSiteCallback}
+        defaultProjectId={'projectId' in props ? props.projectId : undefined}
+        sitePin={'coords' in props ? props.coords : undefined}
+        onInfoPress={onInfo}
+      />
       <PrivacyInfoModal ref={infoModalRef} onClose={onInfoClose} />
-    </BottomSheetModalProvider>
+    </ScreenScaffold>
   );
 };

--- a/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
@@ -18,8 +18,6 @@
 import {useTranslation} from 'react-i18next';
 import {ScrollView} from 'react-native-gesture-handler';
 
-import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
-
 import {selectSite} from 'terraso-client-shared/selectors';
 import {Coords} from 'terraso-client-shared/types';
 
@@ -47,27 +45,25 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
   const {status} = useSoilIdData(coords, siteId);
 
   return (
-    <BottomSheetModalProvider>
-      <ScreenScaffold
-        AppBar={
-          <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
-        }>
-        <ScrollView>
-          <SoilIdDescriptionSection siteId={siteId} coords={coords} />
-          {status === 'ready' && (
-            <SoilIdMatchesSection siteId={siteId} coords={coords} />
-          )}
-          {siteId ? (
-            <SiteRoleContextProvider siteId={siteId}>
-              <SiteDataSection siteId={siteId} />
-            </SiteRoleContextProvider>
-          ) : (
-            <Box paddingVertical="md">
-              <CreateSiteButton coords={coords} />
-            </Box>
-          )}
-        </ScrollView>
-      </ScreenScaffold>
-    </BottomSheetModalProvider>
+    <ScreenScaffold
+      AppBar={
+        <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
+      }>
+      <ScrollView>
+        <SoilIdDescriptionSection siteId={siteId} coords={coords} />
+        {status === 'ready' && (
+          <SoilIdMatchesSection siteId={siteId} coords={coords} />
+        )}
+        {siteId ? (
+          <SiteRoleContextProvider siteId={siteId}>
+            <SiteDataSection siteId={siteId} />
+          </SiteRoleContextProvider>
+        ) : (
+          <Box paddingVertical="md">
+            <CreateSiteButton coords={coords} />
+          </Box>
+        )}
+      </ScrollView>
+    </ScreenScaffold>
   );
 };

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -17,7 +17,7 @@
 
 import {useCallback, useRef} from 'react';
 
-import {BottomSheetModal, BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {BottomSheetModal} from '@gorhom/bottom-sheet';
 
 import {PrivacyInfoModal} from 'terraso-mobile-client/components/modals/privacy/PrivacyInfoModal';
 import {BottomSheetPrivacyModalContext} from 'terraso-mobile-client/context/BottomSheetPrivacyModalContext';
@@ -45,14 +45,12 @@ export const ProjectViewScreen = ({projectId}: Props) => {
   return (
     <ProjectRoleContextProvider projectId={projectId}>
       <BottomSheetPrivacyModalContext.Provider value={onInfoPress}>
-        <BottomSheetModalProvider>
-          <ScreenScaffold
-            AppBar={<AppBar title={project?.name} />}
-            BottomNavigation={null}>
-            <ProjectTabNavigator projectId={projectId} />
-          </ScreenScaffold>
+        <ScreenScaffold
+          AppBar={<AppBar title={project?.name} />}
+          BottomNavigation={null}>
+          <ProjectTabNavigator projectId={projectId} />
           <PrivacyInfoModal ref={infoModalRef} onClose={onInfoClose} />
-        </BottomSheetModalProvider>
+        </ScreenScaffold>
       </BottomSheetPrivacyModalContext.Provider>
     </ProjectRoleContextProvider>
   );

--- a/dev-client/src/screens/ScreenScaffold.tsx
+++ b/dev-client/src/screens/ScreenScaffold.tsx
@@ -19,6 +19,8 @@ import {useCallback, useState} from 'react';
 import {LayoutChangeEvent, StatusBar, StyleSheet, View} from 'react-native';
 import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
+import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+
 import {Box, Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {HeaderHeightContext} from 'terraso-mobile-client/context/HeaderHeightContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -55,12 +57,15 @@ export const ScreenScaffold = ({
         translucent
         backgroundColor={theme.colors.transparent}
       />
-      <Column backgroundColor="primary.contrast" flex={1}>
-        <View onLayout={onLayout}>{PropsAppBar}</View>
-        <HeaderHeightContext.Provider value={safeAreaTop + (headerHeight ?? 0)}>
-          <Box flex={1}>{children}</Box>
-        </HeaderHeightContext.Provider>
-      </Column>
+      <BottomSheetModalProvider>
+        <Column backgroundColor="primary.contrast" flex={1}>
+          <View onLayout={onLayout}>{PropsAppBar}</View>
+          <HeaderHeightContext.Provider
+            value={safeAreaTop + (headerHeight ?? 0)}>
+            <Box flex={1}>{children}</Box>
+          </HeaderHeightContext.Provider>
+        </Column>
+      </BottomSheetModalProvider>
     </SafeAreaView>
   );
 };

--- a/dev-client/src/screens/ScreenScaffold.tsx
+++ b/dev-client/src/screens/ScreenScaffold.tsx
@@ -17,7 +17,7 @@
 
 import {useCallback, useState} from 'react';
 import {LayoutChangeEvent, StatusBar, StyleSheet, View} from 'react-native';
-import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 
@@ -39,7 +39,6 @@ export const ScreenScaffold = ({
   const [headerHeight, setHeaderHeight] = useState<number | undefined>(
     undefined,
   );
-  const safeAreaTop = useSafeAreaInsets().top;
 
   const onLayout = useCallback(
     (e: LayoutChangeEvent) => setHeaderHeight(e.nativeEvent.layout.height),
@@ -57,15 +56,14 @@ export const ScreenScaffold = ({
         translucent
         backgroundColor={theme.colors.transparent}
       />
-      <BottomSheetModalProvider>
-        <Column backgroundColor="primary.contrast" flex={1}>
-          <View onLayout={onLayout}>{PropsAppBar}</View>
-          <HeaderHeightContext.Provider
-            value={safeAreaTop + (headerHeight ?? 0)}>
+      <Column backgroundColor="primary.contrast" flex={1}>
+        <View onLayout={onLayout}>{PropsAppBar}</View>
+        <HeaderHeightContext.Provider value={headerHeight ?? 0}>
+          <BottomSheetModalProvider>
             <Box flex={1}>{children}</Box>
-          </HeaderHeightContext.Provider>
-        </Column>
-      </BottomSheetModalProvider>
+          </BottomSheetModalProvider>
+        </HeaderHeightContext.Provider>
+      </Column>
     </SafeAreaView>
   );
 };

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -23,7 +23,6 @@ import {CameraView, useCameraPermissions} from 'expo-camera';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import {DeviceMotion} from 'expo-sensors';
 
-import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import {Button, Link} from 'native-base';
 
 import {updateSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
@@ -90,73 +89,68 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
 
   return (
     <ScreenScaffold AppBar={null} BottomNavigation={null}>
-      <BottomSheetModalProvider>
-        <Row flex={1} alignItems="stretch" px="24px" py="20px">
-          <Box flex={1} justifyContent="center">
-            {permission?.granted ? (
-              <CameraView style={styles.camera}>
-                <Column flex={1} alignItems="stretch">
-                  <Box flex={1} />
-                  <Box height="3px" bg="text.primary" />
-                  <Box height="3px" bg="primary.contrast" />
-                  <Box flex={1} bg="#00000080" />
-                </Column>
-              </CameraView>
-            ) : permission?.canAskAgain ? (
-              <Button size="lg" onPress={requestPermission}>
-                {t('slope.steepness.camera_grant')}
-              </Button>
-            ) : (
-              <>
-                <Heading variant="h6">{t('slope.steepness.no_camera')}</Heading>
-                <Text variant="body1" textAlign="center">
-                  {t('slope.steepness.no_camera_explanation')}
-                </Text>
-                <Link onPress={Linking.openSettings}>
-                  {t('general.open_settings')}
-                </Link>
-              </>
-            )}
+      <Row flex={1} alignItems="stretch" px="24px" py="20px">
+        <Box flex={1} justifyContent="center">
+          {permission?.granted ? (
+            <CameraView style={styles.camera}>
+              <Column flex={1} alignItems="stretch">
+                <Box flex={1} />
+                <Box height="3px" bg="text.primary" />
+                <Box height="3px" bg="primary.contrast" />
+                <Box flex={1} bg="#00000080" />
+              </Column>
+            </CameraView>
+          ) : permission?.canAskAgain ? (
+            <Button size="lg" onPress={requestPermission}>
+              {t('slope.steepness.camera_grant')}
+            </Button>
+          ) : (
+            <>
+              <Heading variant="h6">{t('slope.steepness.no_camera')}</Heading>
+              <Text variant="body1" textAlign="center">
+                {t('slope.steepness.no_camera_explanation')}
+              </Text>
+              <Link onPress={Linking.openSettings}>
+                {t('general.open_settings')}
+              </Link>
+            </>
+          )}
+        </Box>
+        <Column alignItems="center">
+          <Box {...styles.closeButtonBox}>
+            <BigCloseButton onPress={onClose} />
           </Box>
-          <Column alignItems="center">
-            <Box {...styles.closeButtonBox}>
-              <BigCloseButton onPress={onClose} />
-            </Box>
-            <Column
-              px="56px"
-              flex={1}
-              justifyContent="center"
-              alignItems="center">
-              <Row alignItems="center">
-                <Heading variant="h6">
-                  {t('slope.steepness.slope_meter')}
-                </Heading>
-                <InfoOverlaySheetButton
-                  Header={t('slope.steepness.info.title')}>
-                  <SlopeMeterInfoContent />
-                </InfoOverlaySheetButton>
-              </Row>
-              <Box height="12px" />
-              <Heading variant="h5" fontWeight={700}>
-                {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
-              </Heading>
-              <Box height="5px" />
-              <Heading variant="h6">
-                {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
-              </Heading>
-              <Box height="18px" />
-              <Button
-                onPress={onUse}
-                size="lg"
-                px="46px"
-                py="18px"
-                {...styles.useButton}>
-                {t('general.use')}
-              </Button>
-            </Column>
+          <Column
+            px="56px"
+            flex={1}
+            justifyContent="center"
+            alignItems="center">
+            <Row alignItems="center">
+              <Heading variant="h6">{t('slope.steepness.slope_meter')}</Heading>
+              <InfoOverlaySheetButton Header={t('slope.steepness.info.title')}>
+                <SlopeMeterInfoContent />
+              </InfoOverlaySheetButton>
+            </Row>
+            <Box height="12px" />
+            <Heading variant="h5" fontWeight={700}>
+              {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
+            </Heading>
+            <Box height="5px" />
+            <Heading variant="h6">
+              {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
+            </Heading>
+            <Box height="18px" />
+            <Button
+              onPress={onUse}
+              size="lg"
+              px="46px"
+              py="18px"
+              {...styles.useButton}>
+              {t('general.use')}
+            </Button>
           </Column>
-        </Row>
-      </BottomSheetModalProvider>
+        </Column>
+      </Row>
     </ScreenScaffold>
   );
 };


### PR DESCRIPTION
## Description

Fixes crash issues with info overlay sheets opening on certain screens.

This was inadvertently introduced by #1397, which enabled the Gorhom Bottom Sheet Modal's nested scrolling; however, this also introduced a dependency on having a navigation context available. Because our bottom sheet providers were not consistently placed in the application hierarchy, certain screens did not have access to the context, which caused the crash. This fix standardizes their provisioning to occur within the `ScreenScaffold` component and ensure that all bottom sheets exist within it. Incidentally, this also fixes issues with sheets opening to unexpected heights, which was another side-effect of the inconsistent placement of the `Provider` component.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #1533

### Verification steps

Visit all screens featuring info overlay sheets. Open them and verify that the application does not crash.