### PR TITLE
fix: make 100% fit on one line in SoilMatchTile on iOS

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
@@ -37,8 +37,9 @@ export const SoilMatchTile = ({soil_name, score, onPress}: Props) => {
         justifyContent="space-between"
         my="4px"
         py="4px">
-        <Box marginHorizontal="16px" width="74px" justifyContent="center">
+        <Box marginHorizontal="16px" width="78px" justifyContent="center">
           <Text
+            variant="score-tile"
             size="30px"
             fontWeight={400}
             color="primary.lighter"


### PR DESCRIPTION
## Description
For some reason the fonts on iOS and Android are different, such that 74px was not sufficient to fit "100%" without wrapping. Just up the width of that section slightly for now, and hopefully [#1537](https://github.com/techmatters/terraso-mobile-client/issues/1537) will more holistically address the issue.
![Screenshot 2024-06-10 at 1 31 15 PM](https://github.com/techmatters/terraso-mobile-client/assets/5590815/00bed163-6f46-4415-949e-adb00d9c2ff3) --> ![Screenshot 2024-06-10 at 1 13 21 PM](https://github.com/techmatters/terraso-mobile-client/assets/5590815/05206fd1-bf49-4408-af36-0289c493a5c6)

### Related Issues
Follow-up work to #1197
