### PR TITLE
fix: reinstate overlay sheet providers in app stack to fix crashes and conflict w/ FAB

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -40,6 +40,7 @@ import 'terraso-mobile-client/config';
 import {Portal} from 'react-native-paper';
 import {enableFreeze} from 'react-native-screens';
 
+import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import * as Sentry from '@sentry/react-native';
 
 import {APP_CONFIG} from 'terraso-mobile-client/config';
@@ -78,18 +79,22 @@ function App(): React.JSX.Element {
   return (
     <GestureHandlerRootView style={style}>
       <Provider store={store}>
-        <NativeBaseProvider theme={theme}>
-          <Portal.Host>
-            <NavigationContainer>
-              <GeospatialProvider>
-                <Toasts />
-                <HomeScreenContextProvider>
-                  <RootNavigator />
-                </HomeScreenContextProvider>
-              </GeospatialProvider>
-            </NavigationContainer>
-          </Portal.Host>
-        </NativeBaseProvider>
+        <BottomSheetModalProvider>
+          <NativeBaseProvider theme={theme}>
+            <Portal.Host>
+              <NavigationContainer>
+                <BottomSheetModalProvider>
+                  <GeospatialProvider>
+                    <Toasts />
+                    <HomeScreenContextProvider>
+                      <RootNavigator />
+                    </HomeScreenContextProvider>
+                  </GeospatialProvider>
+                </BottomSheetModalProvider>
+              </NavigationContainer>
+            </Portal.Host>
+          </NativeBaseProvider>
+        </BottomSheetModalProvider>
       </Provider>
     </GestureHandlerRootView>
   );

--- a/dev-client/src/screens/ScreenScaffold.tsx
+++ b/dev-client/src/screens/ScreenScaffold.tsx
@@ -17,9 +17,7 @@
 
 import {useCallback, useState} from 'react';
 import {LayoutChangeEvent, StatusBar, StyleSheet, View} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
-
-import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {Box, Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {HeaderHeightContext} from 'terraso-mobile-client/context/HeaderHeightContext';
@@ -39,6 +37,7 @@ export const ScreenScaffold = ({
   const [headerHeight, setHeaderHeight] = useState<number | undefined>(
     undefined,
   );
+  const safeAreaTop = useSafeAreaInsets().top;
 
   const onLayout = useCallback(
     (e: LayoutChangeEvent) => setHeaderHeight(e.nativeEvent.layout.height),
@@ -58,10 +57,8 @@ export const ScreenScaffold = ({
       />
       <Column backgroundColor="primary.contrast" flex={1}>
         <View onLayout={onLayout}>{PropsAppBar}</View>
-        <HeaderHeightContext.Provider value={headerHeight ?? 0}>
-          <BottomSheetModalProvider>
-            <Box flex={1}>{children}</Box>
-          </BottomSheetModalProvider>
+        <HeaderHeightContext.Provider value={safeAreaTop + (headerHeight ?? 0)}>
+          <Box flex={1}>{children}</Box>
         </HeaderHeightContext.Provider>
       </Column>
     </SafeAreaView>


### PR DESCRIPTION
## Description

Fix crashes in filter screens that use overlay sheet selection components by reintroducing the root-level `BottomSheetModalProvider`. Add another `BottomSheetModalProvider` underneath the `NativeBaseProvider` so that other components can still render under floating NativeBase elements, fixing the unexpected FAB issue.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #1536

### Verification steps

Open filter modals and verify that filter selections work as expected. Open site color entry screen and verify that "Done" button no longer floats above info modal.