### PR TITLE
feat: Update design for ManageTeamMemberScreen

### DIFF
--- a/dev-client/src/components/RadioBlock.tsx
+++ b/dev-client/src/components/RadioBlock.tsx
@@ -26,7 +26,7 @@ type RadioOption = {
 };
 
 type Props<Keys extends string> = {
-  label: string | React.ReactNode;
+  label?: string | React.ReactNode;
   options: Record<Keys, RadioOption>;
   allDisabled?: boolean;
   groupProps: Omit<IRadioGroupProps, 'onChange'> & {
@@ -64,8 +64,9 @@ export const RadioBlock = <T extends string>({
             helpText ? (
               <FormControl.HelperText
                 key={helpText + value}
-                ml="15px"
-                mt="-5px">
+                ml="40px"
+                mt="-4px"
+                mb="4px">
                 {helpText}
               </FormControl.HelperText>
             ) : undefined,

--- a/dev-client/src/screens/AddUserToProjectScreen/components/MinimalUserDisplay.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/MinimalUserDisplay.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+
+import {Image} from 'native-base';
+
+import {User} from 'terraso-client-shared/account/accountSlice';
+
+import {
+  HStack,
+  Text,
+  VStack,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {formatName} from 'terraso-mobile-client/util';
+
+export type UserFields = Omit<User, 'preferences'>;
+
+type DisplayProps = {
+  user: UserFields;
+};
+
+export const MinimalUserDisplay = ({
+  user: {profileImage, firstName, lastName, email},
+}: DisplayProps) => {
+  const {t} = useTranslation();
+
+  return (
+    <VStack>
+      <HStack>
+        <Image
+          variant="profilePic"
+          source={{uri: profileImage}}
+          alt={t('general.profile_image_alt')}
+        />
+
+        <VStack ml="32px">
+          <Text variant="body1-strong">{formatName(firstName, lastName)}</Text>
+          <Text variant="body1">{email}</Text>
+        </VStack>
+      </HStack>
+    </VStack>
+  );
+};

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -26,10 +26,12 @@ import {
   updateUserRole,
 } from 'terraso-client-shared/project/projectSlice';
 
+import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {
   Box,
+  Heading,
   Text,
   VStack,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
@@ -37,9 +39,9 @@ import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenCloseButton} from 'terraso-mobile-client/navigation/components/ScreenCloseButton';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {MinimalUserDisplay} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/MinimalUserDisplay';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
-import {formatName} from 'terraso-mobile-client/util';
 
 type Props = {
   projectId: string;
@@ -84,42 +86,39 @@ export const ManageTeamMemberScreen = ({
       AppBar={
         <AppBar title={project?.name} LeftButton={<ScreenCloseButton />} />
       }>
-      <VStack mx="14px">
-        <VStack mt="22px" mb="15px">
-          <Text variant="body1" fontWeight={700}>
-            {formatName(user.firstName, user.lastName)}
-          </Text>
-          <Text numberOfLines={1} variant="body1">
-            {user.email}
-          </Text>
-        </VStack>
-        <RadioBlock<ProjectRole>
-          labelProps={{variant: 'secondary'}}
-          label={t('projects.manage_member.project_role')}
-          options={{
-            MANAGER: {
-              text: t('general.role.MANAGER'),
-              helpText: t('projects.manage_member.manager_help'),
-            },
-            CONTRIBUTOR: {
-              text: t('general.role.CONTRIBUTOR'),
-              helpText: t('projects.manage_member.contributor_help'),
-            },
-            VIEWER: {
-              text: t('general.role.VIEWER'),
-              helpText: t('projects.manage_member.viewer_help'),
-            },
-          }}
-          groupProps={{
-            onChange: setSelectedRole,
-            value: selectedRole,
-            name: 'selected-role',
-          }}
-        />
-
-        <Divider my="20px" width="90%" alignSelf="center" />
-
+      <ScreenContentSection title={t('projects.manage_member.title')}>
         <VStack>
+          <Box ml="md" my="lg">
+            <MinimalUserDisplay user={user} />
+          </Box>
+          <Heading variant="h6">
+            {t('projects.manage_member.project_role')}
+          </Heading>
+
+          <RadioBlock<ProjectRole>
+            labelProps={{variant: 'secondary'}}
+            options={{
+              VIEWER: {
+                text: t('general.role.VIEWER'),
+                helpText: t('projects.manage_member.viewer_help'),
+              },
+              CONTRIBUTOR: {
+                text: t('general.role.CONTRIBUTOR'),
+                helpText: t('projects.manage_member.contributor_help'),
+              },
+              MANAGER: {
+                text: t('general.role.MANAGER'),
+                helpText: t('projects.manage_member.manager_help'),
+              },
+            }}
+            groupProps={{
+              onChange: setSelectedRole,
+              value: selectedRole,
+              name: 'selected-role',
+            }}
+          />
+          <Divider my="20px" alignSelf="center" />
+
           <ConfirmModal
             trigger={onOpen => (
               <Button
@@ -143,14 +142,14 @@ export const ManageTeamMemberScreen = ({
           <Text ml="20px" variant="caption">
             {t('projects.manage_member.remove_help')}
           </Text>
-        </VStack>
 
-        <Box flex={0} height="15%" justifyContent="flex-end">
-          <Button onPress={updateUser} alignSelf="flex-end">
-            {t('general.save_fab')}
-          </Button>
-        </Box>
-      </VStack>
+          <Box flex={0} height="15%" justifyContent="flex-end">
+            <Button onPress={updateUser} alignSelf="flex-end">
+              {t('general.save_fab')}
+            </Button>
+          </Box>
+        </VStack>
+      </ScreenContentSection>
     </ScreenScaffold>
   );
 };

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -446,8 +446,8 @@ export const theme = extendTheme({
     Image: {
       variants: {
         profilePic: {
-          size: '50px',
-          borderRadius: 100,
+          size: '40px',
+          borderRadius: 80,
         },
       },
     },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -321,6 +321,7 @@
       "empty_email": "Please enter an email"
     },
     "manage_member": {
+      "title": "Manage Team Member",
       "project_role": "Project Role",
       "manager_help": "Can view and edit all aspects of the projects and its affiliated sites.",
       "contributor_help": "Can view, add, and edit site data.",


### PR DESCRIPTION
## Description
Gets closer to the Figma design for the "Manage Team Member" screen ([link](https://www.figma.com/design/KMJbhjVyrrLFHj6jGcX9lN/LandPKS-Design-Prototype-working-file?node-id=5800-12866&m=dev)). 

This includes some work to set up for [#1505](https://github.com/techmatters/terraso-mobile-client/issues/1505)/[#1447](https://github.com/techmatters/terraso-mobile-client/issues/1447). But also some screen-specific styling updates cuz I was already there 

Includes: 
- Add title
- Include user photo (and make smaller to match spec)
- Reorder and slightly restyle radio button text
- Minor spacing changes

Changes still needed for the screen to be up-to-spec:
- Put the Save button in exactly the right place (seems like a bigger thing to address holistically)
- Fix "Remove from project" button styling (couldn't easily find an existing button component for this)
- Super duper pixel perfect

### Related Issues
Is sorta setup work for [#1447](https://github.com/techmatters/terraso-mobile-client/issues/1447)

