### PR TITLE
fix: remove extra space below sheet on iOS devices with notches/islands

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -102,7 +102,7 @@ exports[`renders correctly 1`] = `
               <RNCSafeAreaView
                 edges={
                   {
-                    "bottom": "additive",
+                    "bottom": "off",
                     "left": "additive",
                     "right": "additive",
                     "top": "additive",

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -102,7 +102,7 @@ exports[`renders correctly 1`] = `
               <RNCSafeAreaView
                 edges={
                   {
-                    "bottom": "additive",
+                    "bottom": "off",
                     "left": "additive",
                     "right": "additive",
                     "top": "additive",

--- a/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -102,7 +102,7 @@ exports[`renders correctly 1`] = `
               <RNCSafeAreaView
                 edges={
                   {
-                    "bottom": "additive",
+                    "bottom": "off",
                     "left": "additive",
                     "right": "additive",
                     "top": "additive",

--- a/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -102,7 +102,7 @@ exports[`renders correctly 1`] = `
               <RNCSafeAreaView
                 edges={
                   {
-                    "bottom": "additive",
+                    "bottom": "off",
                     "left": "additive",
                     "right": "additive",
                     "top": "additive",

--- a/dev-client/src/screens/ScreenScaffold.tsx
+++ b/dev-client/src/screens/ScreenScaffold.tsx
@@ -46,6 +46,7 @@ export const ScreenScaffold = ({
 
   return (
     <SafeAreaView
+      edges={['top', 'left', 'right']}
       style={[
         styles.safeAreaContainer,
         {backgroundColor: theme.colors.primary.dark},


### PR DESCRIPTION
## Description
Remove the extra space below bottom sheet on iOS devices with notches/islands.

Before:
<img width="260" alt="image" src="https://github.com/techmatters/terraso-mobile-client/assets/86784/46daaddb-2f9b-4431-83c9-5be32a6593d2">

After:
<img width="282" alt="image" src="https://github.com/techmatters/terraso-mobile-client/assets/86784/4f8e5907-b2f5-4ae4-a843-db1cf25a3c1a">
