### PR TITLE
fix: use correct color for pressed state of buttons

### DIFF
--- a/dev-client/src/navigation/components/ScreenBackButton.tsx
+++ b/dev-client/src/navigation/components/ScreenBackButton.tsx
@@ -27,5 +27,11 @@ export const ScreenBackButton = ({icon = 'arrow-back'}: Props) => {
   const navigation = useNavigation();
   const goBack = useCallback(() => navigation.pop(), [navigation]);
 
-  return <AppBarIconButton name={icon} onPress={goBack} />;
+  return (
+    <AppBarIconButton
+      name={icon}
+      onPress={goBack}
+      _pressed={{backgroundColor: 'primary.main'}}
+    />
+  );
 };

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -130,6 +130,11 @@ export const theme = extendTheme({
       },
     },
     Button: {
+      defaultProps: {
+        _pressed: {
+          bg: 'primary.dark',
+        },
+      },
       baseStyle: {
         _disabled: {
           opacity: '100',

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -308,6 +308,9 @@ export const theme = extendTheme({
         },
       },
       defaultProps: {
+        _pressed: {
+          bg: 'secondary.dark',
+        },
         size: 'sm',
         _icon: {
           size: 'md',

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -41,6 +41,7 @@ export const theme = extendTheme({
     },
     secondary: {
       main: '#C05621',
+      dark: '#9C4221',
     },
     error: {
       main: '#D32F2F',


### PR DESCRIPTION
## Description
Use correct color for pressed state of buttons (dark green by default)
- Manually set pressed state color for IconButton
- Manually set pressed state color for ScreenBackButton
- Manually set pressed state color for ListButton