### PR TITLE
fix: pass elevation data through to Learn More screen

### DIFF
--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -68,7 +68,7 @@ export const CreateSiteView = ({
       const createdSite = await createSiteCallback({...site, elevation});
       if (createdSite !== undefined) {
         homeScreen?.showSiteOnMap(createdSite);
-        navigation.pop();
+        navigation.navigate('BOTTOM_TABS');
       }
     },
     [createSiteCallback, navigation, validationSchema, homeScreen, elevation],

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -70,8 +70,11 @@ export const TemporaryLocationCallout = ({
   }, [closeCallout, navigation, coords, siteElevationValue]);
 
   const onLearnMore = useCallback(() => {
-    navigation.navigate('LOCATION_DASHBOARD', {coords});
-  }, [navigation, coords]);
+    navigation.navigate('LOCATION_DASHBOARD', {
+      coords,
+      elevation: siteElevationValue,
+    });
+  }, [navigation, coords, siteElevationValue]);
 
   return (
     <Card

--- a/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
@@ -39,7 +39,9 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
 import {isSiteManager} from 'terraso-mobile-client/util';
 
-type Props = ({siteId: string} | {coords: Coords}) & {initialTab?: SiteTabName};
+type Props = ({siteId: string} | {coords: Coords} | {elevation: number}) & {
+  initialTab?: SiteTabName;
+};
 
 // A "Location" can refer to a "Site" (with siteId) xor a "Temporary Location" (with only coords)
 export const LocationDashboardScreen = (props: Props) => {
@@ -53,6 +55,8 @@ export const LocationDashboardScreen = (props: Props) => {
     siteId === undefined ? undefined : selectSite(siteId)(state),
   );
   const coords = 'coords' in props ? props.coords : site!;
+
+  const elevation = 'elevation' in props ? props.elevation : undefined;
 
   const userRole = useSelector(state =>
     siteId === undefined ? null : selectUserRoleSite(state, siteId),
@@ -103,7 +107,11 @@ export const LocationDashboardScreen = (props: Props) => {
             />
           </SiteRoleContextProvider>
         ) : (
-          <LocationDashboardContent siteId={siteId} coords={coords} />
+          <LocationDashboardContent
+            siteId={siteId}
+            coords={coords}
+            elevation={elevation}
+          />
         )}
         <PrivacyInfoModal ref={infoModalRef} onClose={onInfoClose} />
       </ScreenScaffold>


### PR DESCRIPTION
## Description
Pass elevation data through to Learn More screen when creating sites via map callout.

### Related Issues
Part of fix for https://github.com/techmatters/terraso-product/issues/774