### PR TITLE
fix: text input field improvements

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -452,6 +452,7 @@ exports[`renders correctly 1`] = `
                                     cursorColor="#8B8B8B"
                                     editable={true}
                                     maxFontSizeMultiplier={1.5}
+                                    maxLength={50}
                                     multiline={false}
                                     onBlur={[Function]}
                                     onChangeText={[Function]}
@@ -671,10 +672,13 @@ exports[`renders correctly 1`] = `
                                     </Text>
                                   </View>
                                   <TextInput
+                                    autoComplete="off"
                                     cursorColor="#8B8B8B"
                                     editable={true}
                                     maxFontSizeMultiplier={1.5}
+                                    maxLength={72}
                                     multiline={true}
+                                    numberOfLines={3}
                                     onBlur={[Function]}
                                     onChangeText={[Function]}
                                     onFocus={[Function]}

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -707,7 +707,7 @@ exports[`renders correctly 1`] = `
                                   <TextInput
                                     cursorColor="#028843"
                                     editable={true}
-                                    keyboardType="decimal-pad"
+                                    keyboardType="numeric"
                                     maxFontSizeMultiplier={1.5}
                                     multiline={false}
                                     onBlur={[Function]}
@@ -917,7 +917,7 @@ exports[`renders correctly 1`] = `
                                   <TextInput
                                     cursorColor="#028843"
                                     editable={true}
-                                    keyboardType="decimal-pad"
+                                    keyboardType="numeric"
                                     maxFontSizeMultiplier={1.5}
                                     multiline={false}
                                     onBlur={[Function]}

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -455,6 +455,7 @@ exports[`renders correctly 1`] = `
                                     cursorColor="#028843"
                                     editable={true}
                                     maxFontSizeMultiplier={1.5}
+                                    maxLength={50}
                                     multiline={false}
                                     onBlur={[Function]}
                                     onChangeText={[Function]}

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -540,6 +540,7 @@ exports[`renders correctly 1`] = `
                                   "color": "#1A202C",
                                   "fontSize": 16,
                                   "fontWeight": "400",
+                                  "marginTop": -20,
                                 }
                               }
                             >

--- a/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
@@ -501,7 +501,6 @@ exports[`renders correctly 1`] = `
                                   },
                                   {
                                     "marginBottom": 23,
-                                    "marginHorizontal": 15,
                                   },
                                 ]
                               }
@@ -1656,7 +1655,6 @@ exports[`renders correctly 1`] = `
                                   },
                                   {
                                     "marginBottom": 23,
-                                    "marginHorizontal": 15,
                                   },
                                 ]
                               }
@@ -2811,7 +2809,6 @@ exports[`renders correctly 1`] = `
                                   },
                                   {
                                     "marginBottom": 23,
-                                    "marginHorizontal": 15,
                                   },
                                 ]
                               }
@@ -3966,7 +3963,6 @@ exports[`renders correctly 1`] = `
                                   },
                                   {
                                     "marginBottom": 23,
-                                    "marginHorizontal": 15,
                                   },
                                 ]
                               }
@@ -5121,7 +5117,6 @@ exports[`renders correctly 1`] = `
                                   },
                                   {
                                     "marginBottom": 23,
-                                    "marginHorizontal": 15,
                                   },
                                 ]
                               }
@@ -6276,7 +6271,6 @@ exports[`renders correctly 1`] = `
                                   },
                                   {
                                     "marginBottom": 23,
-                                    "marginHorizontal": 15,
                                   },
                                 ]
                               }

--- a/dev-client/src/components/AddIntervalModal.tsx
+++ b/dev-client/src/components/AddIntervalModal.tsx
@@ -68,7 +68,6 @@ export const AddIntervalModalBody = ({
       onSubmit={onSubmit}>
       {({handleSubmit, isValid, isSubmitting}) => (
         <>
-          <Box height="20px" />
           <IntervalForm />
           <Box height="50px" />
           <Button

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -53,6 +53,7 @@ export const IntervalForm = () => {
         <Box flex={1}>
           <FormInput
             name="start"
+            keyboardType="decimal-pad"
             placeholder={t('soil.depth_interval.start_label', {
               units: 'cm',
             })}
@@ -64,6 +65,7 @@ export const IntervalForm = () => {
         <Box flex={1}>
           <FormInput
             name="end"
+            keyboardType="decimal-pad"
             placeholder={t('soil.depth_interval.end_label', {
               units: 'cm',
             })}

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -22,7 +22,7 @@ import {FormControl} from 'native-base';
 import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
 import {useFieldContext} from 'terraso-mobile-client/components/form/hooks/useFieldContext';
 import {Box, Row} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {FORM_LABEL_MAX} from 'terraso-mobile-client/constants';
+import {DEPTH_INTERVAL_LABEL_MAX_LENGTH} from 'terraso-mobile-client/constants';
 
 export type IntervalFormInput = {
   label: string;
@@ -40,12 +40,12 @@ export const IntervalForm = () => {
           name="label"
           placeholder={t('soil.depth_interval.label_placeholder')}
           textInputLabel={t('soil.depth_interval.label_placeholder')}
-          maxLength={FORM_LABEL_MAX}
+          maxLength={DEPTH_INTERVAL_LABEL_MAX_LENGTH}
         />
         <FormControl.HelperText>
           {t('general.character_limit', {
             current: label?.length ?? 0,
-            limit: FORM_LABEL_MAX,
+            limit: DEPTH_INTERVAL_LABEL_MAX_LENGTH,
           })}
         </FormControl.HelperText>
       </FormControl>

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -39,6 +39,7 @@ export const IntervalForm = () => {
         <FormInput
           name="label"
           placeholder={t('soil.depth_interval.label_placeholder')}
+          textInputLabel={t('soil.depth_interval.label_placeholder')}
           maxLength={FORM_LABEL_MAX}
         />
         <FormControl.HelperText>
@@ -55,12 +56,18 @@ export const IntervalForm = () => {
             placeholder={t('soil.depth_interval.start_label', {
               units: 'cm',
             })}
+            textInputLabel={t('soil.depth_interval.start_label', {
+              units: 'cm',
+            })}
           />
         </Box>
         <Box flex={1}>
           <FormInput
             name="end"
             placeholder={t('soil.depth_interval.end_label', {
+              units: 'cm',
+            })}
+            textInputLabel={t('soil.depth_interval.end_label', {
               units: 'cm',
             })}
           />

--- a/dev-client/src/components/IntervalForm.tsx
+++ b/dev-client/src/components/IntervalForm.tsx
@@ -53,7 +53,7 @@ export const IntervalForm = () => {
         <Box flex={1}>
           <FormInput
             name="start"
-            keyboardType="decimal-pad"
+            keyboardType="numeric"
             placeholder={t('soil.depth_interval.start_label', {
               units: 'cm',
             })}
@@ -65,7 +65,7 @@ export const IntervalForm = () => {
         <Box flex={1}>
           <FormInput
             name="end"
-            keyboardType="decimal-pad"
+            keyboardType="numeric"
             placeholder={t('soil.depth_interval.end_label', {
               units: 'cm',
             })}

--- a/dev-client/src/components/ScreenFormWrapper.tsx
+++ b/dev-client/src/components/ScreenFormWrapper.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {forwardRef, useImperativeHandle, useRef} from 'react';
+import {forwardRef, useCallback, useImperativeHandle, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {KeyboardAvoidingView, Platform} from 'react-native';
 
@@ -68,16 +68,19 @@ export const ScreenFormWrapper = forwardRef(
     };
 
     // Only show a delete confirmation message if the note is a new, blank note.
-    const conditionallyConfirmDelete = (onOpen: () => void) => {
-      if (
-        formikRef?.current?.dirty === true ||
-        formikRef?.current?.values?.content?.length
-      ) {
-        onOpen();
-      } else {
-        navigation.pop();
-      }
-    };
+    const conditionallyConfirmDelete = useCallback(
+      (onOpen: () => void) => {
+        if (
+          formikRef?.current?.dirty === true ||
+          formikRef?.current?.values?.content?.length
+        ) {
+          onOpen();
+        } else {
+          navigation.pop();
+        }
+      },
+      [navigation],
+    );
 
     return (
       <ScreenScaffold BottomNavigation={null} AppBar={null}>

--- a/dev-client/src/components/ScreenFormWrapper.tsx
+++ b/dev-client/src/components/ScreenFormWrapper.tsx
@@ -27,6 +27,7 @@ import {HorizontalIconButton} from 'terraso-mobile-client/components/icons/Horiz
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Row} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {SITE_NOTE_MIN_LENGTH} from 'terraso-mobile-client/constants';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 
 type Props = {
@@ -43,6 +44,7 @@ export const ScreenFormWrapper = forwardRef(
   ({initialValues, onSubmit, onDelete, children, isSubmitting}: Props, ref) => {
     const formikRef = useRef<FormikProps<{content: string}>>(null);
     const {t} = useTranslation();
+    const navigation = useNavigation();
     const notesFormSchema = yup.object().shape({
       content: yup
         .string()
@@ -94,7 +96,16 @@ export const ScreenFormWrapper = forwardRef(
                       size: '5',
                     }}
                     isDisabled={isSubmitting}
-                    onPress={onOpen}
+                    onPress={() => {
+                      if (
+                        formikRef?.current?.dirty === true ||
+                        formikRef?.current?.values?.content?.length
+                      ) {
+                        onOpen();
+                      } else {
+                        navigation.pop();
+                      }
+                    }}
                   />
                 </Box>
               )}

--- a/dev-client/src/components/ScreenFormWrapper.tsx
+++ b/dev-client/src/components/ScreenFormWrapper.tsx
@@ -67,6 +67,18 @@ export const ScreenFormWrapper = forwardRef(
       }
     };
 
+    // Only show a delete confirmation message if the note is a new, blank note.
+    const conditionallyConfirmDelete = (onOpen: () => void) => {
+      if (
+        formikRef?.current?.dirty === true ||
+        formikRef?.current?.values?.content?.length
+      ) {
+        onOpen();
+      } else {
+        navigation.pop();
+      }
+    };
+
     return (
       <ScreenScaffold BottomNavigation={null} AppBar={null}>
         <KeyboardAvoidingView
@@ -96,16 +108,7 @@ export const ScreenFormWrapper = forwardRef(
                       size: '5',
                     }}
                     isDisabled={isSubmitting}
-                    onPress={() => {
-                      if (
-                        formikRef?.current?.dirty === true ||
-                        formikRef?.current?.values?.content?.length
-                      ) {
-                        onOpen();
-                      } else {
-                        navigation.pop();
-                      }
-                    }}
+                    onPress={() => conditionallyConfirmDelete(onOpen)}
                   />
                 </Box>
               )}

--- a/dev-client/src/constants.ts
+++ b/dev-client/src/constants.ts
@@ -24,15 +24,18 @@ export const LATITUDE_MIN = -90;
 export const LATITUDE_MAX = 90;
 export const LONGITUDE_MIN = -180;
 export const LONGITUDE_MAX = 180;
-export const SITE_NAME_MIN = 3;
-export const SITE_NAME_MAX = 50;
-export const PROJECT_NAME_MAX_LENGTH = 50;
+
+export const SITE_NAME_MIN_LENGTH = 3;
+export const SITE_NAME_MAX_LENGTH = 50;
 export const PROJECT_NAME_MIN_LENGTH = 3;
+export const PROJECT_NAME_MAX_LENGTH = 50;
+export const PROJECT_DESCRIPTION_MIN_LENGTH = 3;
 export const PROJECT_DESCRIPTION_MAX_LENGTH = 72;
+export const DEPTH_INTERVAL_LABEL_MAX_LENGTH = 10;
+export const SITE_NOTE_MIN_LENGTH = 3;
+
 export const BOTTOM_BAR_SIZE = '10%';
-export const FORM_LABEL_MAX = 10;
 export const PROJECT_DEFAULT_MEASUREMENT_UNITS: MeasurementUnit = 'METRIC';
 export const GEOSPATIAL_CONTEXT_USER_DISTANCE_CACHE = 5;
-export const SITE_NOTE_MIN_LENGTH = 3;
 export const LOCALE = 'en-US';
 export const MAP_QUERY_MIN_LENGTH = 2;

--- a/dev-client/src/constants.ts
+++ b/dev-client/src/constants.ts
@@ -24,6 +24,7 @@ export const LATITUDE_MIN = -90;
 export const LATITUDE_MAX = 90;
 export const LONGITUDE_MIN = -180;
 export const LONGITUDE_MAX = 180;
+export const DEPTH_INTERVAL_MAX = 200;
 
 export const SITE_NAME_MIN_LENGTH = 3;
 export const SITE_NAME_MAX_LENGTH = 50;

--- a/dev-client/src/schemas/intervalSchema.ts
+++ b/dev-client/src/schemas/intervalSchema.ts
@@ -44,6 +44,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       .min(0)
       .max(DEPTH_INTERVAL_MAX)
       .required(t('general.required'))
+      .typeError(t('soil.depth_interval.number_required', {item: 'start'}))
       .test((start, {createError}) => {
         if (
           existingIntervals.some(
@@ -63,6 +64,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       .min(0)
       .max(DEPTH_INTERVAL_MAX)
       .required(t('general.required'))
+      .typeError(t('soil.depth_interval.number_required', {item: 'end'}))
       .test((end, {createError, parent}) => {
         if (
           existingIntervals.some(

--- a/dev-client/src/schemas/intervalSchema.ts
+++ b/dev-client/src/schemas/intervalSchema.ts
@@ -20,7 +20,10 @@ import * as yup from 'yup';
 
 import {DepthInterval} from 'terraso-client-shared/soilId/soilIdSlice';
 
-import {DEPTH_INTERVAL_LABEL_MAX_LENGTH} from 'terraso-mobile-client/constants';
+import {
+  DEPTH_INTERVAL_LABEL_MAX_LENGTH,
+  DEPTH_INTERVAL_MAX,
+} from 'terraso-mobile-client/constants';
 
 type Args = {
   t: TFunction;
@@ -39,7 +42,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       .number()
       .integer()
       .min(0)
-      .max(200)
+      .max(DEPTH_INTERVAL_MAX)
       .required(t('general.required'))
       .test((start, {createError}) => {
         if (
@@ -58,7 +61,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       .number()
       .integer()
       .min(0)
-      .max(200)
+      .max(DEPTH_INTERVAL_MAX)
       .required(t('general.required'))
       .test((end, {createError, parent}) => {
         if (

--- a/dev-client/src/schemas/intervalSchema.ts
+++ b/dev-client/src/schemas/intervalSchema.ts
@@ -37,6 +37,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       ),
     start: yup
       .number()
+      .integer()
       .min(0)
       .max(200)
       .required(t('general.required'))
@@ -55,6 +56,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       }),
     end: yup
       .number()
+      .integer()
       .min(0)
       .max(200)
       .required(t('general.required'))

--- a/dev-client/src/schemas/intervalSchema.ts
+++ b/dev-client/src/schemas/intervalSchema.ts
@@ -20,7 +20,7 @@ import * as yup from 'yup';
 
 import {DepthInterval} from 'terraso-client-shared/soilId/soilIdSlice';
 
-import {FORM_LABEL_MAX} from 'terraso-mobile-client/constants';
+import {DEPTH_INTERVAL_LABEL_MAX_LENGTH} from 'terraso-mobile-client/constants';
 
 type Args = {
   t: TFunction;
@@ -29,12 +29,12 @@ type Args = {
 
 export const intervalSchema = ({t, existingIntervals}: Args) =>
   yup.object({
-    label: yup
-      .string()
-      .max(
-        FORM_LABEL_MAX,
-        t('soil.depth_interval.label_help', {max: FORM_LABEL_MAX}),
-      ),
+    label: yup.string().max(
+      DEPTH_INTERVAL_LABEL_MAX_LENGTH,
+      t('soil.depth_interval.label_help', {
+        max: DEPTH_INTERVAL_LABEL_MAX_LENGTH,
+      }),
+    ),
     start: yup
       .number()
       .integer()

--- a/dev-client/src/schemas/intervalSchema.ts
+++ b/dev-client/src/schemas/intervalSchema.ts
@@ -38,6 +38,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
     start: yup
       .number()
       .min(0)
+      .max(200)
       .required(t('general.required'))
       .test((start, {createError}) => {
         if (
@@ -54,6 +55,7 @@ export const intervalSchema = ({t, existingIntervals}: Args) =>
       }),
     end: yup
       .number()
+      .min(0)
       .max(200)
       .required(t('general.required'))
       .test((end, {createError, parent}) => {

--- a/dev-client/src/schemas/siteValidationSchema.ts
+++ b/dev-client/src/schemas/siteValidationSchema.ts
@@ -23,8 +23,8 @@ import {
   LATITUDE_MIN,
   LONGITUDE_MAX,
   LONGITUDE_MIN,
-  SITE_NAME_MAX,
-  SITE_NAME_MIN,
+  SITE_NAME_MAX_LENGTH,
+  SITE_NAME_MIN_LENGTH,
 } from 'terraso-mobile-client/constants';
 
 export const siteValidationSchema = (t: TFunction) =>
@@ -33,15 +33,15 @@ export const siteValidationSchema = (t: TFunction) =>
       .string()
       .trim()
       .min(
-        SITE_NAME_MIN,
+        SITE_NAME_MIN_LENGTH,
         t('site.form.name_min_length_error', {
-          min: SITE_NAME_MIN,
+          min: SITE_NAME_MIN_LENGTH,
         }),
       )
       .max(
-        SITE_NAME_MAX,
+        SITE_NAME_MAX_LENGTH,
         t('site.form.name_max_length_error', {
-          max: SITE_NAME_MAX,
+          max: SITE_NAME_MAX_LENGTH,
         }),
       )
       .required(t('general.required')),

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -137,11 +137,12 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
       <Box mx="5%" mb="15px">
         <FreeformTextInput
           validationFunc={validationFunc}
-          placeholder={t('general.example_email')}
+          placeholder={t('general.email_placeholder')}
           inputProps={{
             autoComplete: 'email',
             autoCapitalize: 'none',
             keyboardType: 'email-address',
+            label: t('general.email_label'),
           }}
         />
       </Box>

--- a/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/ProjectForm.tsx
@@ -39,6 +39,7 @@ import {
 import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {
   PROJECT_DESCRIPTION_MAX_LENGTH,
+  PROJECT_DESCRIPTION_MIN_LENGTH,
   PROJECT_NAME_MAX_LENGTH,
   PROJECT_NAME_MIN_LENGTH,
 } from 'terraso-mobile-client/constants';
@@ -60,12 +61,20 @@ export const projectValidationFields = (t: TFunction) => ({
       }),
     )
     .required(t('general.required')),
-  description: yup.string().max(
-    PROJECT_DESCRIPTION_MAX_LENGTH,
-    t('projects.form.description_max_length_error', {
-      max: PROJECT_DESCRIPTION_MAX_LENGTH,
-    }),
-  ),
+  description: yup
+    .string()
+    .min(
+      PROJECT_DESCRIPTION_MIN_LENGTH,
+      t('projects.form.description_min_length_error', {
+        max: PROJECT_DESCRIPTION_MIN_LENGTH,
+      }),
+    )
+    .max(
+      PROJECT_DESCRIPTION_MAX_LENGTH,
+      t('projects.form.description_max_length_error', {
+        max: PROJECT_DESCRIPTION_MAX_LENGTH,
+      }),
+    ),
   privacy: yup.string().oneOf(['PRIVATE', 'PUBLIC']).required(),
 });
 
@@ -119,6 +128,7 @@ export const EditProjectForm = ({
           <FormInput
             key="name"
             name="name"
+            maxLength={PROJECT_NAME_MAX_LENGTH}
             placeholder={t('projects.create.name_label')}
             id="project-form-name"
             textInputLabel={t('projects.create.name_label')}
@@ -126,6 +136,7 @@ export const EditProjectForm = ({
           <FormInput
             key="description"
             name="description"
+            maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
             placeholder={t('projects.create.description_label')}
             numberOfLines={3}
             multiline={true}
@@ -169,6 +180,7 @@ export default function ProjectForm({
   return (
     <Column space={5}>
       <TextInput
+        maxLength={PROJECT_NAME_MAX_LENGTH}
         placeholder={t('projects.create.name_label')}
         label={t('projects.create.name_label')}
         {...inputParams('name')}
@@ -176,8 +188,11 @@ export default function ProjectForm({
       <ErrorMessage fieldName="name" />
 
       <TextInput
+        maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
         placeholder={t('projects.create.description_label')}
         label={t('projects.create.description_label')}
+        numberOfLines={3}
+        autoComplete="off"
         multiline={true}
         {...inputParams('description')}
       />

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -37,6 +37,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {ProjectSelect} from 'terraso-mobile-client/components/ProjectSelect';
 import {HelpTooltipButton} from 'terraso-mobile-client/components/tooltips/HelpTooltipButton';
+import {SITE_NAME_MAX_LENGTH} from 'terraso-mobile-client/constants';
 import {siteValidationSchema} from 'terraso-mobile-client/schemas/siteValidationSchema';
 import {useSelector} from 'terraso-mobile-client/store';
 
@@ -75,6 +76,7 @@ export const CreateSiteForm = ({
         <Column p="16px" pt="30px" space="18px">
           <FormField name="name">
             <FormInput
+              maxLength={SITE_NAME_MAX_LENGTH}
               placeholder={t('site.create.name_label')}
               textInputLabel={t('site.create.name_label')}
             />

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -90,14 +90,14 @@ export const CreateSiteForm = ({
             <FormInput
               value={values.latitude.toString()}
               textInputLabel={t('site.create.latitude')}
-              keyboardType="decimal-pad"
+              keyboardType="numeric"
             />
           </FormField>
           <FormField name="longitude">
             <FormInput
               value={values.longitude.toString()}
               textInputLabel={t('site.create.longitude')}
-              keyboardType="decimal-pad"
+              keyboardType="numeric"
             />
           </FormField>
           {hasProjects && (

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -81,7 +81,7 @@ export const CreateSiteForm = ({
           </FormField>
 
           <FormLabel>{t('site.create.location_label')}</FormLabel>
-          <Text>
+          <Text mt="-20px">
             {t('site.create.location_accuracy', {
               accuracyM: accuracyM?.toFixed(0),
             })}

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -26,6 +26,7 @@ import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {SITE_NAME_MAX_LENGTH} from 'terraso-mobile-client/constants';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -60,6 +61,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     <ScreenScaffold BottomNavigation={null} AppBar={<AppBar title={name} />}>
       <Column px="16px" py="22px" space="20px" alignItems="flex-start">
         <TextInput
+          maxLength={SITE_NAME_MAX_LENGTH}
           value={name}
           onChangeText={setName}
           label={t('site.create.name_label')}

--- a/dev-client/src/screens/SlopeScreen/components/ManualSteepnessModal.tsx
+++ b/dev-client/src/screens/SlopeScreen/components/ManualSteepnessModal.tsx
@@ -138,6 +138,7 @@ export const ManualSteepnessModal = ({siteId}: Props) => {
                 name="slopeSteepnessPercent"
                 helpText={t('slope.steepness.percentage_help')}
                 placeholder={t('slope.steepness.percentage_placeholder')}
+                textInputLabel={t('slope.steepness.percentage_placeholder')}
                 onChangeText={text => {
                   handleChange('slopeSteepnessPercent')(text);
                   setLastTouched('slopeSteepnessPercent');
@@ -162,6 +163,7 @@ export const ManualSteepnessModal = ({siteId}: Props) => {
                 name="slopeSteepnessDegree"
                 helpText={t('slope.steepness.degree_help')}
                 placeholder={t('slope.steepness.degree_placeholder')}
+                textInputLabel={t('slope.steepness.degree_placeholder')}
                 onChangeText={text => {
                   handleChange('slopeSteepnessDegree')(text);
                   setLastTouched('slopeSteepnessDegree');

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -117,7 +117,9 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
           {workflow === 'CAMERA' && <PhotoConditions {...props} />}
         </>
       )}
-      <DoneButton isDisabled={!color} />
+      <Box position="absolute" right="0" bottom="0">
+        <DoneButton isDisabled={!color} />
+      </Box>
     </SoilPitInputScreenScaffold>
   );
 };

--- a/dev-client/src/screens/SoilScreen/SoilScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SoilScreen.tsx
@@ -143,7 +143,10 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
               onPress={onOpen}>
               {t('soil.add_depth_label')}
             </Button>
-          )}>
+          )}
+          Header={
+            <Heading variant="h6">{t('soil.depth_interval.add_title')}</Heading>
+          }>
           <AddIntervalModalBody
             onSubmit={onAddDepthInterval}
             existingIntervals={existingIntervals}

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -169,18 +169,6 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
           </Button>
         </Column>
         <Column p="15px" bg="primary.contrast">
-          {/*<Row alignItems="center">
-            <Text variant="body1-strong">{t('soil.texture.clay_title')}</Text>
-            <FormTooltip icon="info">Unimplemented tooltip</FormTooltip>
-          </Row>
-          <Box height="10px" />
-           <FormInput
-            onChangeText={onClayChange}
-            keyboardType="numeric"
-            placeholder={t('soil.texture.clay_label')}
-            helpText={t('soil.texture.clay_help')}
-          />
-          <Box height="20px" /> */}
           <Row alignItems="center">
             <Text variant="body1-strong">
               {t('soil.texture.fragment_title')}

--- a/dev-client/src/screens/SoilScreen/components/EditIntervalModal.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditIntervalModal.tsx
@@ -191,13 +191,13 @@ export const EditIntervalModal = ({
         }}
         onSubmit={onSubmit}>
         {({handleSubmit, isValid, isSubmitting}) => (
-          <Column mb="23px" mx="15px">
+          <Column mb="23px">
             {mutable && (
               <>
                 <Box pl="2px" mb="11px">
                   <IntervalForm />
                 </Box>
-                <Heading variant="h6">
+                <Heading variant="h6" mt="11px" mb="11px">
                   {t('soil.depth_interval.data_inputs_title')}
                 </Heading>
               </>

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -78,7 +78,9 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
           />
         </Box>
       </Column>
-      <DoneButton isDisabled={!cracking} />
+      <Box position="absolute" bottom="0" right="0">
+        <DoneButton isDisabled={!cracking} />
+      </Box>
     </ScreenScaffold>
   );
 };

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -311,7 +311,7 @@
       "user_does_not_exist": "User {{email}} is not a Terraso user, unable to add to project.",
       "user_in_project": "User {{email}} is already a member of this project.",
       "already_added": "User {{email}} already added to user list.",
-      "empty_email": "Please enter an email"
+      "empty_email": "Enter an email address"
     },
     "manage_member": {
       "title": "Manage Team Member",
@@ -366,7 +366,8 @@
     "you_name": "{{name}} (you)",
     "details": "Details",
     "apply": "Apply",
-    "example_email": "name@domain.com",
+    "email_placeholder": "name@domain.com",
+    "email_label": "Email address",
     "profile_image_alt": "Profile image",
     "role": {
       "MANAGER": "Manager",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -334,6 +334,7 @@
     "form": {
       "name_min_length_error": "Project name must be at least {{min}} characters",
       "name_max_length_error": "Project name must be at most {{max}} characters",
+      "description_min_length_error": "Project description must be at least {{min}} characters",
       "description_max_length_error": "Project description must be at most {{max}} characters"
     },
     "sort_label": "Sort projects by:",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -548,6 +548,9 @@
       "apply_to_all_label": "Apply to all intervals",
       "start_label": "From ({{units}})",
       "end_label": "To ({{units}})",
+      "number_required": "$t(soil.depth_interval.interval, {\"context\": \"{{item}}\"}) must be a number",
+      "interval_start": "interval start",
+      "interval_end": "interval end",
       "update_modal": {
         "title": "Change depth?",
         "body": "Data that has been entered at this depth will be deleted. This action cannot be undone.",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -13,7 +13,7 @@
     }
   },
   "search": {
-    "placeholder": "Search"
+    "placeholder": "Search map"
   },
   "site": {
     "list_title": "Sites List",


### PR DESCRIPTION
## Description
Text input field improvements:
- add text labels to add team member, custom soil depth interval, slope steepness screens
- don’t prompt to delete new, blank notes
- on site creation form, reduce space above GPS accuracy label
- add project description minimum length
- enforce max length for site name, project name and project description
- ensure depth intervals are integers
- add header to "add depth interval" screen (and fix layout spacing)

Alsos:
- move done button to bottom right on color and soil surface screens