### PR TITLE
fix: create sites at location indicated on map (not current location)

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -1162,7 +1162,7 @@ exports[`renders correctly 1`] = `
                                     <Text
                                       style={{}}
                                     >
-                                      1.000000
+                                      1
                                     </Text>
                                   </Text>
                                   <Text
@@ -1190,7 +1190,7 @@ exports[`renders correctly 1`] = `
                                     <Text
                                       style={{}}
                                     >
-                                      1.000000
+                                      1
                                     </Text>
                                   </Text>
                                   <Text

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -39,6 +39,7 @@ import {ProjectSelect} from 'terraso-mobile-client/components/ProjectSelect';
 import {HelpTooltipButton} from 'terraso-mobile-client/components/tooltips/HelpTooltipButton';
 import {siteValidationSchema} from 'terraso-mobile-client/schemas/siteValidationSchema';
 import {useSelector} from 'terraso-mobile-client/store';
+import {formatCoordinate} from 'terraso-mobile-client/util';
 
 export type FormState = InferType<ReturnType<typeof siteValidationSchema>>;
 
@@ -88,14 +89,14 @@ export const CreateSiteForm = ({
           </Text>
           <FormField name="latitude">
             <FormInput
-              value={values.latitude.toString()}
+              value={formatCoordinate(values.latitude)}
               textInputLabel={t('site.create.latitude')}
               keyboardType="decimal-pad"
             />
           </FormField>
           <FormField name="longitude">
             <FormInput
-              value={values.longitude.toString()}
+              value={formatCoordinate(values.longitude)}
               textInputLabel={t('site.create.longitude')}
               keyboardType="decimal-pad"
             />

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -52,13 +52,10 @@ export const CreateSiteView = ({
 }: Props) => {
   const {t} = useTranslation();
   const validationSchema = useMemo(() => siteValidationSchema(t), [t]);
-  const userLocation = useSelector(state => state.map.userLocation);
   const defaultProject = useSelector(state =>
     defaultProjectId ? state.project.projects[defaultProjectId] : undefined,
   );
   const homeScreen = useHomeScreenContext();
-
-  const defaultCoords = userLocation.coords;
 
   const navigation = useNavigation();
 
@@ -80,10 +77,8 @@ export const CreateSiteView = ({
       validationSchema={validationSchema}
       initialValues={{
         name: '',
-        latitude:
-          defaultCoords?.latitude !== undefined ? defaultCoords?.latitude : 0,
-        longitude:
-          defaultCoords?.longitude !== undefined ? defaultCoords?.longitude : 0,
+        latitude: sitePin?.latitude !== undefined ? sitePin?.latitude : 0,
+        longitude: sitePin?.longitude !== undefined ? sitePin?.longitude : 0,
         projectId: defaultProject?.id,
         privacy: defaultProject?.privacy ?? 'PUBLIC',
       }}

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -44,6 +44,7 @@ import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigatio
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {ProjectInstructionsButton} from 'terraso-mobile-client/screens/LocationScreens/components/ProjectInstructionsButton';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
+import {formatCoordinate} from 'terraso-mobile-client/util';
 
 type Props = {
   siteId?: string;
@@ -162,11 +163,11 @@ export const LocationDashboardContent = ({
       <Box px="16px" py="16px">
         <LocationDetail
           label={t('geo.latitude.title')}
-          value={coords?.latitude.toFixed(6)}
+          value={formatCoordinate(coords?.latitude)}
         />
         <LocationDetail
           label={t('geo.longitude.title')}
-          value={coords?.longitude.toFixed(6)}
+          value={formatCoordinate(coords?.longitude)}
         />
         <LocationDetail
           label={t('geo.elevation.title')}


### PR DESCRIPTION
## Description
Create sites at location indicated on map (not current location) (bug introduced in v138)

Use formatCoordinate on site creation for and site dashboard.


### Related Issues
Fixes #1559.