### PR TITLE
feat: delete account pending buttons

### DIFF
--- a/dev-client/src/components/buttons/list/ListButton.tsx
+++ b/dev-client/src/components/buttons/list/ListButton.tsx
@@ -16,6 +16,7 @@
  */
 
 import {useMemo} from 'react';
+import {Text} from 'react-native';
 import {PressableProps} from 'react-native-paper/lib/typescript/components/TouchableRipple/Pressable';
 
 import {Button} from 'native-base';
@@ -27,7 +28,9 @@ export type ListButtonType = 'default' | 'error';
 export type ListButtonProps = {
   type: ListButtonType;
   labelText: string;
+  subLabelText?: string;
   iconName: IconName;
+  disabled?: boolean;
   onPress?: PressableProps['onPress'];
 };
 
@@ -35,16 +38,19 @@ export function ListButton({
   type = 'default',
   iconName,
   labelText,
+  subLabelText,
+  disabled,
   onPress,
 }: ListButtonProps) {
   const {color, pressedColor} = useMemo(() => {
-    switch (type) {
-      case 'error':
-        return {color: 'error.main', pressedColor: 'red.100'};
-      default:
-        return {color: 'text.primary', pressedColor: undefined};
+    if (disabled) {
+      return COLORS.disabled;
+    } else if (type === 'error') {
+      return COLORS.error;
+    } else {
+      return COLORS.default;
     }
-  }, [type]);
+  }, [disabled, type]);
 
   return (
     <Button
@@ -54,8 +60,25 @@ export function ListButton({
       _text={{color: color, textTransform: 'uppercase'}}
       leftIcon={iconName ? <Icon name={iconName} color={color} /> : undefined}
       _pressed={{backgroundColor: pressedColor}}
+      disabled={disabled}
       onPress={onPress}>
       {labelText}
+      {subLabelText && <Text>{subLabelText}</Text>}
     </Button>
   );
 }
+
+const COLORS = {
+  disabled: {
+    color: 'text.disabled',
+    pressedColor: undefined,
+  },
+  default: {
+    color: 'text.primary',
+    pressedColor: undefined,
+  },
+  error: {
+    color: 'error.main',
+    pressedColor: 'red.100',
+  },
+};

--- a/dev-client/src/components/modals/SignOutModal.tsx
+++ b/dev-client/src/components/modals/SignOutModal.tsx
@@ -15,24 +15,31 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {ListButton} from 'terraso-mobile-client/components/buttons/list/ListButton';
-import {LogoutModal} from 'terraso-mobile-client/components/modals/LogoutModal';
+import {signOut} from 'terraso-client-shared/account/accountSlice';
 
-export function LogOutButton() {
+import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
+import {ModalProps} from 'terraso-mobile-client/components/modals/Modal';
+import {useDispatch} from 'terraso-mobile-client/store';
+
+export type LogoutModalProps = Pick<ModalProps, 'trigger'>;
+
+export function SignOutModal({trigger}: LogoutModalProps) {
   const {t} = useTranslation();
+  const dispatch = useDispatch();
+  const onSignOut = useCallback(() => {
+    dispatch(signOut());
+  }, [dispatch]);
 
   return (
-    <LogoutModal
-      trigger={onOpen => (
-        <ListButton
-          type="default"
-          iconName="logout"
-          labelText={t('settings.log_out')}
-          onPress={onOpen}
-        />
-      )}
+    <ConfirmModal
+      trigger={trigger}
+      body={t('sign_out.confirm_body')}
+      actionName={t('sign_out.confirm_action')}
+      isConfirmError={false}
+      handleConfirm={onSignOut}
     />
   );
 }

--- a/dev-client/src/hooks/userDeletionRequest.ts
+++ b/dev-client/src/hooks/userDeletionRequest.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback, useState} from 'react';
+import {useCallback} from 'react';
 
 import {savePreference} from 'terraso-client-shared/account/accountSlice';
 
@@ -27,13 +27,12 @@ const PREFERENCES_VALUE = 'true';
 export const useUserDeletionRequests = () => {
   const dispatch = useDispatch();
   const {data: user} = useSelector(state => state.account.currentUser);
-  const [isPending, setIsPending] = useState(
-    user!.preferences[PREFERENCES_KEY] === PREFERENCES_VALUE,
-  );
+  const isSaving = useSelector(state => state.account.preferences.saving);
+  const isPending = user!.preferences[PREFERENCES_KEY] === PREFERENCES_VALUE;
+
   const requestDeletion = useCallback(() => {
-    setIsPending(true);
     dispatch(savePreference({key: PREFERENCES_KEY, value: PREFERENCES_VALUE}));
   }, [dispatch]);
 
-  return {user, isPending, requestDeletion};
+  return {user, isPending, requestDeletion, isSaving};
 };

--- a/dev-client/src/screens/DeleteAccountScreen/DeleteAccountScreen.tsx
+++ b/dev-client/src/screens/DeleteAccountScreen/DeleteAccountScreen.tsx
@@ -30,7 +30,8 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 
 export function DeleteAccountScreen() {
   const {t} = useTranslation();
-  const {user, isPending, requestDeletion} = useUserDeletionRequests();
+  const {user, isPending, isSaving, requestDeletion} =
+    useUserDeletionRequests();
 
   return (
     <ScreenScaffold AppBar={<AppBar LeftButton={<ScreenBackButton />} />}>
@@ -44,6 +45,7 @@ export function DeleteAccountScreen() {
                 <DeleteAccountConfirmContent user={user} />
                 <DeleteAccountConfirmForm
                   user={user}
+                  isSaving={isSaving}
                   onConfirm={requestDeletion}
                 />
               </Column>

--- a/dev-client/src/screens/DeleteAccountScreen/components/DeleteAccountConfirmForm.tsx
+++ b/dev-client/src/screens/DeleteAccountScreen/components/DeleteAccountConfirmForm.tsx
@@ -28,11 +28,13 @@ import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigatio
 
 export type DeleteAccountConfirmFormProps = {
   user: User;
+  isSaving: boolean;
   onConfirm: () => void;
 };
 
 export function DeleteAccountConfirmForm({
   user,
+  isSaving,
   onConfirm,
 }: DeleteAccountConfirmFormProps) {
   const {t} = useTranslation();
@@ -41,7 +43,7 @@ export function DeleteAccountConfirmForm({
 
   const email = user.email;
   const [value, setValue] = useState('');
-  const isDisabled = email !== value;
+  const isEmailConfirmed = email !== value;
 
   return (
     <Column space="24px">
@@ -58,7 +60,7 @@ export function DeleteAccountConfirmForm({
         </Button>
         <Button
           onPress={onConfirm}
-          isDisabled={isDisabled}
+          isDisabled={isEmailConfirmed || isSaving}
           {...ACTION_BUTTON_VARIANTS.confirm}>
           {t('delete_account.confirm.delete')}
         </Button>

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -20,7 +20,7 @@ import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {DeleteAccountButton} from 'terraso-mobile-client/screens/UserSettingsScreen/components/actions/DeleteAccountButton';
-import {LogOutButton} from 'terraso-mobile-client/screens/UserSettingsScreen/components/actions/LogOutButton';
+import {SignOutButton} from 'terraso-mobile-client/screens/UserSettingsScreen/components/actions/SignOutButton';
 import {UserIndicator} from 'terraso-mobile-client/screens/UserSettingsScreen/components/UserIndicatorComponent';
 import {VersionIndicator} from 'terraso-mobile-client/screens/UserSettingsScreen/components/VersionIndicatorComponent';
 
@@ -30,7 +30,7 @@ export function UserSettingsScreen() {
       <Column height="full" margin="12px">
         <UserIndicator />
         <ButtonList>
-          <LogOutButton />
+          <SignOutButton />
           <DeleteAccountButton />
         </ButtonList>
         <VersionIndicator />

--- a/dev-client/src/screens/UserSettingsScreen/components/actions/DeleteAccountButton.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/actions/DeleteAccountButton.tsx
@@ -19,10 +19,12 @@ import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {ListButton} from 'terraso-mobile-client/components/buttons/list/ListButton';
+import {useUserDeletionRequests} from 'terraso-mobile-client/hooks/userDeletionRequest';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 
 export function DeleteAccountButton() {
   const {t} = useTranslation();
+  const {isPending} = useUserDeletionRequests();
   const navigation = useNavigation();
   const onDeleteAccount = useCallback(
     () => navigation.navigate('DELETE_ACCOUNT'),
@@ -34,6 +36,10 @@ export function DeleteAccountButton() {
       type="error"
       iconName="delete"
       labelText={t('settings.delete_account')}
+      disabled={isPending}
+      subLabelText={
+        isPending ? t('settings.delete_account_pending') : undefined
+      }
       onPress={onDeleteAccount}
     />
   );

--- a/dev-client/src/screens/UserSettingsScreen/components/actions/SignOutButton.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/actions/SignOutButton.tsx
@@ -15,31 +15,24 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {signOut} from 'terraso-client-shared/account/accountSlice';
+import {ListButton} from 'terraso-mobile-client/components/buttons/list/ListButton';
+import {SignOutModal} from 'terraso-mobile-client/components/modals/SignOutModal';
 
-import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
-import {ModalProps} from 'terraso-mobile-client/components/modals/Modal';
-import {useDispatch} from 'terraso-mobile-client/store';
-
-export type LogoutModalProps = Pick<ModalProps, 'trigger'>;
-
-export function LogoutModal({trigger}: LogoutModalProps) {
+export function SignOutButton() {
   const {t} = useTranslation();
-  const dispatch = useDispatch();
-  const onLogout = useCallback(() => {
-    dispatch(signOut());
-  }, [dispatch]);
 
   return (
-    <ConfirmModal
-      trigger={trigger}
-      body={t('logout.confirm_body')}
-      actionName={t('logout.confirm_action')}
-      isConfirmError={false}
-      handleConfirm={onLogout}
+    <SignOutModal
+      trigger={onOpen => (
+        <ListButton
+          type="default"
+          iconName="logout"
+          labelText={t('settings.sign_out')}
+          onPress={onOpen}
+        />
+      )}
     />
   );
 }

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -346,7 +346,7 @@
   },
   "settings": {
     "unknown_user": "Unknown user",
-    "log_out": "Sign Out",
+    "sign_out": "Sign Out",
     "delete_account": "Delete Account",
     "unknown_version": "Untagged application version",
     "version": "Version {{version}}"
@@ -457,7 +457,7 @@
       "p2": "You will receive an email confirmation when your account has been deleted."
     }
   },
-  "logout": {
+  "sign_out": {
     "confirm_body": "Are you sure you want to sign out?",
     "confirm_action": "Sign out"
   },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -348,6 +348,7 @@
     "unknown_user": "Unknown user",
     "sign_out": "Sign Out",
     "delete_account": "Delete Account",
+    "delete_account_pending": "Pending",
     "unknown_version": "Untagged application version",
     "version": "Version {{version}}"
   },


### PR DESCRIPTION
## Description

Update the delete account workflow to disable buttons when the deletion is pending, simplifying the hook's internals to remove unnecessary state tracking. Do some associated refactoring to make deletion / logout systems more consistently implemented.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1179

### Verification steps

Open the user settings screen and execute the delete account workflow. Observe that the action button does not allow the user to click it again while the request is pending. Observe that the button on the settings screen is now disabled and shows the "Pending" sub-label.