### PR TITLE
feat: Implement new "Add team member" flow

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -55,7 +55,7 @@
         "react-native-screens": "^3.31.1",
         "react-native-svg": "^15.3.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#955095c8480485c00d3a8913a6adaa5a9b6847d1",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#6cf29e10f3b3914ae327ffc3c91608736bae2a6c",
         "uuid": "^9.0.1",
         "yup": "^1.4.0"
       },
@@ -25636,8 +25636,8 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#955095c8480485c00d3a8913a6adaa5a9b6847d1",
-      "integrity": "sha512-jtBw8UgA84inOjg9/itquASxJdUdBwvmrabeIBWvZ9+/NuKeS8LjB9fwL/1mYRhXYVowQDMzDzQglsvaaFC+/A==",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#6cf29e10f3b3914ae327ffc3c91608736bae2a6c",
+      "integrity": "sha512-qPVVWkhpBR1JGSp+U8w0qkgslyH6/+8SC5YyCe163id68TPaD03PayzixH+B3h8kR9a/mIS+BLD3tq65ZSebkA==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -64,7 +64,7 @@
     "react-native-screens": "^3.31.1",
     "react-native-svg": "^15.3.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#955095c8480485c00d3a8913a6adaa5a9b6847d1",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#6cf29e10f3b3914ae327ffc3c91608736bae2a6c",
     "uuid": "^9.0.1",
     "yup": "^1.4.0"
   },

--- a/dev-client/src/navigation/screenDefinitions.tsx
+++ b/dev-client/src/navigation/screenDefinitions.tsx
@@ -21,6 +21,7 @@ import {
 } from 'terraso-mobile-client/navigation/types';
 import {generateScreens} from 'terraso-mobile-client/navigation/utils/utils';
 import {AddSiteNoteScreen} from 'terraso-mobile-client/screens/AddSiteNoteScreen';
+import {AddUserToProjectRoleScreen} from 'terraso-mobile-client/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen';
 import {AddUserToProjectScreen} from 'terraso-mobile-client/screens/AddUserToProjectScreen/AddUserToProjectScreen';
 import {BottomTabsScreen} from 'terraso-mobile-client/screens/BottomTabsScreen';
 import {ColorAnalysisScreen} from 'terraso-mobile-client/screens/ColorAnalysisScreen/ColorAnalysisScreen';
@@ -74,6 +75,7 @@ export const screenDefinitions = {
   SITE_SETTINGS: SiteSettingsScreen,
   SITE_TEAM_SETTINGS: SiteTeamSettingsScreen,
   ADD_USER_PROJECT: AddUserToProjectScreen,
+  ADD_USER_PROJECT_ROLE: AddUserToProjectRoleScreen,
   MANAGE_TEAM_MEMBER: ManageTeamMemberScreen,
   SLOPE_STEEPNESS: SlopeSteepnessScreen,
   SLOPE_SHAPE: SlopeShapeScreen,

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -20,7 +20,6 @@ import {useTranslation} from 'react-i18next';
 
 import {Button} from 'native-base';
 
-import {SimpleUserInfo} from 'terraso-client-shared/account/accountSlice';
 import {
   addUserToProject,
   ProjectRole,
@@ -36,13 +35,13 @@ import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {MinimalUserDisplay} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/MinimalUserDisplay';
 import {ProjectRoleRadioBlock} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/ProjectRoleRadioBlock';
+import {UserFields} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/UserDisplay';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
 type Props = {
   projectId: string;
-  // TODO-cknipe: Consolidate UserFields and SimpleUserInfo
-  user: SimpleUserInfo;
+  user: UserFields;
 };
 
 export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
@@ -60,11 +59,9 @@ export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
 
   const addUser = useCallback(async () => {
     try {
-      // TODO-cknipe: Why can't you use the values directly in addUserToProject?
-      // TODO-cknipe: To await or not?
-      const userId = user.id;
-      const role = selectedRole;
-      dispatch(addUserToProject({userId, role, projectId}));
+      dispatch(
+        addUserToProject({userId: user.id, role: selectedRole, projectId}),
+      );
     } catch (e) {
       console.error(e);
     }

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -68,7 +68,7 @@ export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
       console.error(e);
     }
     navigation.navigate('PROJECT_VIEW', {projectId: projectId});
-    TabActions.jumpTo(TabRoutes.TEAM);
+    navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
   return (

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -33,7 +33,6 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
-import {ScreenCloseButton} from 'terraso-mobile-client/navigation/components/ScreenCloseButton';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {MinimalUserDisplay} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/MinimalUserDisplay';
 import {ProjectRoleRadioBlock} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/ProjectRoleRadioBlock';
@@ -55,6 +54,10 @@ export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
 
   const [selectedRole, setSelectedRole] = useState<ProjectRole>('VIEWER');
 
+  const onCancel = useCallback(() => {
+    navigation.pop();
+  }, [navigation]);
+
   const addUser = useCallback(async () => {
     try {
       // TODO-cknipe: Why can't you use the values directly in addUserToProject?
@@ -70,10 +73,7 @@ export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
   return (
-    <ScreenScaffold
-      AppBar={
-        <AppBar title={project?.name} LeftButton={<ScreenCloseButton />} />
-      }>
+    <ScreenScaffold AppBar={<AppBar title={project?.name} />}>
       <ScreenContentSection title={t('projects.add_user.heading')}>
         <Column>
           <Box ml="md" my="lg">
@@ -92,7 +92,7 @@ export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
             space="12px"
             pt="md">
             <Button
-              onPress={addUser}
+              onPress={onCancel}
               size="lg"
               variant="outline"
               borderColor="action.active"

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -18,6 +18,7 @@
 import {useCallback, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
+import {TabActions} from '@react-navigation/native';
 import {Button} from 'native-base';
 
 import {
@@ -32,6 +33,7 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
+import {TabRoutes} from 'terraso-mobile-client/navigation/constants';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {MinimalUserDisplay} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/MinimalUserDisplay';
 import {ProjectRoleRadioBlock} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/ProjectRoleRadioBlock';
@@ -65,8 +67,8 @@ export const AddUserToProjectRoleScreen = ({projectId, user}: Props) => {
     } catch (e) {
       console.error(e);
     }
-    navigation.pop();
-    navigation.pop();
+    navigation.navigate('PROJECT_VIEW', {projectId: projectId});
+    TabActions.jumpTo(TabRoutes.TEAM);
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
   return (

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -15,31 +15,21 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
+import {Formik} from 'formik';
 import {Button} from 'native-base';
+import * as yup from 'yup';
 
 import {checkUserInProject} from 'terraso-client-shared/account/accountService';
-import {
-  addUserToProject,
-  ProjectRole,
-} from 'terraso-client-shared/project/projectSlice';
 
-import {
-  Box,
-  Row,
-  Text,
-} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
+import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
+import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
-import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {FreeformTextInput} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/FreeformTextInput';
-import MembershipControlList, {
-  UserWithRole,
-} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/MembershipControlList';
-import {useKeyboardOpen} from 'terraso-mobile-client/screens/AddUserToProjectScreen/hooks/useKeyboardOpen';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
-import {useDispatch, useSelector} from 'terraso-mobile-client/store';
+import {useSelector} from 'terraso-mobile-client/store';
 
 type Props = {
   projectId: string;
@@ -47,123 +37,189 @@ type Props = {
 
 export const AddUserToProjectScreen = ({projectId}: Props) => {
   const {t} = useTranslation();
-  const [userRecord, setUserRecord] = useState<Record<string, UserWithRole>>(
-    {},
-  );
-  const keyboardOpen = useKeyboardOpen();
+  // TODO-cknipe: Remove this or put it in the appropriate place
+  // const [userRecord, setUserRecord] = useState<Record<string, UserWithRole>>(
+  //   {},
+  // );
+  // const keyboardOpen = useKeyboardOpen();
 
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const navigation = useNavigation();
-  const dispatch = useDispatch();
+  // const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  // const navigation = useNavigation();
+  // const dispatch = useDispatch();
 
   const projectName = useSelector(
     state => state.project.projects[projectId]?.name,
   );
 
-  const userList = useMemo(() => Object.values(userRecord), [userRecord]);
-  const disableSubmit = useMemo(
-    () => isSubmitting || Object.keys(userRecord).length === 0,
-    [userRecord, isSubmitting],
-  );
+  // TODO-cknipe: Remove this or put it in the appropriate place
+  // const userList = useMemo(() => Object.values(userRecord), [userRecord]);
+  // const disableSubmit = useMemo(
+  //   () => isSubmitting || Object.keys(userRecord).length === 0,
+  //   [userRecord, isSubmitting],
+  // );
 
-  const validationFunc = async (email: string) => {
+  // // TODO-cknipe: Remove this
+  // const validationFunc = async (email: string) => {
+  //   if (email === '') {
+  //     // TODO: current bug means empty string for email is considered existing :(
+  //     // Easier just to explicitly reject it here
+  //     return t('projects.add_user.empty_email');
+  //   }
+  //   const userExists = await checkUserInProject(projectId, email);
+  //   if ('type' in userExists) {
+  //     switch (userExists.type) {
+  //       case 'NoUser':
+  //         return t('projects.add_user.user_does_not_exist', {email: email});
+  //       case 'InProject':
+  //         return t('projects.add_user.user_in_project', {email: email});
+  //     }
+  //   }
+  //   if (userExists.id in userRecord) {
+  //     return t('projects.add_user.already_added', {email: email});
+  //   }
+
+  //   setUserRecord(users => {
+  //     return {
+  //       ...users,
+  //       [userExists.id]: {user: userExists, role: 'VIEWER'},
+  //     };
+  //   });
+  //   return null;
+  // };
+
+  // const updateUserRole = useCallback((role: ProjectRole, userId: string) => {
+  //   setUserRecord(users => {
+  //     const newUsers = {...users};
+  //     newUsers[userId].role = role;
+  //     return newUsers;
+  //   });
+  // }, []);
+
+  // const removeUser = useCallback((userId: string) => {
+  //   setUserRecord(users => {
+  //     let newUsers = {...users};
+  //     delete newUsers[userId];
+  //     return newUsers;
+  //   });
+  // }, []);
+
+  // const submitUsers = async () => {
+  //   setIsSubmitting(true);
+  //   for (const {
+  //     user: {id: userId},
+  //     role,
+  //   } of Object.values(userRecord)) {
+  //     try {
+  //       dispatch(addUserToProject({userId, role, projectId}));
+  //     } catch (e) {
+  //       console.error(e);
+  //     }
+  //   }
+  //   navigation.pop();
+  //   setIsSubmitting(false);
+  // };
+
+  return (
+    <ScreenScaffold AppBar={<AppBar title={projectName} />}>
+      <ScreenContentSection title={t('projects.add_user.heading')}>
+        <Text variant="body1">{t('projects.add_user.help_text')}</Text>
+        <Box mt="md">
+          <AddTeamMemberForm projectId={projectId} />
+        </Box>
+      </ScreenContentSection>
+    </ScreenScaffold>
+  );
+};
+
+// TODO-cknipe: Move this to new file?
+type FormValues = {
+  email: string;
+};
+
+type FormProps = {
+  projectId: string;
+};
+
+const AddTeamMemberForm = ({projectId}: FormProps) => {
+  const {t} = useTranslation();
+
+  const onNext = async (values: FormValues) => {
+    // TODO-cknipe: Do the right thing on Next button
+    const validationErrors = await backendValidate(values.email);
+    console.log('Validation errors: ', validationErrors);
+  };
+
+  const backendValidate = async (email: string) => {
     if (email === '') {
-      // TODO: current bug means empty string for email is considered existing :(
-      // Easier just to explicitly reject it here
-      return t('projects.add_user.empty_email');
+      return t('general.required');
     }
-    const userExists = await checkUserInProject(projectId, email);
-    if ('type' in userExists) {
-      switch (userExists.type) {
+
+    const userOrError = await checkUserInProject(projectId, email);
+    if ('type' in userOrError) {
+      switch (userOrError.type) {
         case 'NoUser':
           return t('projects.add_user.user_does_not_exist', {email: email});
         case 'InProject':
           return t('projects.add_user.user_in_project', {email: email});
       }
     }
-    if (userExists.id in userRecord) {
+
+    // TODO-cknipe: What's userRecord? Remove this or use the real one.
+    const userRecord = ['TODO-cknipe'];
+    if (userOrError.id in userRecord) {
       return t('projects.add_user.already_added', {email: email});
     }
 
-    setUserRecord(users => {
-      return {
-        ...users,
-        [userExists.id]: {user: userExists, role: 'VIEWER'},
-      };
-    });
-    return null;
+    return true;
   };
 
-  const updateUserRole = useCallback((role: ProjectRole, userId: string) => {
-    setUserRecord(users => {
-      const newUsers = {...users};
-      newUsers[userId].role = role;
-      return newUsers;
-    });
-  }, []);
-
-  const removeUser = useCallback((userId: string) => {
-    setUserRecord(users => {
-      let newUsers = {...users};
-      delete newUsers[userId];
-      return newUsers;
-    });
-  }, []);
-
-  const submitUsers = async () => {
-    setIsSubmitting(true);
-    for (const {
-      user: {id: userId},
-      role,
-    } of Object.values(userRecord)) {
-      try {
-        dispatch(addUserToProject({userId, role, projectId}));
-      } catch (e) {
-        console.error(e);
-      }
-    }
-    navigation.pop();
-    setIsSubmitting(false);
-  };
+  // TODO-cknipe: Don't do the backend call every time
+  // Debounce or only do the backend validation when "Next" is pressed
+  const validationSchema = yup.object().shape({
+    email: yup
+      .string()
+      .required(t('projects.add_user.empty_email'))
+      .email(t('projects.add_user.invalid_email'))
+      .test(async (value, {createError}) => {
+        const validationResult = await backendValidate(value);
+        return validationResult === true
+          ? true
+          : createError({
+              message: validationResult,
+            });
+      }),
+  });
 
   return (
-    <ScreenScaffold AppBar={<AppBar title={projectName} />}>
-      <Box mx="5%" mb="15px" mt="22px">
-        <Text variant="body1" fontWeight="bold">
-          {t('projects.add_user.heading')}
-        </Text>
-        <Text variant="body1">{t('projects.add_user.help_text')}</Text>
-      </Box>
-      <Box mx="5%" mb="15px">
-        <FreeformTextInput
-          validationFunc={validationFunc}
-          placeholder={t('general.email_placeholder')}
-          inputProps={{
-            autoComplete: 'email',
-            autoCapitalize: 'none',
-            keyboardType: 'email-address',
-            label: t('general.email_label'),
-          }}
-        />
-      </Box>
-      <MembershipControlList
-        users={userList}
-        updateUserRole={updateUserRole}
-        removeUser={removeUser}
-      />
-      <Row
-        flexDirection="row-reverse"
-        my="20px"
-        ml="20px"
-        display={keyboardOpen ? 'none' : undefined}>
-        <Button
-          onPress={submitUsers}
-          isDisabled={disableSubmit}
-          isLoading={isSubmitting}
-          w="100px">
-          {t('general.save_fab')}
-        </Button>
-      </Row>
-    </ScreenScaffold>
+    <Formik
+      initialValues={{email: ''}}
+      validationSchema={validationSchema}
+      validateOnMount={true}
+      initialTouched={{
+        email: true,
+      }}
+      onSubmit={onNext}>
+      {({handleSubmit, isValid, isValidating, isSubmitting}) => {
+        return (
+          <>
+            <FormInput
+              key="email"
+              name="email"
+              textInputLabel={t('general.email_label')}
+              placeholder={t('general.email_placeholder')}
+            />
+            <Button
+              mt="sm"
+              alignSelf="flex-end"
+              rightIcon={<Icon name="chevron-right" />}
+              onPress={handleSubmit}
+              disabled={!isValid || isValidating || isSubmitting}
+              _text={{textTransform: 'uppercase'}}>
+              {t('general.next')}
+            </Button>
+          </>
+        );
+      }}
+    </Formik>
   );
 };

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -32,6 +32,7 @@ import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
 
@@ -47,7 +48,6 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   // wanting to add multiple users at the same time.
 
   // const keyboardOpen = useKeyboardOpen();
-  // const navigation = useNavigation();
   // const dispatch = useDispatch();
   const projectName = useSelector(
     state => state.project.projects[projectId]?.name,
@@ -78,6 +78,7 @@ type UserOrError = SimpleUserInfo | {type: UserInProjectError};
 
 const AddTeamMemberForm = ({projectId}: FormProps) => {
   const {t} = useTranslation();
+  const navigation = useNavigation();
 
   const onNext = async (
     values: FormValues,
@@ -90,28 +91,14 @@ const AddTeamMemberForm = ({projectId}: FormProps) => {
     );
     // Backend returned errors
     if (validationResult !== undefined) {
-      const errors = {email: validationResult};
-      formikHelpers.setErrors(errors);
+      const error = {email: validationResult};
+      formikHelpers.setErrors(error);
     }
     // Success
     else {
+      const user = userOrError as SimpleUserInfo;
+      navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
       // TODO-cknipe: Go to the next screen, pass it the SimpleUserInfo
-      // Do this on the next screen:
-      // const submitUsers = async () => {
-      //   setIsSubmitting(true);
-      //   for (const {
-      //     user: {id: userId},
-      //     role,
-      //   } of Object.values(userRecord)) {
-      //     try {
-      //       dispatch(addUserToProject({userId, role, projectId}));
-      //     } catch (e) {
-      //       console.error(e);
-      //     }
-      //   }
-      //   navigation.pop();
-      //   setIsSubmitting(false);
-      // };
     }
   };
 

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -17,22 +17,10 @@
 
 import {useTranslation} from 'react-i18next';
 
-import {Formik, FormikHelpers} from 'formik';
-import {Button} from 'native-base';
-import * as yup from 'yup';
-
-import {
-  checkUserInProject,
-  UserInProjectError,
-} from 'terraso-client-shared/account/accountService';
-import {SimpleUserInfo} from 'terraso-client-shared/account/accountSlice';
-
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
-import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
-import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {AddTeamMemberForm} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/AddTeamMemberForm';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
 
@@ -60,103 +48,5 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
         </Box>
       </ScreenContentSection>
     </ScreenScaffold>
-  );
-};
-
-// TODO-cknipe: Move this to new file?
-type FormValues = {
-  email: string;
-};
-
-type FormProps = {
-  projectId: string;
-};
-
-type UserOrError = SimpleUserInfo | {type: UserInProjectError};
-
-const AddTeamMemberForm = ({projectId}: FormProps) => {
-  const {t} = useTranslation();
-  const navigation = useNavigation();
-
-  const onNext = async (
-    values: FormValues,
-    formikHelpers: FormikHelpers<FormValues>,
-  ) => {
-    const userOrError = await checkUserInProject(projectId, values.email);
-    const validationResult = createBackendValidationErrorMessage(
-      values.email,
-      userOrError,
-    );
-    // Backend returned errors
-    if (validationResult !== undefined) {
-      const error = {email: validationResult};
-      formikHelpers.setErrors(error);
-    }
-    // Success
-    else {
-      const user = userOrError as SimpleUserInfo;
-      navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
-    }
-  };
-
-  const createBackendValidationErrorMessage = (
-    email: string,
-    userOrError: UserOrError,
-  ) => {
-    if ('type' in userOrError) {
-      switch (userOrError.type) {
-        case 'NoUser':
-          return t('projects.add_user.user_does_not_exist', {
-            email: email,
-          });
-        case 'InProject':
-          return t('projects.add_user.user_in_project', {email: email});
-      }
-    }
-    return undefined;
-  };
-
-  const validationSchema = yup.object().shape({
-    email: yup
-      .string()
-      .required(t('projects.add_user.empty_email'))
-      .email(t('projects.add_user.invalid_email')),
-  });
-
-  return (
-    <Formik
-      initialValues={{email: ''}}
-      validationSchema={validationSchema}
-      validateOnMount={true}
-      initialTouched={{
-        email: true,
-      }}
-      onSubmit={(values, formikHelpers) => onNext(values, formikHelpers)}>
-      {({handleSubmit, isValid, isSubmitting}) => {
-        return (
-          <>
-            <Box minHeight="84px">
-              <FormInput
-                key="email"
-                name="email"
-                textInputLabel={t('general.email_label')}
-                placeholder={t('general.email_placeholder')}
-                autoComplete="email"
-                keyboardType="email-address"
-              />
-            </Box>
-            <Button
-              mt="sm"
-              alignSelf="flex-end"
-              rightIcon={<Icon name="chevron-right" />}
-              onPress={handleSubmit}
-              isDisabled={!isValid || isSubmitting}
-              _text={{textTransform: 'uppercase'}}>
-              {t('general.next')}
-            </Button>
-          </>
-        );
-      }}
-    </Formik>
   );
 };

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -213,7 +213,7 @@ const AddTeamMemberForm = ({projectId}: FormProps) => {
               alignSelf="flex-end"
               rightIcon={<Icon name="chevron-right" />}
               onPress={handleSubmit}
-              disabled={!isValid || isValidating || isSubmitting}
+              isDisabled={!isValid || isValidating || isSubmitting}
               _text={{textTransform: 'uppercase'}}>
               {t('general.next')}
             </Button>

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -43,15 +43,13 @@ type Props = {
 export const AddUserToProjectScreen = ({projectId}: Props) => {
   const {t} = useTranslation();
 
-  // FYI: There was previously a mechanism to enter emails individually, but set roles at the same time.
-  // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
-  // wanting to add multiple users at the same time.
-
-  // const keyboardOpen = useKeyboardOpen();
-  // const dispatch = useDispatch();
   const projectName = useSelector(
     state => state.project.projects[projectId]?.name,
   );
+
+  // FYI: There was previously a mechanism to enter emails individually, but set roles at the same time.
+  // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
+  // wanting to add multiple users at the same time.
 
   return (
     <ScreenScaffold AppBar={<AppBar title={projectName} />}>
@@ -98,7 +96,6 @@ const AddTeamMemberForm = ({projectId}: FormProps) => {
     else {
       const user = userOrError as SimpleUserInfo;
       navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
-      // TODO-cknipe: Go to the next screen, pass it the SimpleUserInfo
     }
   };
 
@@ -138,12 +135,16 @@ const AddTeamMemberForm = ({projectId}: FormProps) => {
       {({handleSubmit, isValid, isSubmitting}) => {
         return (
           <>
-            <FormInput
-              key="email"
-              name="email"
-              textInputLabel={t('general.email_label')}
-              placeholder={t('general.email_placeholder')}
-            />
+            <Box minHeight="84px">
+              <FormInput
+                key="email"
+                name="email"
+                textInputLabel={t('general.email_label')}
+                placeholder={t('general.email_placeholder')}
+                autoComplete="email"
+                keyboardType="email-address"
+              />
+            </Box>
             <Button
               mt="sm"
               alignSelf="flex-end"

--- a/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
@@ -25,12 +25,12 @@ import {
   checkUserInProject,
   UserInProjectError,
 } from 'terraso-client-shared/account/accountService';
-import {SimpleUserInfo} from 'terraso-client-shared/account/accountSlice';
 
 import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {UserFields} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/UserDisplay';
 
 type FormValues = {
   email: string;
@@ -40,7 +40,7 @@ type FormProps = {
   projectId: string;
 };
 
-type UserOrError = SimpleUserInfo | {type: UserInProjectError};
+type UserOrError = UserFields | {type: UserInProjectError};
 
 export const AddTeamMemberForm = ({projectId}: FormProps) => {
   const {t} = useTranslation();
@@ -62,7 +62,7 @@ export const AddTeamMemberForm = ({projectId}: FormProps) => {
     }
     // Success
     else {
-      const user = userOrError as SimpleUserInfo;
+      const user = userOrError as UserFields;
       navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
     }
   };

--- a/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
@@ -50,20 +50,24 @@ export const AddTeamMemberForm = ({projectId}: FormProps) => {
     values: FormValues,
     formikHelpers: FormikHelpers<FormValues>,
   ) => {
-    const userOrError = await checkUserInProject(projectId, values.email);
-    const validationResult = createBackendValidationErrorMessage(
-      values.email,
-      userOrError,
-    );
-    // Backend returned errors
-    if (validationResult !== undefined) {
-      const error = {email: validationResult};
-      formikHelpers.setErrors(error);
-    }
-    // Success
-    else {
-      const user = userOrError as UserFields;
-      navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
+    try {
+      const userOrError = await checkUserInProject(projectId, values.email);
+      const validationResult = createBackendValidationErrorMessage(
+        values.email,
+        userOrError,
+      );
+      // Backend returned errors
+      if (validationResult !== undefined) {
+        const error = {email: validationResult};
+        formikHelpers.setErrors(error);
+      }
+      // Success
+      else {
+        const user = userOrError as UserFields;
+        navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
+      }
+    } catch (e) {
+      console.error(e);
     }
   };
 
@@ -109,8 +113,9 @@ export const AddTeamMemberForm = ({projectId}: FormProps) => {
                 name="email"
                 textInputLabel={t('general.email_label')}
                 placeholder={t('general.email_placeholder')}
-                autoComplete="email"
                 keyboardType="email-address"
+                autoComplete="email"
+                autoCapitalize="none"
               />
             </Box>
             <Button

--- a/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
@@ -91,7 +91,7 @@ export const AddTeamMemberForm = ({projectId}: FormProps) => {
   const validationSchema = yup.object().shape({
     email: yup
       .string()
-      .required(t('projects.add_user.empty_email'))
+      .required(t('projects.add_user.invalid_email'))
       .email(t('projects.add_user.invalid_email')),
   });
 

--- a/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+
+import {Formik, FormikHelpers} from 'formik';
+import {Button} from 'native-base';
+import * as yup from 'yup';
+
+import {
+  checkUserInProject,
+  UserInProjectError,
+} from 'terraso-client-shared/account/accountService';
+import {SimpleUserInfo} from 'terraso-client-shared/account/accountSlice';
+
+import {FormInput} from 'terraso-mobile-client/components/form/FormInput';
+import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+
+type FormValues = {
+  email: string;
+};
+
+type FormProps = {
+  projectId: string;
+};
+
+type UserOrError = SimpleUserInfo | {type: UserInProjectError};
+
+export const AddTeamMemberForm = ({projectId}: FormProps) => {
+  const {t} = useTranslation();
+  const navigation = useNavigation();
+
+  const onNext = async (
+    values: FormValues,
+    formikHelpers: FormikHelpers<FormValues>,
+  ) => {
+    const userOrError = await checkUserInProject(projectId, values.email);
+    const validationResult = createBackendValidationErrorMessage(
+      values.email,
+      userOrError,
+    );
+    // Backend returned errors
+    if (validationResult !== undefined) {
+      const error = {email: validationResult};
+      formikHelpers.setErrors(error);
+    }
+    // Success
+    else {
+      const user = userOrError as SimpleUserInfo;
+      navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, user});
+    }
+  };
+
+  const createBackendValidationErrorMessage = (
+    email: string,
+    userOrError: UserOrError,
+  ) => {
+    if ('type' in userOrError) {
+      switch (userOrError.type) {
+        case 'NoUser':
+          return t('projects.add_user.user_does_not_exist', {
+            email: email,
+          });
+        case 'InProject':
+          return t('projects.add_user.user_in_project', {email: email});
+      }
+    }
+    return undefined;
+  };
+
+  const validationSchema = yup.object().shape({
+    email: yup
+      .string()
+      .required(t('projects.add_user.empty_email'))
+      .email(t('projects.add_user.invalid_email')),
+  });
+
+  return (
+    <Formik
+      initialValues={{email: ''}}
+      validationSchema={validationSchema}
+      validateOnMount={true}
+      initialTouched={{
+        email: true,
+      }}
+      onSubmit={(values, formikHelpers) => onNext(values, formikHelpers)}>
+      {({handleSubmit, isValid, isSubmitting}) => {
+        return (
+          <>
+            <Box minHeight="84px">
+              <FormInput
+                key="email"
+                name="email"
+                textInputLabel={t('general.email_label')}
+                placeholder={t('general.email_placeholder')}
+                autoComplete="email"
+                keyboardType="email-address"
+              />
+            </Box>
+            <Button
+              mt="sm"
+              alignSelf="flex-end"
+              rightIcon={<Icon name="chevron-right" />}
+              onPress={handleSubmit}
+              isDisabled={!isValid || isSubmitting}
+              _text={{textTransform: 'uppercase'}}>
+              {t('general.next')}
+            </Button>
+          </>
+        );
+      }}
+    </Formik>
+  );
+};

--- a/dev-client/src/screens/AddUserToProjectScreen/components/MinimalUserDisplay.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/MinimalUserDisplay.tsx
@@ -19,16 +19,13 @@ import {useTranslation} from 'react-i18next';
 
 import {Image} from 'native-base';
 
-import {User} from 'terraso-client-shared/account/accountSlice';
-
 import {
   Column,
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {UserFields} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/UserDisplay';
 import {formatName} from 'terraso-mobile-client/util';
-
-export type UserFields = Omit<User, 'preferences'>;
 
 type DisplayProps = {
   user: UserFields;

--- a/dev-client/src/screens/AddUserToProjectScreen/components/ProjectRoleRadioBlock.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/ProjectRoleRadioBlock.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+
+import {ProjectMembershipProjectRoleChoices} from 'terraso-client-shared/graphqlSchema/graphql';
+import {ProjectRole} from 'terraso-client-shared/project/projectSlice';
+
+import {
+  Column,
+  Heading,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
+
+export type Props = {
+  onChange: (value: ProjectMembershipProjectRoleChoices) => void;
+  selectedRole: ProjectMembershipProjectRoleChoices;
+};
+
+export const ProjectRoleRadioBlock = ({onChange, selectedRole}: Props) => {
+  const {t} = useTranslation();
+  return (
+    <Column>
+      <Heading variant="h6">{t('projects.manage_member.project_role')}</Heading>
+      <RadioBlock<ProjectRole>
+        labelProps={{variant: 'secondary'}}
+        options={{
+          VIEWER: {
+            text: t('general.role.VIEWER'),
+            helpText: t('projects.manage_member.viewer_help'),
+          },
+          CONTRIBUTOR: {
+            text: t('general.role.CONTRIBUTOR'),
+            helpText: t('projects.manage_member.contributor_help'),
+          },
+          MANAGER: {
+            text: t('general.role.MANAGER'),
+            helpText: t('projects.manage_member.manager_help'),
+          },
+        }}
+        groupProps={{
+          onChange: onChange,
+          value: selectedRole,
+          name: 'selected-role',
+        }}
+      />
+    </Column>
+  );
+};

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -309,18 +309,16 @@
     "add_user": {
       "heading": "Add Team Member",
       "help_text": "Enter the email address of the person’s Terraso account. A Terraso account can be created by installing the LandPKS Soil ID app and signing in.",
-      "user_does_not_exist": "User {{email}} is not a Terraso user, unable to add to project.",
-      "user_in_project": "User {{email}} is already a member of this project.",
-      "already_added": "User {{email}} already added to user list.",
-      "empty_email": "Please enter an email",
-      "invalid_email": "Not a valid email"
+      "user_does_not_exist": "No Terraso account found",
+      "user_in_project": "Already a team member",
+      "invalid_email": "Enter a valid email address"
     },
     "manage_member": {
       "title": "Manage Team Member",
       "project_role": "Project Role",
-      "manager_help": "Can view and edit all aspects of the projects and its affiliated sites.",
-      "contributor_help": "Can view, add, and edit site data.",
-      "viewer_help": "Can view site data.",
+      "manager_help": "Can view and edit all aspects of the project and its affiliated sites",
+      "contributor_help": "Can view, add, and edit site data",
+      "viewer_help": "Can view site data",
       "remove": "Remove from project",
       "remove_help": "Remove the team member's access to this project, retaining any data contributed to sites",
       "confirm_removal_title": "Remove from Project?",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -307,12 +307,13 @@
       }
     },
     "add_user": {
-      "heading": "Add Team Members",
-      "help_text": "Enter a Terraso email address",
+      "heading": "Add Team Member",
+      "help_text": "Enter the email address associated with the person’s Terraso account. A Terraso account can be created by installing the LandPKS Soil ID app and signing in.",
       "user_does_not_exist": "User {{email}} is not a Terraso user, unable to add to project.",
       "user_in_project": "User {{email}} is already a member of this project.",
       "already_added": "User {{email}} already added to user list.",
-      "empty_email": "Enter an email address"
+      "empty_email": "Please enter an email",
+      "invalid_email": "Not a valid email"
     },
     "manage_member": {
       "title": "Manage Team Member",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -308,7 +308,7 @@
     },
     "add_user": {
       "heading": "Add Team Member",
-      "help_text": "Enter the email address associated with the person’s Terraso account. A Terraso account can be created by installing the LandPKS Soil ID app and signing in.",
+      "help_text": "Enter the email address of the person’s Terraso account. A Terraso account can be created by installing the LandPKS Soil ID app and signing in.",
       "user_does_not_exist": "User {{email}} is not a Terraso user, unable to add to project.",
       "user_in_project": "User {{email}} is already a member of this project.",
       "already_added": "User {{email}} already added to user list.",


### PR DESCRIPTION
## Description
From acceptance criteria of #1447:
- 1st "Add Team Member" screen:
    - Update design upon first opening the screen 
    - Use new up-to-spec TextInput component
    - Red text "Required" shows up when nothing there (do we want this?)
    - Red text shows up when email is invalid email
    - Next button is disabled until email address has a valid email format entry
    - Next button triggers backend validation and shows error message if email is not a terraso user or already in the project
    - Next button goes to the 2nd screen if email is a terraso user who's not already in the project
    - User can't get to this screen unless they're a Manager role
- 2nd "Add Team Member" screen (to choose role):
    - Looks very similar to "Manage Team Member" screen
    - Back arrow in app bar goes back to 1st "Add Team Member" screen, with email address filled out
    - Cancel button navigates back to 1st "Add Team Member" screen, with email address filled out
    - Add button adds user and navigates back to "Project Team" screen

### Related Issues
Implements #1447 
