### PR TITLE
fix: spacing on deletion screen text per design request

### DIFF
--- a/dev-client/src/screens/DeleteAccountScreen/components/DeleteAccountConfirmContent.tsx
+++ b/dev-client/src/screens/DeleteAccountScreen/components/DeleteAccountConfirmContent.tsx
@@ -46,8 +46,6 @@ export function DeleteAccountConfirmContent({
             'delete_account.confirm.p2.b1',
           ]}
         />
-      </View>
-      <View>
         <TranslatedParagraph i18nKey="delete_account.confirm.p3" />
         <TranslatedBulletList
           i18nKeys={[


### PR DESCRIPTION
## Description

Reorder elements in deletion screen to adjust spacing, per design request.

### Related Issues
Feedback on #1263

### Verification steps

Open deletion screen and verify that there is less spacing between the bullet-point section and the paragraph below.
