### PR TITLE
fix: Slightly increase width of soil match tile score 

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
@@ -37,11 +37,9 @@ export const SoilMatchTile = ({soil_name, score, onPress}: Props) => {
         justifyContent="space-between"
         my="4px"
         py="4px">
-        <Box marginHorizontal="16px" width="78px" justifyContent="center">
+        <Box marginHorizontal="16px" width="84px" justifyContent="center">
           <Text
             variant="score-tile"
-            size="30px"
-            fontWeight={400}
             color="primary.lighter"
             textAlign="center"
             mb="-6px">


### PR DESCRIPTION
To prevent 100% match score from wrapping on some devices with default font size
Don't love this as a solution, but couldn't come up with something quick and better. Talked with Courtney and we figured we'd just try this for now.

Also remove styling that is already specified via the Text variant

### Related Issues
Addresses comments of [#1197](https://github.com/techmatters/terraso-mobile-client/issues/1197)