### PR TITLE
fix: correct behavior of site card menu on project management screen

### DIFF
--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -15,13 +15,14 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
+import {Menu} from 'react-native-paper';
 
 import {MaterialTopTabScreenProps} from '@react-navigation/material-top-tabs';
 import type {CompositeScreenProps} from '@react-navigation/native';
 import {createSelector} from '@reduxjs/toolkit';
-import {Button, FlatList, Menu, Pressable} from 'native-base';
+import {Button, FlatList} from 'native-base';
 
 import {
   Project,
@@ -47,7 +48,6 @@ import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal
 import {
   Box,
   Column,
-  Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
@@ -63,23 +63,6 @@ import {AppState, useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {theme} from 'terraso-mobile-client/theme';
 import {searchText} from 'terraso-mobile-client/util';
 
-type SiteMenuProps = {
-  text: string;
-  onPress?: () => void;
-};
-
-const SiteMenuItem = ({text, onPress}: SiteMenuProps) => {
-  return (
-    <Menu.Item>
-      <Pressable onPress={onPress}>
-        <Row flexDirection="row" space={2} alignItems="center">
-          <Text>{text}</Text>
-        </Row>
-      </Pressable>
-    </Menu.Item>
-  );
-};
-
 type SiteProps = {
   site: Site;
 };
@@ -87,6 +70,9 @@ type SiteProps = {
 const SiteMenu = ({site}: SiteProps) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
+  const [visible, setVisible] = useState(false);
+  const openMenu = () => setVisible(true);
+  const closeMenu = () => setVisible(false);
 
   const deleteSiteCallback = async () => {
     await dispatch(deleteSite(site));
@@ -100,32 +86,42 @@ const SiteMenu = ({site}: SiteProps) => {
 
   return (
     <Menu
-      closeOnSelect={true}
-      trigger={triggerProps => (
-        <IconButton name="more-vert" {...triggerProps} />
-      )}>
+      contentStyle={{
+        backgroundColor: theme.colors.background.default,
+      }}
+      visible={visible}
+      onDismiss={closeMenu}
+      anchor={<IconButton onPress={openMenu} name="more-vert" />}>
       <ConfirmModal
-        trigger={onOpen => (
-          <SiteMenuItem
-            text={t('projects.sites.remove_site')}
-            onPress={onOpen}
-          />
-        )}
+        trigger={onOpen => {
+          return (
+            <Menu.Item
+              title={t('projects.sites.remove_site')}
+              onPress={onOpen}
+              titleStyle={MENU_ITEM_STYLE}
+            />
+          );
+        }}
         title={t('projects.sites.remove_site_modal.title')}
-        body={t('projects.sites.remove_site_modal.body', {siteName: site.name})}
+        body={t('projects.sites.remove_site_modal.body', {
+          siteName: site.name,
+        })}
         actionName={t('projects.sites.remove_site_modal.action_name')}
         handleConfirm={removeSiteFromProjectCallback}
       />
 
       <ConfirmModal
         trigger={onOpen => (
-          <SiteMenuItem
+          <Menu.Item
+            title={t('projects.sites.delete_site')}
             onPress={onOpen}
-            text={t('projects.sites.delete_site')}
+            titleStyle={MENU_ITEM_STYLE}
           />
         )}
         title={t('projects.sites.delete_site_modal.title')}
-        body={t('projects.sites.delete_site_modal.body', {siteName: site.name})}
+        body={t('projects.sites.delete_site_modal.body', {
+          siteName: site.name,
+        })}
         actionName={t('projects.sites.delete_site_modal.action_name')}
         handleConfirm={deleteSiteCallback}
       />
@@ -289,3 +285,7 @@ export function ProjectSitesScreen({
     </Column>
   );
 }
+
+const MENU_ITEM_STYLE = {
+  fontSize: 18,
+};

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -97,6 +97,7 @@ const SiteMenu = ({site}: SiteProps) => {
           return (
             <Menu.Item
               title={t('projects.sites.remove_site')}
+              leadingIcon="remove"
               onPress={onOpen}
               titleStyle={MENU_ITEM_STYLE}
             />
@@ -114,6 +115,7 @@ const SiteMenu = ({site}: SiteProps) => {
         trigger={onOpen => (
           <Menu.Item
             title={t('projects.sites.delete_site')}
+            leadingIcon="delete"
             onPress={onOpen}
             titleStyle={MENU_ITEM_STYLE}
           />

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -103,7 +103,7 @@ const SiteMenu = ({site}: SiteProps) => {
           return (
             <Menu.Item
               title={t('projects.sites.remove_site')}
-              leadingIcon="remove"
+              leadingIcon="minus"
               onPress={onOpen}
               titleStyle={MENU_ITEM_STYLE}
             />

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -91,7 +91,13 @@ const SiteMenu = ({site}: SiteProps) => {
       }}
       visible={visible}
       onDismiss={closeMenu}
-      anchor={<IconButton onPress={openMenu} name="more-vert" />}>
+      anchor={
+        <IconButton
+          onPress={openMenu}
+          _pressed={{backgroundColor: 'primary.lighter'}}
+          name="more-vert"
+        />
+      }>
       <ConfirmModal
         trigger={onOpen => {
           return (

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -94,7 +94,10 @@ const SiteMenu = ({site}: SiteProps) => {
       anchor={
         <IconButton
           onPress={openMenu}
-          _pressed={{backgroundColor: 'primary.lighter'}}
+          _pressed={{
+            backgroundColor: 'background.default',
+            color: 'primary.dark',
+          }}
           name="more-vert"
         />
       }>

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -34,7 +34,6 @@ import {
 } from 'terraso-client-shared/site/siteSlice';
 import {normalizeText} from 'terraso-client-shared/utils';
 
-import {Icon, IconName} from 'terraso-mobile-client/components/icons/Icon';
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
 import {
   ListFilterModal,
@@ -65,17 +64,15 @@ import {theme} from 'terraso-mobile-client/theme';
 import {searchText} from 'terraso-mobile-client/util';
 
 type SiteMenuProps = {
-  iconName: IconName;
   text: string;
   onPress?: () => void;
 };
 
-const SiteMenuItem = ({iconName, text, onPress}: SiteMenuProps) => {
+const SiteMenuItem = ({text, onPress}: SiteMenuProps) => {
   return (
     <Menu.Item>
       <Pressable onPress={onPress}>
         <Row flexDirection="row" space={2} alignItems="center">
-          <Icon name={iconName} size="xs" />
           <Text>{text}</Text>
         </Row>
       </Pressable>
@@ -110,7 +107,6 @@ const SiteMenu = ({site}: SiteProps) => {
       <ConfirmModal
         trigger={onOpen => (
           <SiteMenuItem
-            iconName="remove"
             text={t('projects.sites.remove_site')}
             onPress={onOpen}
           />
@@ -124,7 +120,6 @@ const SiteMenu = ({site}: SiteProps) => {
       <ConfirmModal
         trigger={onOpen => (
           <SiteMenuItem
-            iconName="delete"
             onPress={onOpen}
             text={t('projects.sites.delete_site')}
           />


### PR DESCRIPTION
## Description
Correct behavior of site card menu on project management screen
- remove dot beside "delete site" menu item
- don't block dialog with menu (Android)
- don't crash (iOS)

Use React Native Paper instead of NativeBase.

### Related Issues
Addresses #1592.