### PR TITLE
fix: get SENTRY_ORG and SENTRY_PROJECT from vars instead of inputs

### DIFF
--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -21,14 +21,6 @@ on:
         required: false
         type: string
         default: 'v1'
-      SENTRY_ORG:
-        required: false
-        type: string
-        default: 'techmatters'
-      SENTRY_PROJECT:
-        required: false
-        type: string
-        default: 'terraso-lpks'
     secrets:
       MAPBOX_DOWNLOADS_TOKEN:
         required: true
@@ -77,8 +69,8 @@ jobs:
       SENTRY_ENABLED: ${{ vars.SENTRY_ENABLED }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DISABLE_AUTO_UPLOAD: ${{ inputs.upload == 'false' && 'true' || 'false' }}
-      SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
+      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 
     steps:
       - name: Check out git repository

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -21,14 +21,6 @@ on:
         required: false
         type: string
         default: 'v1'
-      SENTRY_ORG:
-        required: false
-        type: string
-        default: 'techmatters'
-      SENTRY_PROJECT:
-        required: false
-        type: string
-        default: 'terraso-lpks'
     secrets:
       MAPBOX_DOWNLOADS_TOKEN:
         required: true
@@ -81,8 +73,8 @@ jobs:
       SENTRY_ENABLED: ${{ vars.SENTRY_ENABLED }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DISABLE_AUTO_UPLOAD: ${{ inputs.upload == 'false' && 'true' || 'false' }}
-      SENTRY_ORG: ${{ inputs.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ inputs.SENTRY_PROJECT }}
+      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       CLANG: clang
       CLANGPLUSPLUS: clang++
       LD: clang

--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -41,8 +41,6 @@ const validateEnvConfig = <K extends string>(
   );
 
 const BUILD_CONFIG = validateEnvConfig(process.env, [
-  'SENTRY_ORG',
-  'SENTRY_PROJECT',
   'MAPBOX_DOWNLOADS_TOKEN',
 ] as const);
 
@@ -53,6 +51,8 @@ const ENV_CONFIG = validateEnvConfig(process.env, [
   'PUBLIC_MAPBOX_TOKEN',
   'SENTRY_DSN',
   'SENTRY_ENABLED',
+  'SENTRY_ORG',
+  'SENTRY_PROJECT',
   'TERRASO_BACKEND',
   'GOOGLE_OAUTH_ANDROID_CLIENT_ID',
   'GOOGLE_OAUTH_IOS_CLIENT_ID',
@@ -130,8 +130,8 @@ export default ({config}: ConfigContext): ExpoConfig => ({
     [
       '@sentry/react-native/expo',
       {
-        organization: BUILD_CONFIG.SENTRY_ORG,
-        project: BUILD_CONFIG.SENTRY_PROJECT,
+        organization: ENV_CONFIG.SENTRY_ORG,
+        project: ENV_CONFIG.SENTRY_PROJECT,
       },
     ],
     [


### PR DESCRIPTION
## Description
When building for iOS and Android, get SENTRY_ORG and SENTRY_PROJECT from vars instead of inputs.