### PR TITLE
fix: Restyle 'Remove from project' button on Manage Team Member screen

### DIFF
--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -122,14 +122,12 @@ export const ManageTeamMemberScreen = ({
           <ConfirmModal
             trigger={onOpen => (
               <Button
-                size="sm"
+                size="lg"
                 variant="ghost"
-                alignSelf="start"
-                width="70%"
+                alignSelf="flex-start"
                 onPress={onOpen}
-                _text={{color: 'error.main'}}
+                _text={{color: 'error.main', textTransform: 'uppercase'}}
                 _pressed={{backgroundColor: 'red.100'}}
-                textTransform="uppercase"
                 leftIcon={<Icon name="delete" color="error.main" />}>
                 {t('projects.manage_member.remove')}
               </Button>


### PR DESCRIPTION
## Description
Still not exactly consistent / unified with all the other buttons of its type, but at least looks like the spec for Capri

### Related Issues
Sorta mentioned in #1447, though it's pretty tangential honestly

Before: 
![Screenshot 2024-06-20 at 2 59 56 PM](https://github.com/techmatters/terraso-mobile-client/assets/5590815/f7b7bb60-5e43-422e-814f-5a4d079b8cdc) 
After: 
![Screenshot 2024-06-20 at 3 32 33 PM](https://github.com/techmatters/terraso-mobile-client/assets/5590815/acb8216c-0816-4560-ae04-c2f8912e7a52)