### PR TITLE
fix: url for landpks data portal

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -428,7 +428,7 @@
       "privacy_item2": "All data entered into the LandPKS mobile app is included, except for personally identifiable information (PII).",
       "privacy_item3": "<bold>A private site</bold> not affiliated with a project is only visible to the person who created it. That person can change the privacy at any time. ",
       "privacy_item4": "<bold>A project’s privacy setting determines the privacy of its affiliated sites.</bold> Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time. ",
-      "data_portal_link_url": "https://landpotential.org/",
+      "data_portal_link_url": "https://landpks.terraso.org/portal",
       "data_portal_link_text": "LandPKS Data Portal",
       "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
       "privacy_policy_link_text": "Read more about our data privacy policy."


### PR DESCRIPTION
## Description

Make URL on privacy sheet match request from design. Note that the URL itself is not yet valid on the terraso.org site, but this will be its location at launch.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #755

### Verification steps

Open privacy sheet and verify that expected URL is opened from portal link.