### PR TITLE
fix: filter projects by role for site transfer selection

### DIFF
--- a/dev-client/src/components/ProjectSelect.tsx
+++ b/dev-client/src/components/ProjectSelect.tsx
@@ -35,9 +35,12 @@ export const ProjectSelect = ({projectId, userRoles, setProjectId}: Props) => {
   const projects = useSelector(state => state.project.projects);
   const rolesFilter = useProjectUserRolesFilter(userRoles);
   const projectIdList = useMemo(
-    () => Object.values(projects).filter(project => rolesFilter(project)),
+    () =>
+      Object.values(projects)
+        .filter(project => rolesFilter(project))
+        .map(project => project.id),
     [projects, rolesFilter],
-  ).map(project => project.id);
+  );
 
   const renderProject = useCallback(
     (id: string) => projects[id].name,

--- a/dev-client/src/components/ProjectSelect.tsx
+++ b/dev-client/src/components/ProjectSelect.tsx
@@ -18,18 +18,27 @@
 import {useCallback, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
+import {ProjectRole} from 'terraso-client-shared/project/projectSlice';
+
 import {Select} from 'terraso-mobile-client/components/inputs/Select';
+import {useProjectUserRolesFilter} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useSelector} from 'terraso-mobile-client/store';
 
 type Props = {
   projectId: string | null;
+  userRoles?: ProjectRole[];
   setProjectId: (projectId: string | null) => void;
 };
 
-export const ProjectSelect = ({projectId, setProjectId}: Props) => {
+export const ProjectSelect = ({projectId, userRoles, setProjectId}: Props) => {
   const {t} = useTranslation();
   const projects = useSelector(state => state.project.projects);
-  const projectList = useMemo(() => Object.keys(projects), [projects]);
+  const rolesFilter = useProjectUserRolesFilter(userRoles);
+  const projectIdList = useMemo(
+    () => Object.values(projects).filter(project => rolesFilter(project)),
+    [projects, rolesFilter],
+  ).map(project => project.id);
+
   const renderProject = useCallback(
     (id: string) => projects[id].name,
     [projects],
@@ -38,7 +47,7 @@ export const ProjectSelect = ({projectId, setProjectId}: Props) => {
   return (
     <Select
       nullable
-      options={projectList}
+      options={projectIdList}
       label={t('site.create.add_to_project_caption')}
       value={projectId}
       onValueChange={setProjectId}

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -31,7 +31,7 @@ export const useProjectUserRolesFilter = (
        * Filter returns whether we can find a membership for the project
        * that matches the current user and has a role in the accepted list
        */
-      !!Object.values(project.memberships).find(
+      Boolean(Object.values(project.memberships).find(
         membership =>
           currentUser?.id === membership.userId &&
           userRoles.includes(membership.userRole),

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -34,7 +34,7 @@ export const useProjectUserRolesFilter = (
       !!Object.values(project.memberships).find(
         membership =>
           currentUser?.id === membership.userId &&
-          userRoles.indexOf(membership.userRole) >= 0,
+          userRoles.includes(membership.userRole),
       );
   } else {
     return _ => true;

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -27,9 +27,13 @@ export const useProjectUserRolesFilter = (
   const currentUser = useSelector(state => state.account.currentUser.data);
   if (userRoles) {
     return project =>
+      /*
+       * Filter returns whether we can find a membership for the project
+       * that matches the current user and has a role in the accepted list
+       */
       !!Object.values(project.memberships).find(
         membership =>
-          membership.userId === currentUser?.id &&
+          currentUser?.id === membership.userId &&
           userRoles.indexOf(membership.userRole) >= 0,
       );
   } else {

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Project, ProjectRole} from 'terraso-client-shared/project/projectSlice';
+
+import {useSelector} from 'terraso-mobile-client/store';
+
+type ProjectFilter = (project: Project) => boolean;
+
+export const useProjectUserRolesFilter = (
+  userRoles?: ProjectRole[],
+): ProjectFilter => {
+  const currentUser = useSelector(state => state.account.currentUser.data);
+  if (userRoles) {
+    return project =>
+      !!Object.values(project.memberships).find(
+        membership =>
+          membership.userId === currentUser?.id &&
+          userRoles.indexOf(membership.userRole) >= 0,
+      );
+  } else {
+    return _ => true;
+  }
+};

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -31,10 +31,12 @@ export const useProjectUserRolesFilter = (
        * Filter returns whether we can find a membership for the project
        * that matches the current user and has a role in the accepted list
        */
-      Boolean(Object.values(project.memberships).find(
-        membership =>
-          currentUser?.id === membership.userId &&
-          userRoles.includes(membership.userRole),
+      Boolean(
+        Object.values(project.memberships).find(
+          membership =>
+            currentUser?.id === membership.userId &&
+            userRoles.includes(membership.userRole),
+        ),
       );
   } else {
     return _ => true;

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useCallback} from 'react';
+
 import {Project, ProjectRole} from 'terraso-client-shared/project/projectSlice';
 
 import {useSelector} from 'terraso-mobile-client/store';
@@ -25,20 +27,24 @@ export const useProjectUserRolesFilter = (
   userRoles?: ProjectRole[],
 ): ProjectFilter => {
   const currentUser = useSelector(state => state.account.currentUser.data);
-  if (userRoles) {
-    return project =>
+  return useCallback(
+    project => {
+      if (!userRoles) {
+        return true;
+      }
+
       /*
        * Filter returns whether we can find a membership for the project
        * that matches the current user and has a role in the accepted list
        */
-      Boolean(
+      return Boolean(
         Object.values(project.memberships).find(
           membership =>
             currentUser?.id === membership.userId &&
             userRoles.includes(membership.userRole),
         ),
       );
-  } else {
-    return _ => true;
-  }
+    },
+    [currentUser, userRoles],
+  );
 };

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -113,6 +113,7 @@ export const CreateSiteForm = ({
               </FormLabel>
               <ProjectSelect
                 projectId={values.projectId ?? null}
+                userRoles={['MANAGER', 'CONTRIBUTOR']}
                 setProjectId={projectId =>
                   setValues(current => ({
                     ...current,


### PR DESCRIPTION
## Description

Add a hook allowing us to filter projects based on the current user's role for the project, and use it in `ProjectSelect` and `CreateSiteForm` so that users aren't able to create sites for projects to which they cannot add.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#944

### Verification steps

Create a new site and verify that projects for which the current user is a viewer are not included in the select list, while projects for which the user is a manager or contributor are included.