### PR TITLE
fix: fix spacing/margins on soil id tile

### DIFF
--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -74,12 +74,7 @@ const LocationPrediction = ({
   const {t} = useTranslation();
 
   return (
-    <Box
-      variant="tile"
-      flexDirection="column"
-      alignItems="flex-start"
-      py="18px"
-      pl="16px">
+    <Box variant="tile" flexDirection="column" alignItems="flex-start" p="18px">
       <Row alignItems="center">
         <Box mr={15}>
           <StackedBarChart />
@@ -105,7 +100,7 @@ const LocationPrediction = ({
       </Text>
 
       <Button
-        w="95%"
+        w="100%"
         _text={{textTransform: 'uppercase'}}
         rightIcon={<Icon name="chevron-right" />}
         onPress={onExploreDataPress}>


### PR DESCRIPTION
## Description
fix spacing/margins on soil id tile:

<img width="323" alt="image" src="https://github.com/techmatters/terraso-mobile-client/assets/86784/91a63680-901e-4a93-aa4a-ffa134611949">

### Related Issues
Addresses #1652.