### PR TITLE
fix: site notes usability

### DIFF
--- a/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
@@ -71,9 +71,7 @@ export const SiteNoteCard = ({note}: Props) => {
         <Spacer />
         {canViewEditScreen && <Icon name="edit" color="primary.dark" />}
       </Row>
-      <Text pt={2} numberOfLines={3} ellipsizeMode="tail">
-        {note.content}
-      </Text>
+      <Text pt={2}>{note.content}</Text>
     </Card>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
@@ -23,7 +23,7 @@ import {Spacer} from 'native-base';
 import {SiteNote} from 'terraso-client-shared/site/siteSlice';
 
 import {Card} from 'terraso-mobile-client/components/Card';
-import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
+import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useSiteRoleContext} from 'terraso-mobile-client/context/SiteRoleContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -47,12 +47,10 @@ export const SiteNoteCard = ({note}: Props) => {
     currentUserIsAuthor || currentUserIsOwner || currentUserIsManager;
 
   const onEditNote = useCallback(() => {
-    navigation.navigate('EDIT_SITE_NOTE', {note: note});
-  }, [navigation, note]);
-
-  const onShowNote = useCallback(() => {
-    navigation.navigate('READ_NOTE', {content: note.content});
-  }, [navigation, note.content]);
+    if (canViewEditScreen) {
+      navigation.navigate('EDIT_SITE_NOTE', {note: note});
+    }
+  }, [navigation, canViewEditScreen, note]);
 
   return (
     <Card
@@ -62,7 +60,7 @@ export const SiteNoteCard = ({note}: Props) => {
       mb={3}
       ml={4}
       mr={4}
-      onPress={onShowNote}>
+      onPress={onEditNote}>
       <Row>
         <Text variant="body2" italic>
           {t('site.notes.note_attribution', {
@@ -71,17 +69,7 @@ export const SiteNoteCard = ({note}: Props) => {
           })}
         </Text>
         <Spacer />
-        {canViewEditScreen && (
-          <IconButton
-            p={0}
-            name="edit"
-            _icon={{
-              color: 'primary.dark',
-              size: '5',
-            }}
-            onPress={onEditNote}
-          />
-        )}
+        {canViewEditScreen && <Icon name="edit" color="primary.dark" />}
       </Row>
       <Text pt={2} numberOfLines={3} ellipsizeMode="tail">
         {note.content}


### PR DESCRIPTION
## Description

Per design feedback on #709, increase size of site note edit icon, change card press behavior to only open edit screen, and remove truncation from site notes (it still exists for pinned notes).

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#709

### Verification steps

Verify that tapping on a site note without edit permissions does nothing. Verify that multiline site notes are no longer truncated after 3 lines.