### PR TITLE
fix: Decrease font size of soil match percent, use adjustsFontSizeToFit

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
@@ -35,10 +35,10 @@ export const SoilMatchTile = ({soil_name, score, onPress}: Props) => {
         flexDirection="row"
         justifyContent="space-between"
         my="4px"
-        py="4px">
+        py="6px">
         <Box marginHorizontal="16px" width="84px" justifyContent="center">
           <Text
-            variant="score-tile"
+            variant="match-tile-score"
             color="primary.lighter"
             textAlign="center"
             mb="-6px">

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -430,6 +430,13 @@ export const theme = extendTheme({
           lineHeight: '27px',
           letterSpacing: '0.15px',
         },
+        'match-tile-score': {
+          fontWeight: 400,
+          fontSize: '24px',
+          lineHeight: '36px',
+          adjustsFontSizeToFit: true,
+          numberOfLines: 1,
+        },
       },
     },
     Heading: {


### PR DESCRIPTION
## Description
Another attempt at preventing the "100%" from wrapping (or truncating) -- this time by decreasing the font size and using adjustsfontSizeToFit onto one line.

### Related Issues
Addresses #1635 
However, I still don't understand why:
a) With 30px or 32px font size, we'd get "100" without the "%" sign, even with adjustsFontSizeToFit?
b) Why font size and Box width are both specified in fixed pixels but not 

Before --> After:
<img src="https://github.com/techmatters/terraso-mobile-client/assets/5590815/6d0eb9a0-4b01-40f4-ad8d-3c5aaaa0a3d0" width="250px"> --> <img src="https://github.com/techmatters/terraso-mobile-client/assets/5590815/1d137eb0-3eb2-4264-b5f2-0929673a022f" width="250px">

And also any individual percentage, like the "100%", will get smaller if it would overflow its box, like this (but note this is not the new 24px font size):
<img src="https://github.com/techmatters/terraso-mobile-client/assets/5590815/1376000d-362b-4dcb-b9b3-c9bad913ac7f" width="250px">
 
