### PR TITLE
fix: Remove 'Create Site Here' button on overlay sheet, add bottom margin

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilInfo/ScoreInfoContainer.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/ScoreInfoContainer.tsx
@@ -20,5 +20,9 @@ import {PropsWithChildren} from 'react';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 
 export function ScoreInfoContainer({children}: PropsWithChildren) {
-  return <Column space={6}>{children}</Column>;
+  return (
+    <Column space={6} mb="lg">
+      {children}
+    </Column>
+  );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
@@ -20,7 +20,6 @@ import {Divider} from 'react-native-paper';
 import {LocationBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
-import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {PropertiesDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/PropertiesDisplay';
 import {ScoreInfoContainer} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/ScoreInfoContainer';
@@ -50,7 +49,6 @@ export function TempScoreInfoContent({
       />
       <Divider />
       <PropertiesDisplay match={locationMatch} />
-      <CreateSiteButton coords={coords} />
     </ScoreInfoContainer>
   );
 }


### PR DESCRIPTION
## Description
Pressing the "Create Site Here" button would not close the soil info overlay sheet that it was on (though it would navigate to a different sheet underneath the open overlay sheet). This was undesirable. If we wanted to fix it, we could probably pass the button a ref to the overlay sheet to allow the button to close the overlay sheet on press, but Courtney suggested just removing the button. I think this makes sense because the soil info sheet is just specific to that soil, and if you want to create a site from that temporary location, you can just close the overlay sheet to access another "Create Site Here" button.

Also added a bit of margin at the bottom to let it breathe and not feel like the content is so close to the edge of the screen.

### Related Issues
Fixes [#1556](https://github.com/techmatters/terraso-mobile-client/issues/1556)


### Screenshot
<img src="https://github.com/techmatters/terraso-mobile-client/assets/5590815/2f93cfee-1d99-461c-afb8-b017f517698b" height="600">
