### PR TITLE
fix: validate soil id urls before allowing users to navigate to them

### DIFF
--- a/dev-client/src/components/links/ExternalLink.tsx
+++ b/dev-client/src/components/links/ExternalLink.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import React from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {Linking, Pressable, StyleSheet, View} from 'react-native';
 
 import {IconButton as NativeIconButton} from 'native-base';
@@ -26,6 +26,7 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {validateUrl} from 'terraso-mobile-client/util';
 
 export type ExternalLinkProps = {
   label: string;
@@ -38,23 +39,28 @@ export const ExternalLink = React.forwardRef(
       <NativeIconButton ref={ref} icon={<Icon name="open-in-new" />} />
     );
 
+    const isValidUrl = useMemo(() => validateUrl(url), [url]);
+    const openUrl = useCallback(() => Linking.openURL(url), [url]);
+
     return (
-      <View style={styles.container}>
-        <Pressable onPress={() => Linking.openURL(url)}>
-          <Box>
-            <Row alignItems="center">
-              <Text
-                color="primary.main"
-                fontSize="md"
-                textTransform="uppercase"
-                style={styles.label}>
-                {label}
-              </Text>
-              {icon}
-            </Row>
-          </Box>
-        </Pressable>
-      </View>
+      isValidUrl && (
+        <View style={styles.container}>
+          <Pressable onPress={openUrl}>
+            <Box>
+              <Row alignItems="center">
+                <Text
+                  color="primary.main"
+                  fontSize="md"
+                  textTransform="uppercase"
+                  style={styles.label}>
+                  {label}
+                </Text>
+                {icon}
+              </Row>
+            </Box>
+          </Pressable>
+        </View>
+      )
     );
   },
 );

--- a/dev-client/src/components/links/ExternalLink.tsx
+++ b/dev-client/src/components/links/ExternalLink.tsx
@@ -35,10 +35,6 @@ export type ExternalLinkProps = {
 
 export const ExternalLink = React.forwardRef(
   ({label, url}: ExternalLinkProps, ref: React.Ref<unknown>) => {
-    const icon = (
-      <NativeIconButton ref={ref} icon={<Icon name="open-in-new" />} />
-    );
-
     const isValidUrl = useMemo(() => validateUrl(url), [url]);
     const openUrl = useCallback(() => Linking.openURL(url), [url]);
 
@@ -55,7 +51,10 @@ export const ExternalLink = React.forwardRef(
                   style={styles.label}>
                   {label}
                 </Text>
-                {icon}
+                <NativeIconButton
+                  ref={ref}
+                  icon={<Icon name="open-in-new" />}
+                />
               </Row>
             </Box>
           </Pressable>

--- a/dev-client/src/components/links/InternalLink.tsx
+++ b/dev-client/src/components/links/InternalLink.tsx
@@ -15,31 +15,32 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import {Linking} from 'react-native';
 
 import {Link} from 'native-base';
 import {InterfaceLinkProps} from 'native-base/lib/typescript/components/primitives/Link/types';
 
+import {validateUrl} from 'terraso-mobile-client/util';
+
 type InternalLinkProps = {
   label: string;
   onPress?: InterfaceLinkProps['onPress'];
-  url?: string;
+  url: string;
 };
 
 export default function InternalLink({label, onPress, url}: InternalLinkProps) {
-  const openUrl = useCallback(() => {
-    if (url !== undefined) {
-      Linking.openURL(url);
-    }
-  }, [url]);
+  const isValidUrl = useMemo(() => validateUrl(url), [url]);
+  const openUrl = useCallback(() => Linking.openURL(url), [url]);
 
   return (
-    <Link
-      _text={{color: 'primary.main'}}
-      isUnderlined={true}
-      onPress={onPress ? onPress : openUrl}>
-      {label}
-    </Link>
+    isValidUrl && (
+      <Link
+        _text={{color: 'primary.main'}}
+        isUnderlined={true}
+        onPress={onPress ? onPress : openUrl}>
+        {label}
+      </Link>
+    )
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
@@ -15,6 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {SoilInfo} from 'terraso-client-shared/graphqlSchema/graphql';
@@ -27,6 +28,7 @@ import {
   Heading,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {validateUrl} from 'terraso-mobile-client/util';
 
 type SoilInfoDisplayProps = {
   dataSource: string;
@@ -35,16 +37,28 @@ type SoilInfoDisplayProps = {
 
 export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
   const {t} = useTranslation();
+
+  const hasValidUrl = useMemo(
+    () => validateUrl(soilInfo.soilSeries.fullDescriptionUrl),
+    [soilInfo],
+  );
+  const hasValidEsUrl = useMemo(
+    () => validateUrl(soilInfo.ecologicalSite?.url),
+    [soilInfo],
+  );
+
   return (
     <Column space={3}>
       <Heading variant="h6" fontStyle="italic" pb="10px">
         {soilInfo.soilSeries.taxonomySubgroup}
       </Heading>
       <Text variant="body1">{soilInfo.soilSeries.description}</Text>
-      <InternalLink
-        label={t('site.soil_id.soil_info.series_descr_url')}
-        url={soilInfo.soilSeries.fullDescriptionUrl}
-      />
+      {hasValidUrl && (
+        <InternalLink
+          label={t('site.soil_id.soil_info.series_descr_url')}
+          url={soilInfo.soilSeries.fullDescriptionUrl}
+        />
+      )}
       {soilInfo.ecologicalSite && (
         <>
           <Box>
@@ -61,10 +75,12 @@ export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
               }}
             />
           </Box>
-          <InternalLink
-            label={t('site.soil_id.soil_info.eco_descr_url')}
-            url={soilInfo.ecologicalSite.url}
-          />
+          {hasValidEsUrl && (
+            <InternalLink
+              label={t('site.soil_id.soil_info.eco_descr_url')}
+              url={soilInfo.ecologicalSite.url}
+            />
+          )}
         </>
       )}
       <Box>

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
@@ -15,7 +15,6 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {SoilInfo} from 'terraso-client-shared/graphqlSchema/graphql';
@@ -28,7 +27,6 @@ import {
   Heading,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {validateUrl} from 'terraso-mobile-client/util';
 
 type SoilInfoDisplayProps = {
   dataSource: string;
@@ -38,27 +36,16 @@ type SoilInfoDisplayProps = {
 export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
   const {t} = useTranslation();
 
-  const hasValidUrl = useMemo(
-    () => validateUrl(soilInfo.soilSeries.fullDescriptionUrl),
-    [soilInfo],
-  );
-  const hasValidEsUrl = useMemo(
-    () => validateUrl(soilInfo.ecologicalSite?.url),
-    [soilInfo],
-  );
-
   return (
     <Column space={3}>
       <Heading variant="h6" fontStyle="italic" pb="10px">
         {soilInfo.soilSeries.taxonomySubgroup}
       </Heading>
       <Text variant="body1">{soilInfo.soilSeries.description}</Text>
-      {hasValidUrl && (
-        <InternalLink
-          label={t('site.soil_id.soil_info.series_descr_url')}
-          url={soilInfo.soilSeries.fullDescriptionUrl}
-        />
-      )}
+      <InternalLink
+        label={t('site.soil_id.soil_info.series_descr_url')}
+        url={soilInfo.soilSeries.fullDescriptionUrl}
+      />
       {soilInfo.ecologicalSite && (
         <>
           <Box>
@@ -75,12 +62,10 @@ export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
               }}
             />
           </Box>
-          {hasValidEsUrl && (
-            <InternalLink
-              label={t('site.soil_id.soil_info.eco_descr_url')}
-              url={soilInfo.ecologicalSite.url}
-            />
-          )}
+          <InternalLink
+            label={t('site.soil_id.soil_info.eco_descr_url')}
+            url={soilInfo.ecologicalSite.url}
+          />
         </>
       )}
       <Box>

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -164,3 +164,11 @@ export const isSiteManager = matchesRole([
 export const getSoilWebUrl = (coords: Coords) => {
   return `https://casoilresource.lawr.ucdavis.edu/gmap/?loc=${coords.latitude},${coords.longitude}`;
 };
+
+export const validateUrl = (url?: string): URL | false => {
+  try {
+    return url ? new URL(url) : false;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Description

Validate information URLs returned by the soil ID algorithm before displaying them to the user.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1715

### Verification steps

Verify that soil ID results that previously crashed now have their URL components hidden.