### PR TITLE
fix: Update mobile_bug_report.yml to auto-add labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
@@ -1,6 +1,6 @@
 name: "Mobile App Bug Report"
 description: Used for reporting bugs and defects in mobile apps.
-labels: bug, "needs triage"
+labels: "needs triage"
 body:
 - type: input
   id: app-version

--- a/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
@@ -1,5 +1,6 @@
 name: "Mobile App Bug Report"
 description: Used for reporting bugs and defects in mobile apps.
+labels: bug, "needs triage"
 body:
 - type: input
   id: app-version


### PR DESCRIPTION
auto add labels to bug reports

## Description
Add labels "bug", and "needs triage" to issues filed with this formed. 

## References
- got sample code [from this conversation](https://github.com/orgs/community/discussions/23682#discussioncomment-3241404)

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Verification steps
- [ ] new labels should be applied automatically to issues as they are created, like 
