### PR TITLE
feat: Update depth presets for Capri

### DIFF
--- a/dev-client/__tests__/integration/SlopeScreen-test.tsx
+++ b/dev-client/__tests__/integration/SlopeScreen-test.tsx
@@ -33,7 +33,7 @@ test('renders correctly', () => {
         status: 'ready',
         soilData: {
           '1': {
-            depthIntervalPreset: 'LANDPKS',
+            depthIntervalPreset: 'NRCS',
             depthIntervals: [],
             depthDependentData: [],
             slopeSteepnessSelect: 'FLAT',
@@ -45,7 +45,7 @@ test('renders correctly', () => {
               collectionMethods.map(method => [methodRequired(method), false]),
             ),
             soilPitRequired: false,
-            depthIntervalPreset: 'LANDPKS',
+            depthIntervalPreset: 'NRCS',
             depthIntervals: [],
             slopeRequired: true,
           },

--- a/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/SoilScreen-test.tsx.snap
@@ -305,7 +305,7 @@ exports[`renders correctly 1`] = `
                           }
                         }
                       >
-                        0–10cm
+                        0–5cm
                       </Text>
                     </View>
                     <View
@@ -598,7 +598,7 @@ exports[`renders correctly 1`] = `
                           }
                         }
                       >
-                        10–20cm
+                        5–15cm
                       </Text>
                     </View>
                     <View
@@ -891,7 +891,7 @@ exports[`renders correctly 1`] = `
                           }
                         }
                       >
-                        20–50cm
+                        15–30cm
                       </Text>
                     </View>
                     <View
@@ -1184,7 +1184,7 @@ exports[`renders correctly 1`] = `
                           }
                         }
                       >
-                        50–70cm
+                        30–60cm
                       </Text>
                     </View>
                     <View
@@ -1477,7 +1477,7 @@ exports[`renders correctly 1`] = `
                           }
                         }
                       >
-                        70–100cm
+                        60–100cm
                       </Text>
                     </View>
                     <View

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -56,7 +56,7 @@
         "react-native-screens": "^3.32.0",
         "react-native-svg": "^15.3.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#e1b4e4d",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#0fd354a7a42f2d0317f5add48b016e62acb29a5b",
         "uuid": "^10.0.0",
         "yup": "^1.4.0"
       },
@@ -25033,11 +25033,13 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#3d323b5d204a8a7d33579cde27d4498c5b307ecb"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#10de1414a43d651af3db55fbac521495d0e2976f",
+      "integrity": "sha512-NWW+HEeIZxfo+RnsGoqGVtRrw0co6+lK9SY27IxLLvpce9YwVQT3Mpt4rUj3YhjKUYpeSs06VjePfMfoswCR1A=="
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#e1b4e4d195f8503c25575e305980547ce6d7a32b",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#0fd354a7a42f2d0317f5add48b016e62acb29a5b",
+      "integrity": "sha512-E4rq8jhF/RgpqSxZxtlFEWX/8buoamw9l8UOaR1Hihp+yW5wr7wAWat94kxLYCR9/kLE4ikcH0NIAHnyGG0ZUQ==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
@@ -25045,7 +25047,7 @@
         "munsell": "^1.1.5",
         "react": "18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#b542062",
+        "terraso-backend": "github:techmatters/terraso-backend#10de1414a43d651af3db55fbac521495d0e2976f",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -65,7 +65,7 @@
     "react-native-screens": "^3.32.0",
     "react-native-svg": "^15.3.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#e1b4e4d",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#0fd354a7a42f2d0317f5add48b016e62acb29a5b",
     "uuid": "^10.0.0",
     "yup": "^1.4.0"
   },

--- a/dev-client/src/screens/SoilScreen/components/EditSiteSoilDepthPreset.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditSiteSoilDepthPreset.tsx
@@ -50,8 +50,8 @@ export const EditSiteSoilDepthPreset = ({selected, updateChoice}: Props) => {
         label={t('soil.soil_preset.label')}
         labelProps={{variant: 'body1'}}
         options={{
-          LANDPKS: {text: t('soil.soil_preset.LANDPKS')},
           NRCS: {text: t('soil.soil_preset.NRCS')},
+          BLM: {text: t('soil.soil_preset.BLM')},
           CUSTOM: {text: t('soil.soil_preset.CUSTOM')},
         }}
         groupProps={{

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -264,8 +264,8 @@
       "depths": {
         "title": "Soil Pit Depths",
         "preset": {
-          "LANDPKS": "LandPKS",
           "NRCS": "NRCS/GSP",
+          "BLM": "BLM Monitoring Standard",
           "CUSTOM": "Custom…",
           "NONE": "None specified"
         },
@@ -604,8 +604,8 @@
       "header": "Change soil pit depths",
       "info": "Data already entered for a depth will be deleted when the depth is changed.",
       "label": "Depths",
-      "LANDPKS": "LandPKS (default)",
-      "NRCS": "NRCS/GSP",
+      "NRCS": "NRCS/GSP (default)",
+      "BLM": "BLM Monitoring Standard",
       "CUSTOM": "Custom"
     },
     "depth": {

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -265,7 +265,7 @@
         "title": "Soil Pit Depths",
         "preset": {
           "LANDPKS": "LandPKS",
-          "NRCS": "NRCS",
+          "NRCS": "NRCS/GSP",
           "CUSTOM": "Custom…",
           "NONE": "None specified"
         },
@@ -605,7 +605,7 @@
       "info": "Data already entered for a depth will be deleted when the depth is changed.",
       "label": "Depths",
       "LANDPKS": "LandPKS (default)",
-      "NRCS": "NRCS",
+      "NRCS": "NRCS/GSP",
       "CUSTOM": "Custom"
     },
     "depth": {


### PR DESCRIPTION
For depth presets:
- remove LandPKS
- add BLM monitoring standard
- make NRCS the default, and change user-visible string to "NRCS/GSP"

### Related Issues
mobile-client part to address [#1541](https://github.com/techmatters/terraso-mobile-client/issues/1541)
