### PR TITLE
fix: update home screen name so app bar shows LandPKS Soil ID

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -459,7 +459,7 @@
     "generic": "Error saving soil ID information."
   },
   "screens": {
-    "HOME": "LandPKS",
+    "HOME": "LandPKS Soil ID",
     "PROJECT_LIST": "Projects",
     "PROJECT_VIEW": "Project #{{id}}",
     "LOGIN": "Login",


### PR DESCRIPTION
## Description
Update home screen name so app bar shows "LandPKS Soil ID."