### PR TITLE
feat: update InternalLink to be spec compliant

### DIFF
--- a/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -1199,65 +1199,24 @@ exports[`renders correctly 1`] = `
                                               </Text>
                                                Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time. 
                                             </Text>
-                                            <View
-                                              accessibilityRole="link"
-                                              accessibilityState={
-                                                {
-                                                  "busy": undefined,
-                                                  "checked": undefined,
-                                                  "disabled": undefined,
-                                                  "expanded": undefined,
-                                                  "selected": undefined,
-                                                }
-                                              }
-                                              accessibilityValue={
-                                                {
-                                                  "max": undefined,
-                                                  "min": undefined,
-                                                  "now": undefined,
-                                                  "text": undefined,
-                                                }
-                                              }
-                                              accessible={true}
-                                              collapsable={false}
-                                              dataSet={{}}
-                                              focusable={true}
-                                              onBlur={[Function]}
-                                              onClick={[Function]}
-                                              onFocus={[Function]}
-                                              onResponderGrant={[Function]}
-                                              onResponderMove={[Function]}
-                                              onResponderRelease={[Function]}
-                                              onResponderTerminate={[Function]}
-                                              onResponderTerminationRequest={[Function]}
-                                              onStartShouldSetResponder={[Function]}
+                                            <Text
+                                              letterSpacing="0.15px"
+                                              lineHeight="24px"
+                                              onPress={[Function]}
+                                              onPressIn={[Function]}
+                                              onPressOut={[Function]}
+                                              role="link"
                                               style={
                                                 {
-                                                  "flexDirection": "row",
-                                                  "height": "auto",
-                                                  "width": "auto",
+                                                  "color": "#028843",
+                                                  "fontSize": 16,
+                                                  "fontWeight": "700",
+                                                  "textDecorationLine": "underline",
                                                 }
                                               }
                                             >
-                                              <Text
-                                                dataSet={{}}
-                                                style={
-                                                  {
-                                                    "backgroundColor": undefined,
-                                                    "color": "#028843",
-                                                    "fontFamily": undefined,
-                                                    "fontSize": 16,
-                                                    "fontStyle": "normal",
-                                                    "fontWeight": "800",
-                                                    "letterSpacing": 0.15,
-                                                    "lineHeight": 24,
-                                                    "textDecorationLine": "underline",
-                                                  }
-                                                }
-                                              >
-                                                Read more about our data privacy policy.
-                                              </Text>
-                                            </View>
+                                              Read more about our data privacy policy.
+                                            </Text>
                                           </View>
                                         </View>
                                       </View>

--- a/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -1440,65 +1440,24 @@ exports[`renders correctly 1`] = `
                                           </Text>
                                            Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time. 
                                         </Text>
-                                        <View
-                                          accessibilityRole="link"
-                                          accessibilityState={
-                                            {
-                                              "busy": undefined,
-                                              "checked": undefined,
-                                              "disabled": undefined,
-                                              "expanded": undefined,
-                                              "selected": undefined,
-                                            }
-                                          }
-                                          accessibilityValue={
-                                            {
-                                              "max": undefined,
-                                              "min": undefined,
-                                              "now": undefined,
-                                              "text": undefined,
-                                            }
-                                          }
-                                          accessible={true}
-                                          collapsable={false}
-                                          dataSet={{}}
-                                          focusable={true}
-                                          onBlur={[Function]}
-                                          onClick={[Function]}
-                                          onFocus={[Function]}
-                                          onResponderGrant={[Function]}
-                                          onResponderMove={[Function]}
-                                          onResponderRelease={[Function]}
-                                          onResponderTerminate={[Function]}
-                                          onResponderTerminationRequest={[Function]}
-                                          onStartShouldSetResponder={[Function]}
+                                        <Text
+                                          letterSpacing="0.15px"
+                                          lineHeight="24px"
+                                          onPress={[Function]}
+                                          onPressIn={[Function]}
+                                          onPressOut={[Function]}
+                                          role="link"
                                           style={
                                             {
-                                              "flexDirection": "row",
-                                              "height": "auto",
-                                              "width": "auto",
+                                              "color": "#028843",
+                                              "fontSize": 16,
+                                              "fontWeight": "700",
+                                              "textDecorationLine": "underline",
                                             }
                                           }
                                         >
-                                          <Text
-                                            dataSet={{}}
-                                            style={
-                                              {
-                                                "backgroundColor": undefined,
-                                                "color": "#028843",
-                                                "fontFamily": undefined,
-                                                "fontSize": 16,
-                                                "fontStyle": "normal",
-                                                "fontWeight": "800",
-                                                "letterSpacing": 0.15,
-                                                "lineHeight": 24,
-                                                "textDecorationLine": "underline",
-                                              }
-                                            }
-                                          >
-                                            Read more about our data privacy policy.
-                                          </Text>
-                                        </View>
+                                          Read more about our data privacy policy.
+                                        </Text>
                                       </View>
                                     </View>
                                   </View>

--- a/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/integration/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -1609,65 +1609,24 @@ exports[`renders correctly 1`] = `
                                                       </Text>
                                                        Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time. 
                                                     </Text>
-                                                    <View
-                                                      accessibilityRole="link"
-                                                      accessibilityState={
-                                                        {
-                                                          "busy": undefined,
-                                                          "checked": undefined,
-                                                          "disabled": undefined,
-                                                          "expanded": undefined,
-                                                          "selected": undefined,
-                                                        }
-                                                      }
-                                                      accessibilityValue={
-                                                        {
-                                                          "max": undefined,
-                                                          "min": undefined,
-                                                          "now": undefined,
-                                                          "text": undefined,
-                                                        }
-                                                      }
-                                                      accessible={true}
-                                                      collapsable={false}
-                                                      dataSet={{}}
-                                                      focusable={true}
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onFocus={[Function]}
-                                                      onResponderGrant={[Function]}
-                                                      onResponderMove={[Function]}
-                                                      onResponderRelease={[Function]}
-                                                      onResponderTerminate={[Function]}
-                                                      onResponderTerminationRequest={[Function]}
-                                                      onStartShouldSetResponder={[Function]}
+                                                    <Text
+                                                      letterSpacing="0.15px"
+                                                      lineHeight="24px"
+                                                      onPress={[Function]}
+                                                      onPressIn={[Function]}
+                                                      onPressOut={[Function]}
+                                                      role="link"
                                                       style={
                                                         {
-                                                          "flexDirection": "row",
-                                                          "height": "auto",
-                                                          "width": "auto",
+                                                          "color": "#028843",
+                                                          "fontSize": 16,
+                                                          "fontWeight": "700",
+                                                          "textDecorationLine": "underline",
                                                         }
                                                       }
                                                     >
-                                                      <Text
-                                                        dataSet={{}}
-                                                        style={
-                                                          {
-                                                            "backgroundColor": undefined,
-                                                            "color": "#028843",
-                                                            "fontFamily": undefined,
-                                                            "fontSize": 16,
-                                                            "fontStyle": "normal",
-                                                            "fontWeight": "800",
-                                                            "letterSpacing": 0.15,
-                                                            "lineHeight": 24,
-                                                            "textDecorationLine": "underline",
-                                                          }
-                                                        }
-                                                      >
-                                                        Read more about our data privacy policy.
-                                                      </Text>
-                                                    </View>
+                                                      Read more about our data privacy policy.
+                                                    </Text>
                                                   </View>
                                                 </View>
                                               </View>

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -34,6 +34,7 @@
         "expo-media-library": "~16.0.4",
         "expo-screen-orientation": "~7.0.5",
         "expo-sensors": "~13.0.9",
+        "expo-web-browser": "~13.0.3",
         "formik": "^2.4.6",
         "haversine": "^1.1.1",
         "i18next": "^23.11.5",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -43,6 +43,7 @@
     "expo-media-library": "~16.0.4",
     "expo-screen-orientation": "~7.0.5",
     "expo-sensors": "~13.0.9",
+    "expo-web-browser": "~13.0.3",
     "formik": "^2.4.6",
     "haversine": "^1.1.1",
     "i18next": "^23.11.5",

--- a/dev-client/src/components/links/InternalLink.tsx
+++ b/dev-client/src/components/links/InternalLink.tsx
@@ -18,7 +18,7 @@
 import {useCallback, useMemo, useState} from 'react';
 import {PressableProps} from 'react-native';
 
-import * as WebBrowser from 'expo-web-browser';
+import {openBrowserAsync} from 'expo-web-browser';
 
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {validateUrl} from 'terraso-mobile-client/util';
@@ -31,14 +31,14 @@ type InternalLinkProps = {
 
 export default function InternalLink({label, onPress, url}: InternalLinkProps) {
   const isValidUrl = useMemo(() => validateUrl(url), [url]);
-  const openUrl = useCallback(() => WebBrowser.openBrowserAsync(url), [url]);
+  const openUrl = useCallback(() => openBrowserAsync(url), [url]);
   const [pressed, setPressed] = useState(false);
 
   return (
     isValidUrl && (
       <Text
         role="link"
-        color={!pressed ? 'primary.main' : 'primary.dark'}
+        color={pressed ? 'primary.dark' : 'primary.main'}
         underline={true}
         fontWeight={700}
         onPressIn={() => setPressed(true)}

--- a/dev-client/src/components/links/InternalLink.tsx
+++ b/dev-client/src/components/links/InternalLink.tsx
@@ -16,7 +16,9 @@
  */
 
 import {useCallback, useMemo, useState} from 'react';
-import {Linking, PressableProps} from 'react-native';
+import {PressableProps} from 'react-native';
+
+import * as WebBrowser from 'expo-web-browser';
 
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {validateUrl} from 'terraso-mobile-client/util';
@@ -29,7 +31,7 @@ type InternalLinkProps = {
 
 export default function InternalLink({label, onPress, url}: InternalLinkProps) {
   const isValidUrl = useMemo(() => validateUrl(url), [url]);
-  const openUrl = useCallback(() => Linking.openURL(url), [url]);
+  const openUrl = useCallback(() => WebBrowser.openBrowserAsync(url), [url]);
   const [pressed, setPressed] = useState(false);
 
   return (

--- a/dev-client/src/components/links/InternalLink.tsx
+++ b/dev-client/src/components/links/InternalLink.tsx
@@ -15,32 +15,35 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback, useMemo} from 'react';
-import {Linking} from 'react-native';
+import {useCallback, useMemo, useState} from 'react';
+import {Linking, PressableProps} from 'react-native';
 
-import {Link} from 'native-base';
-import {InterfaceLinkProps} from 'native-base/lib/typescript/components/primitives/Link/types';
-
+import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {validateUrl} from 'terraso-mobile-client/util';
 
 type InternalLinkProps = {
   label: string;
-  onPress?: InterfaceLinkProps['onPress'];
+  onPress?: PressableProps['onPress'];
   url: string;
 };
 
 export default function InternalLink({label, onPress, url}: InternalLinkProps) {
   const isValidUrl = useMemo(() => validateUrl(url), [url]);
   const openUrl = useCallback(() => Linking.openURL(url), [url]);
+  const [pressed, setPressed] = useState(false);
 
   return (
     isValidUrl && (
-      <Link
-        _text={{color: 'primary.main'}}
-        isUnderlined={true}
+      <Text
+        role="link"
+        color={!pressed ? 'primary.main' : 'primary.dark'}
+        underline={true}
+        fontWeight={700}
+        onPressIn={() => setPressed(true)}
+        onPressOut={() => setPressed(false)}
         onPress={onPress ? onPress : openUrl}>
         {label}
-      </Link>
+      </Text>
     )
   );
 }

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -471,17 +471,6 @@ export const theme = extendTheme({
         },
       },
     },
-    Link: {
-      baseStyle: {
-        _text: {
-          fontSize: '16px',
-          fontWeight: 800,
-          lineHeight: '24px',
-          letterSpacing: '0.15px',
-          color: 'primary.main',
-        },
-      },
-    },
     Image: {
       variants: {
         profilePic: {


### PR DESCRIPTION
## Description

Reimplement `InternalLink` to be compliant with spec, discarding old `NativeBase` `Link` implementation for a pressable `Text` element. Incorporate `expo-web-browser` for embedded web view functionality.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1332

### Verification steps

Open sections of the application containing external links. Verify that they match the component specification. Verify that links open in an embedded browser window rather than the user's browser app.