### PR TITLE
fix: gracefully handle areas where elevation data doesn’t exist

### DIFF
--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -35,7 +35,11 @@ export const getElevation = async (
     const response = await fetch(
       `https://epqs.nationalmap.gov/v1/json/?${queryString}`,
     );
-    const result = await response.json();
+    const textResult = await response.text();
+    if (textResult === 'Invalid or missing input parameters.') {
+      return;
+    }
+    const result = JSON.parse(textResult);
 
     elevation = parseFloat(result.value);
   } catch (error) {


### PR DESCRIPTION
## Description
Gracefully handle areas where elevation data doesn’t exist: return undefined instead of throwing an exception.