### PR TITLE
fix: correctly handle unknown elevation vs. loading

### DIFF
--- a/dev-client/src/model/elevation/elevationHooks.ts
+++ b/dev-client/src/model/elevation/elevationHooks.ts
@@ -19,19 +19,20 @@ import {useEffect} from 'react';
 
 import {Coords} from 'terraso-client-shared/types';
 
-import {selectElevation} from 'terraso-mobile-client/model/elevation/elevationSelectors';
+import {selectCachedElevation} from 'terraso-mobile-client/model/elevation/elevationSelectors';
 import {fetchElevation} from 'terraso-mobile-client/model/elevation/elevationSlice';
+import {ElevationRecord} from 'terraso-mobile-client/model/elevation/elevationTypes';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
-export const useElevationData = (coords: Coords): number | undefined => {
+export const useElevationData = (coords: Coords): ElevationRecord => {
   const dispatch = useDispatch();
-  const elevation = useSelector(selectElevation(coords));
+  const cachedElevation = useSelector(selectCachedElevation(coords));
 
   useEffect(() => {
-    if (!elevation) {
+    if (!cachedElevation) {
       dispatch(fetchElevation(coords));
     }
-  }, [dispatch, elevation, coords]);
+  }, [dispatch, cachedElevation, coords]);
 
-  return elevation?.value;
+  return cachedElevation ?? {fetching: true};
 };

--- a/dev-client/src/model/elevation/elevationSelectors.ts
+++ b/dev-client/src/model/elevation/elevationSelectors.ts
@@ -18,7 +18,10 @@
 import {Coords} from 'terraso-client-shared/types';
 
 import {elevationKey} from 'terraso-mobile-client/model/elevation/elevationFunctions';
+import {ElevationRecord} from 'terraso-mobile-client/model/elevation/elevationTypes';
 import {AppState} from 'terraso-mobile-client/store';
 
-export const selectElevation = (coords: Coords) => (state: AppState) =>
-  state.elevation.elevation[elevationKey(coords)];
+export const selectCachedElevation =
+  (coords: Coords) =>
+  (state: AppState): ElevationRecord | undefined =>
+    state.elevation.elevationCache[elevationKey(coords)];

--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -17,6 +17,8 @@
 
 import {formatCoordinate} from 'terraso-mobile-client/util';
 
+const OUT_OF_RANGE_MESSAGE = 'Invalid or missing input parameters.';
+
 export const getElevation = async (
   lat: number,
   lng: number,
@@ -35,9 +37,12 @@ export const getElevation = async (
     const response = await fetch(
       `https://epqs.nationalmap.gov/v1/json/?${queryString}`,
     );
-    const result = await response.json();
-
-    elevation = parseFloat(result.value);
+    const result = await response.text();
+    if (result === OUT_OF_RANGE_MESSAGE) {
+      elevation = undefined;
+    } else {
+      elevation = parseFloat(JSON.parse(result).value);
+    }
   } catch (error) {
     console.error(error);
   }

--- a/dev-client/src/model/elevation/elevationSlice.ts
+++ b/dev-client/src/model/elevation/elevationSlice.ts
@@ -27,11 +27,11 @@ import {
 } from 'terraso-mobile-client/model/elevation/elevationTypes';
 
 export type ElevationState = {
-  elevation: Record<ElevationKey, ElevationRecord>;
+  elevationCache: Record<ElevationKey, ElevationRecord>;
 };
 
 const initialState: ElevationState = {
-  elevation: {},
+  elevationCache: {},
 };
 
 const {reducer} = createSlice({
@@ -41,13 +41,13 @@ const {reducer} = createSlice({
   extraReducers(builder) {
     builder
       .addCase(fetchElevation.pending, (state, action) => {
-        state.elevation[elevationKey(action.meta.arg)] = {fetching: true};
+        state.elevationCache[elevationKey(action.meta.arg)] = {fetching: true};
       })
       .addCase(fetchElevation.rejected, (state, action) => {
-        state.elevation[elevationKey(action.meta.arg)] = {fetching: false};
+        state.elevationCache[elevationKey(action.meta.arg)] = {fetching: false};
       })
       .addCase(fetchElevation.fulfilled, (state, action) => {
-        state.elevation[elevationKey(action.meta.arg)] = {
+        state.elevationCache[elevationKey(action.meta.arg)] = {
           fetching: false,
           value: action.payload,
         };

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -67,7 +67,7 @@ export const TemporaryLocationCallout = ({
   const onCreate = useCallback(() => {
     navigation.navigate('CREATE_SITE', {
       coords,
-      elevation: elevation,
+      elevation: elevation.value,
     });
     closeCallout();
   }, [closeCallout, navigation, coords, elevation]);
@@ -75,7 +75,7 @@ export const TemporaryLocationCallout = ({
   const onLearnMore = useCallback(() => {
     navigation.navigate('LOCATION_DASHBOARD', {
       coords,
-      elevation: elevation,
+      elevation: elevation.value,
     });
   }, [navigation, coords, elevation]);
 
@@ -114,10 +114,10 @@ export const TemporaryLocationCallout = ({
         <CalloutDetail
           label={t('site.elevation_label')}
           value={
-            elevation ? (
-              <Text bold>{renderElevation(t, elevation)}</Text>
-            ) : (
+            elevation.fetching ? (
               <ActivityIndicator size="small" />
+            ) : (
+              <Text bold>{renderElevation(t, elevation.value)}</Text>
             )
           }
         />


### PR DESCRIPTION
## Description

Fix an oversight in elevation hook usage which did not correctly distinguish between unknown elevation and loading elevation when rendering for users. Refactor some nearby code for greater clarity.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1787

### Verification steps

Select a point on the map both inside and outside the US and verify that elevation values show as "unknown" when outside the US. Verify that loading indicator still functions.