### PR TITLE
feat: add Sentry mobile replay

### DIFF
--- a/dev-client/metro.config.js
+++ b/dev-client/metro.config.js
@@ -26,6 +26,8 @@ const config = {
   serializer: {
     customSerializer: createSentryMetroSerializer(),
   },
+
+  annotateReactComponents: true,
 };
 
 module.exports = mergeConfig(defaultConfig, config);

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -68,7 +68,7 @@ if (APP_CONFIG.sentryEnabled) {
       }),
     ],
     _experiments: {
-      replaysSessionSampleRate: 1.0,
+      replaysSessionSampleRate: 0.1,
       replaysOnErrorSampleRate: 1.0,
     },
   });

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -59,7 +59,18 @@ if (APP_CONFIG.sentryEnabled) {
   Sentry.init({
     dsn: APP_CONFIG.sentryDsn,
     environment: APP_CONFIG.environment,
-    integrations: [captureConsoleIntegration({levels: ['warn', 'error']})],
+    integrations: [
+      captureConsoleIntegration({levels: ['warn', 'error']}),
+      Sentry.mobileReplayIntegration({
+        maskAllImages: true,
+        maskAllVectors: true,
+        maskAllText: true,
+      }),
+    ],
+    _experiments: {
+      replaysSessionSampleRate: 1.0,
+      replaysOnErrorSampleRate: 1.0,
+    },
   });
 }
 


### PR DESCRIPTION
## Description
Add Sentry mobile replay support.

docs:
* https://docs.sentry.io/product/explore/session-replay/mobile/
* https://github.com/getsentry/sentry-react-native/releases/tag/5.26.0