### PR TITLE
Fix: add modal to confirm deleting depth interval for projects 

### DIFF
--- a/dev-client/src/components/modals/ConfirmDeleteDepthModal.tsx
+++ b/dev-client/src/components/modals/ConfirmDeleteDepthModal.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+
+import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
+import {ModalTrigger} from 'terraso-mobile-client/components/modals/Modal';
+
+type ConfirmDeleteDepthModalProps = {
+  onConfirm: () => void;
+  trigger: ModalTrigger;
+};
+
+export const ConfirmDeleteDepthModal = ({
+  onConfirm,
+  trigger,
+}: ConfirmDeleteDepthModalProps) => {
+  const {t} = useTranslation();
+
+  return (
+    <ConfirmModal
+      trigger={trigger}
+      title={t('soil.depth.delete_modal.title')}
+      body={t('soil.depth.delete_modal.body')}
+      actionName={t('soil.depth.delete_modal.action')}
+      handleConfirm={onConfirm}
+    />
+  );
+};

--- a/dev-client/src/components/tables/DataGridTable.tsx
+++ b/dev-client/src/components/tables/DataGridTable.tsx
@@ -70,7 +70,7 @@ export const DataGridTable = ({rows, headers, ...containerProps}: Props) => {
           <Row justifyContent="flex-start" key={i} variant="tablerow" py="10px">
             {row.map(displayCol)}
           </Row>
-          <Divider />
+          <Divider key={`divider${i}`} />
         </>
       ))}
     </Box>

--- a/dev-client/src/screens/ProjectInputScreen/DepthTable.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/DepthTable.tsx
@@ -25,6 +25,7 @@ import {
 } from 'terraso-client-shared/soilId/soilIdSlice';
 
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
+import {ConfirmDeleteDepthModal} from 'terraso-mobile-client/components/modals/ConfirmDeleteDepthModal';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {DataGridTable} from 'terraso-mobile-client/components/tables/DataGridTable';
 import {useDispatch} from 'terraso-mobile-client/store';
@@ -71,13 +72,18 @@ export const DepthTable = ({
       if (canDeleteDepth) {
         result.push(
           <Box flex={1} flexDirection="row" justifyContent="flex-end">
-            <IconButton
-              name="close"
-              onPress={deleteDepth(depthInterval)}
-              _icon={{
-                size: 'sm',
-                color: 'action.active',
-              }}
+            <ConfirmDeleteDepthModal
+              onConfirm={deleteDepth(depthInterval)}
+              trigger={onOpen => (
+                <IconButton
+                  name="close"
+                  onPress={onOpen}
+                  _icon={{
+                    size: 'sm',
+                    color: 'action.active',
+                  }}
+                />
+              )}
             />
           </Box>,
         );

--- a/dev-client/src/screens/SoilScreen/components/EditDepthModal.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditDepthModal.tsx
@@ -46,6 +46,7 @@ import {FormLabel} from 'terraso-mobile-client/components/form/FormLabel';
 import {FormSwitch} from 'terraso-mobile-client/components/form/FormSwitch';
 import {useFieldContext} from 'terraso-mobile-client/components/form/hooks/useFieldContext';
 import {IconButton} from 'terraso-mobile-client/components/icons/IconButton';
+import {ConfirmDeleteDepthModal} from 'terraso-mobile-client/components/modals/ConfirmDeleteDepthModal';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
 import {
@@ -220,7 +221,8 @@ export const EditDepthModal = ({
 
             <Row justifyContent="flex-end">
               {mutable && (
-                <ConfirmModal
+                <ConfirmDeleteDepthModal
+                  onConfirm={deleteDepth}
                   trigger={onOpen => (
                     <DeleteButton
                       label={t('soil.depth.delete_button')}
@@ -228,10 +230,6 @@ export const EditDepthModal = ({
                       mr="20px"
                     />
                   )}
-                  title={t('soil.depth.delete_modal.title')}
-                  body={t('soil.depth.delete_modal.body')}
-                  actionName={t('soil.depth.delete_modal.action')}
-                  handleConfirm={deleteDepth}
                 />
               )}
               <ConfirmEditingModal


### PR DESCRIPTION
## Description
- add delete depth modal (same one as used for deleting depth intervals for sites)
- fix warning about needing unique 'key' prop

### Related Issues
Addresses #1639
