### PR TITLE
fix: use optional chaining to avoid crash on soil pit

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -57,7 +57,7 @@
         "react-native-screens": "^3.32.0",
         "react-native-svg": "^15.4.0",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#0fd354a7a42f2d0317f5add48b016e62acb29a5b",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#e6601f0",
         "uuid": "^10.0.0",
         "yup": "^1.4.0"
       },
@@ -25344,8 +25344,7 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#0fd354a7a42f2d0317f5add48b016e62acb29a5b",
-      "integrity": "sha512-E4rq8jhF/RgpqSxZxtlFEWX/8buoamw9l8UOaR1Hihp+yW5wr7wAWat94kxLYCR9/kLE4ikcH0NIAHnyGG0ZUQ==",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#e6601f0e6f6e01f99ebb8d351d82208d30148269",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -66,7 +66,7 @@
     "react-native-screens": "^3.32.0",
     "react-native-svg": "^15.4.0",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#0fd354a7a42f2d0317f5add48b016e62acb29a5b",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#e6601f0",
     "uuid": "^10.0.0",
     "yup": "^1.4.0"
   },

--- a/dev-client/src/components/tables/DataGridTable.tsx
+++ b/dev-client/src/components/tables/DataGridTable.tsx
@@ -65,7 +65,7 @@ export const DataGridTable = ({rows, headers, ...containerProps}: Props) => {
         ))}
       </Row>
       <Divider />
-      {rows.map((row: (typeof rows)[number], i: number) => (
+      {rows?.map((row: (typeof rows)[number], i: number) => (
         <>
           <Row justifyContent="flex-start" key={i} variant="tablerow" py="10px">
             {row.map(displayCol)}

--- a/dev-client/src/screens/ProjectInputScreen/DepthTable.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/DepthTable.tsx
@@ -63,7 +63,7 @@ export const DepthTable = ({
   );
 
   const rows = useMemo(() => {
-    return depthIntervals.map(({label, depthInterval}) => {
+    return depthIntervals?.map(({label, depthInterval}) => {
       let result: (string | React.ReactElement)[] = [];
       if (includeLabel) {
         result.push(label || '');


### PR DESCRIPTION
## Description
Use optional chaining to avoid crash on soil pit when no rows are present.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1830.