### PR TITLE
fix: don't mask sentry replay data in dev/staging environments; update annotateReactComponents config

### DIFF
--- a/dev-client/metro.config.js
+++ b/dev-client/metro.config.js
@@ -1,5 +1,6 @@
 const {getDefaultConfig} = require('expo/metro-config');
 const {mergeConfig} = require('@react-native/metro-config');
+const {withSentryConfig} = require('@sentry/react-native/metro');
 
 const {
   createSentryMetroSerializer,
@@ -30,4 +31,7 @@ const config = {
   annotateReactComponents: true,
 };
 
-module.exports = mergeConfig(defaultConfig, config);
+const m = mergeConfig(defaultConfig, config);
+module.exports = withSentryConfig(m, {
+  annotateReactComponents: true,
+});

--- a/dev-client/metro.config.js
+++ b/dev-client/metro.config.js
@@ -27,8 +27,6 @@ const config = {
   serializer: {
     customSerializer: createSentryMetroSerializer(),
   },
-
-  annotateReactComponents: true,
 };
 
 const m = mergeConfig(defaultConfig, config);

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -55,6 +55,9 @@ import {paperTheme, theme} from 'terraso-mobile-client/theme';
 
 enableFreeze(true);
 
+// Mask user data on production environment
+const maskReplays = APP_CONFIG.environment === 'production';
+
 if (APP_CONFIG.sentryEnabled) {
   Sentry.init({
     dsn: APP_CONFIG.sentryDsn,
@@ -62,9 +65,9 @@ if (APP_CONFIG.sentryEnabled) {
     integrations: [
       captureConsoleIntegration({levels: ['warn', 'error']}),
       Sentry.mobileReplayIntegration({
-        maskAllImages: true,
-        maskAllVectors: true,
-        maskAllText: true,
+        maskAllImages: maskReplays,
+        maskAllVectors: maskReplays,
+        maskAllText: maskReplays,
       }),
     ],
     _experiments: {


### PR DESCRIPTION
## Description
- don't mask sentry replay data in dev/staging environments
- correct annotateReactComponents configuration