### PR TITLE
fix: wrap long site names in site card and app bar

### DIFF
--- a/dev-client/src/components/Card.tsx
+++ b/dev-client/src/components/Card.tsx
@@ -15,9 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-// using native-base's Pressable so we can assign minWidth to it.
-// the react-native Pressable doesn't support this prop.
-import {Pressable} from 'native-base';
+import {Pressable, ViewStyle} from 'react-native';
 
 import {Box, Row} from 'terraso-mobile-client/components/NativeBaseAdapters';
 
@@ -47,7 +45,7 @@ type Props = {
   children?: React.ReactNode;
   onPress?: () => void;
   isPopover?: Boolean;
-  pressableProps?: React.ComponentProps<typeof Pressable>;
+  pressableStyle?: ViewStyle;
 } & React.ComponentProps<typeof Box>;
 
 export const Card = ({
@@ -56,10 +54,10 @@ export const Card = ({
   onPress,
   children,
   isPopover = false,
-  pressableProps,
+  pressableStyle,
   ...boxProps
 }: Props) => (
-  <Pressable onPress={onPress} {...pressableProps}>
+  <Pressable onPress={onPress} style={pressableStyle}>
     <Box
       padding="md"
       margin="0"

--- a/dev-client/src/components/Card.tsx
+++ b/dev-client/src/components/Card.tsx
@@ -68,6 +68,7 @@ export const Card = ({
       {isPopover && <CardTriangle />}
       {(Header || buttons) && (
         <Row
+          space="md"
           alignItems="flex-start"
           justifyContent="space-between"
           width="100%">

--- a/dev-client/src/components/Card.tsx
+++ b/dev-client/src/components/Card.tsx
@@ -62,7 +62,6 @@ export const Card = ({
       padding="md"
       margin="0"
       backgroundColor="background.default"
-      width="100%"
       shadow={undefined}
       {...boxProps}>
       {isPopover && <CardTriangle />}

--- a/dev-client/src/components/Card.tsx
+++ b/dev-client/src/components/Card.tsx
@@ -14,7 +14,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {Pressable} from 'react-native';
+
+// using native-base's Pressable so we can assign minWidth to it.
+// the react-native Pressable doesn't support this prop.
+import {Pressable} from 'native-base';
 
 import {Box, Row} from 'terraso-mobile-client/components/NativeBaseAdapters';
 
@@ -44,6 +47,7 @@ type Props = {
   children?: React.ReactNode;
   onPress?: () => void;
   isPopover?: Boolean;
+  pressableProps?: React.ComponentProps<typeof Pressable>;
 } & React.ComponentProps<typeof Box>;
 
 export const Card = ({
@@ -52,13 +56,23 @@ export const Card = ({
   onPress,
   children,
   isPopover = false,
+  pressableProps,
   ...boxProps
 }: Props) => (
-  <Pressable onPress={onPress}>
-    <Box variant="card" marginTop="0px" shadow={undefined} {...boxProps}>
+  <Pressable onPress={onPress} {...pressableProps}>
+    <Box
+      padding="md"
+      margin="0"
+      backgroundColor="background.default"
+      width="100%"
+      shadow={undefined}
+      {...boxProps}>
       {isPopover && <CardTriangle />}
       {(Header || buttons) && (
-        <Row space="md" alignItems="flex-start" justifyContent="space-between">
+        <Row
+          alignItems="flex-start"
+          justifyContent="space-between"
+          width="100%">
           {Header}
           {buttons}
         </Row>

--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -99,7 +99,7 @@ export const SiteCard = ({
 const pressableStyles = (isPopover: Boolean = false): ViewStyle => {
   return {
     minWidth: isPopover ? '90%' : undefined,
-    maxWidth: isPopover ? '40%' : undefined,
+    maxWidth: isPopover ? '90%' : undefined,
   };
 };
 

--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -64,12 +64,14 @@ export const SiteCard = ({
         <Heading
           variant="h6"
           color="primary.main"
-          maxWidth={isPopover ? '85%' : undefined} // make space for the close button
-        >
+          flex={isPopover ? 1 : undefined}>
           {site.name}
         </Heading>
       }
-      maxWidth={isPopover ? '90%' : undefined} // overall card width
+      pressableProps={{
+        minWidth: isPopover ? '90%' : undefined,
+        maxWidth: isPopover ? '90%' : undefined,
+      }}
       onPress={onCardPress}
       buttons={buttons}
       isPopover={isPopover}>

--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -64,11 +64,12 @@ export const SiteCard = ({
         <Heading
           variant="h6"
           color="primary.main"
-          maxWidth={isPopover ? '85%' : undefined}>
+          maxWidth={isPopover ? '85%' : undefined} // make space for the close button
+        >
           {site.name}
         </Heading>
       }
-      maxWidth={isPopover ? '90%' : undefined}
+      maxWidth={isPopover ? '90%' : undefined} // overall card width
       onPress={onCardPress}
       buttons={buttons}
       isPopover={isPopover}>

--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -61,19 +61,19 @@ export const SiteCard = ({
   return (
     <Card
       Header={
-        <Heading variant="h6" color="primary.main">
+        <Heading
+          variant="h6"
+          color="primary.main"
+          maxWidth={isPopover ? '85%' : undefined}>
           {site.name}
         </Heading>
       }
+      maxWidth={isPopover ? '90%' : undefined}
       onPress={onCardPress}
       buttons={buttons}
       isPopover={isPopover}>
       {project && <Text variant="body1">{project.name}</Text>}
-      <Row
-        alignItems="center"
-        pt="md"
-        justifyContent="space-between"
-        w={isPopover ? '300px' : undefined}>
+      <Row alignItems="center" pt="md" justifyContent="space-between">
         <StaticMapView coords={site} style={styles.mapView} />
         {project && (
           <PeopleBadge count={Object.keys(project.memberships).length} />

--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, {useCallback} from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, ViewStyle} from 'react-native';
 
 import {Site} from 'terraso-client-shared/site/siteSlice';
 
@@ -68,10 +68,7 @@ export const SiteCard = ({
           {site.name}
         </Heading>
       }
-      pressableProps={{
-        minWidth: isPopover ? '90%' : undefined,
-        maxWidth: isPopover ? '90%' : undefined,
-      }}
+      pressableStyle={pressableStyles(isPopover)}
       onPress={onCardPress}
       buttons={buttons}
       isPopover={isPopover}>
@@ -97,6 +94,13 @@ export const SiteCard = ({
       </Row>
     </Card>
   );
+};
+
+const pressableStyles = (isPopover: Boolean = false): ViewStyle => {
+  return {
+    minWidth: isPopover ? '90%' : undefined,
+    maxWidth: isPopover ? '40%' : undefined,
+  };
 };
 
 const styles = StyleSheet.create({

--- a/dev-client/src/components/util/nativeBaseAdapters.ts
+++ b/dev-client/src/components/util/nativeBaseAdapters.ts
@@ -82,6 +82,7 @@ const nativeBaseDimensions = {
   maxHeight: 'maxHeight',
   h: 'height',
   width: 'width',
+  minWidth: 'minWidth',
   maxWidth: 'maxWidth',
   w: 'width',
   left: 'left',

--- a/dev-client/src/navigation/components/AppBar.tsx
+++ b/dev-client/src/navigation/components/AppBar.tsx
@@ -49,6 +49,7 @@ export const AppBar = ({
           <Heading
             variant="h6"
             color="primary.contrast"
+            pr={RightButton ? '65px' : undefined}
             pl={LeftButton ? undefined : '16px'}>
             {title ?? t(`screens.${route.name}`)}
           </Heading>

--- a/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteMapCallout.tsx
@@ -92,7 +92,7 @@ const CalloutChild = (coords: Coords, {sites, state, setState}: Props) => {
 
       return (
         <Card
-          width="270px"
+          width="350px"
           buttons={<CloseButton onPress={closeCallout} />}
           isPopover={true}>
           <FlatList

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -85,6 +85,7 @@ export const TemporaryLocationCallout = ({
         <LatLngDetail isCurrentLocation={isCurrentLocation} coords={coords} />
       }
       buttons={<CloseButton onPress={closeCallout} />}
+      maxWidth="270px"
       isPopover={true}>
       <Column mt="12px" space="12px">
         <>

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -85,8 +85,8 @@ export const TemporaryLocationCallout = ({
         <LatLngDetail isCurrentLocation={isCurrentLocation} coords={coords} />
       }
       buttons={<CloseButton onPress={closeCallout} />}
-      maxWidth="90%"
-      width="270px"
+      width="90%"
+      maxWidth="350px"
       isPopover={true}>
       <Column mt="12px" space="12px">
         <>

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -85,7 +85,8 @@ export const TemporaryLocationCallout = ({
         <LatLngDetail isCurrentLocation={isCurrentLocation} coords={coords} />
       }
       buttons={<CloseButton onPress={closeCallout} />}
-      maxWidth="270px"
+      maxWidth="90%"
+      width="270px"
       isPopover={true}>
       <Column mt="12px" space="12px">
         <>

--- a/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/HomeScreen/components/TemporaryLocationCallout.tsx
@@ -85,8 +85,7 @@ export const TemporaryLocationCallout = ({
         <LatLngDetail isCurrentLocation={isCurrentLocation} coords={coords} />
       }
       buttons={<CloseButton onPress={closeCallout} />}
-      width="90%"
-      maxWidth="350px"
+      width="350px"
       isPopover={true}>
       <Column mt="12px" space="12px">
         <>


### PR DESCRIPTION
## Description
Wrap long site names in site card and app bar

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1656.

Before:
<img width="250" alt="Screenshot 2024-07-25 at 12 52 44 PM" src="https://github.com/user-attachments/assets/4512cf06-b13a-41df-9e2c-f5af1dbde2b4"><img width="250" alt="Screenshot 2024-07-25 at 1 48 01 PM" src="https://github.com/user-attachments/assets/33a47762-f3e6-48a9-bf96-64901932caf4">

After:
<img width="250" alt="Screenshot 2024-07-25 at 12 56 14 PM" src="https://github.com/user-attachments/assets/5dcd3efd-d9f6-47b9-841a-e08c688c6c5f"><img width="250" alt="Screenshot 2024-07-25 at 1 47 24 PM" src="https://github.com/user-attachments/assets/8f822a60-0022-4199-a39f-bf52980f7763">

