### PR TITLE
fix: remove tooltip from and fix spacing on transfer sites screen

### DIFF
--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -209,7 +209,7 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
               </Text>
             }
             boxProps={{
-              mb: projectSites.length === 0 ? '2px' : undefined,
+              mb: '2px',
             }}
             initiallyOpen={projectSites.length > 0}
             disableOpen={projectSites.length === 0}>

--- a/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/components/ListHeader.tsx
@@ -25,7 +25,6 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {HelpTooltipButton} from 'terraso-mobile-client/components/tooltips/HelpTooltipButton';
 
 type Props = {query: string; setQuery: (query: string) => void};
 
@@ -35,9 +34,6 @@ export const ListHeader = memo(({query, setQuery}: Props) => {
     <Column space="10px" px="12px" pt="10px" pb="10px">
       <Row>
         <Heading>{t('projects.transfer_sites.heading')}</Heading>
-        <HelpTooltipButton>
-          {t('projects.transfer_sites.tooltip')}
-        </HelpTooltipButton>
       </Row>
       <Text>{t('projects.transfer_sites.description')}</Text>
       <Searchbar

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -362,8 +362,7 @@
     "transfer_sites": {
       "heading": "Transfer Sites to this Project",
       "description": "Transfer LandPKS Soil ID sites you manage to this project. When you transfer sites, they will use the data settings and team member roles from this project.",
-      "unaffiliated": "Unaffiliated",
-      "tooltip": "Sites you transfer to this project will inherit this project’s data settings, input requirements, and team members."
+      "unaffiliated": "Unaffiliated"
     },
     "form": {
       "name_min_length_error": "Project name must be at least {{min}} characters",


### PR DESCRIPTION
## Description
Remove tooltip from transfer sites screen
Add spacing below site transfer accordion with sites.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1846 and https://github.com/techmatters/terraso-mobile-client/issues/1845