### PR TITLE
fix: gracefully handle NationalMaps.gov "unable to process" error

### DIFF
--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -18,6 +18,7 @@
 import {formatCoordinate} from 'terraso-mobile-client/util';
 
 const OUT_OF_RANGE_MESSAGE = 'Invalid or missing input parameters.';
+const UNABLE_TO_PROCESS_MESSAGE = 'Unable to complete operation.';
 
 export const getElevation = async (
   lat: number,
@@ -38,7 +39,7 @@ export const getElevation = async (
       `https://epqs.nationalmap.gov/v1/json/?${queryString}`,
     );
     const result = await response.text();
-    if (result === OUT_OF_RANGE_MESSAGE) {
+    if ([OUT_OF_RANGE_MESSAGE, UNABLE_TO_PROCESS_MESSAGE].includes(result)) {
       elevation = undefined;
     } else {
       elevation = parseFloat(JSON.parse(result).value);


### PR DESCRIPTION
## Description
Gracefully handle NationalMaps.gov "unable to process" error

Example: 
```
https://epqs.nationalmap.gov/v1/json/?x=%D9%A4%D9%A4%D9%AB%D9%A6%D9%A7%D9%A8%D9%A0%D9%A2&y=%D9%A1%D9%A4%D9%AB%D9%A2%D9%A3%D9%A8%D9%A3%D9%A1&units=Meters
```

Addresses Sentry https://techmatters.sentry.io/issues/5504862811/?