### PR TITLE
docs: Add a github issue template that sets project = LandPKS

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_LandPKS_project.yml
+++ b/.github/ISSUE_TEMPLATE/general_LandPKS_project.yml
@@ -1,0 +1,3 @@
+name: "General (LandPKS Project)"
+description: Regular blank issue, with Project = LandPKS
+projects: ["techmatters/7"]


### PR DESCRIPTION
Occasionally we'd file a mobile-client issue and forget to add it to the LandPKS project, which means it doesn't show up in our backlog views. 

Side question: Is there a way to confirm this works before merging it?