### PR TITLE
fix: update name of team button; ensure width is size of text label

### DIFF
--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -28,6 +28,7 @@ import {selectProjectMembershipsWithUsers} from 'terraso-client-shared/selectors
 
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
 import {
+  Box,
   Column,
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
@@ -92,15 +93,17 @@ export const ProjectTeamScreen = ({route}: Props) => {
   return (
     <Column height="full" p={4} space={3} backgroundColor="background.default">
       <RestrictByProjectRole role="MANAGER">
-        <AddButton
-          text={t('projects.team.add')}
-          buttonProps={{
-            onPress: () =>
-              navigation.navigate('ADD_USER_PROJECT', {
-                projectId: route.params.projectId,
-              }),
-          }}
-        />
+        <Box alignSelf="flex-start">
+          <AddButton
+            text={t('projects.team.add')}
+            buttonProps={{
+              onPress: () =>
+                navigation.navigate('ADD_USER_PROJECT', {
+                  projectId: route.params.projectId,
+                }),
+            }}
+          />
+        </Box>
       </RestrictByProjectRole>
       <Heading variant="h6" py="20px">
         {t('projects.team.manage_team')}

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -279,7 +279,7 @@
       }
     },
     "team": {
-      "add": "Add team members",
+      "add": "Add team member",
       "manage_team": "Manage Team",
       "leave_project_modal": {
         "trigger": "LEAVE PROJECT",


### PR DESCRIPTION
## Description
Update name of team button to Add Team Member; ensure button width is size of text label.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1890
The button width became full width when `alignItems="flex-start"` was removed in https://github.com/techmatters/terraso-mobile-client/pull/1878/commits/bab67a8110f5d18a29dde7369ad529a95c544e30 as part of https://github.com/techmatters/terraso-mobile-client/pull/1878