### PR TITLE
fix: Ask for location permissions on home screen after login

### DIFF
--- a/dev-client/src/navigation/navigators/RootNavigator.tsx
+++ b/dev-client/src/navigation/navigators/RootNavigator.tsx
@@ -18,16 +18,13 @@
 import {useEffect} from 'react';
 
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
-import {Location, locationManager} from '@rnmapbox/maps';
 
 import {
   fetchUser,
   setHasAccessTokenAsync,
 } from 'terraso-client-shared/account/accountSlice';
 
-import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
 import {useStorage} from 'terraso-mobile-client/hooks/useStorage';
-import {updateLocation} from 'terraso-mobile-client/model/map/mapSlice';
 import {DEFAULT_STACK_NAVIGATOR_OPTIONS} from 'terraso-mobile-client/navigation/constants';
 import {
   modalScreens,
@@ -63,30 +60,6 @@ export const RootNavigator = () => {
       dispatch(fetchUser());
     }
   }, [hasToken, currentUser, dispatch]);
-
-  useEffect(() => {
-    locationManager.getLastKnownLocation().then(initCoords => {
-      if (initCoords !== null) {
-        dispatch(
-          updateLocation({
-            coords: initCoords.coords,
-            accuracyM: initCoords.coords.accuracy ?? null,
-          }),
-        );
-      }
-    });
-
-    // add listener to update location on user movement
-    const listener = ({coords}: Location) => {
-      dispatch(
-        updateLocation({coords: coords, accuracyM: coords.accuracy ?? null}),
-      );
-    };
-    locationManager.setMinDisplacement(USER_DISPLACEMENT_MIN_DISTANCE_M);
-    locationManager.addListener(listener);
-
-    return () => locationManager.removeListener(listener);
-  }, [dispatch]);
 
   return (
     <RootStack.Navigator


### PR DESCRIPTION
## Description
App used to do location stuff in RootNavigator, resulting in asking user for location permission on the welcome screen. Now do the same stuff, but instead on the BottomTabsScreen (which would ask for permissions effectively on the home screen after login)

Relatedly: I don't think _everything_ you could do to `locationManager` implicitly launches a permissions check -- like you can do locationManager.setMinDisplacement and it doesn't -- but it seems like stuff to do with using the user's location does.

**Side note**: There is still this warning before user has given permissions (was happening from RootNavigator code, now in BottomTabsScreen because this change moves the code there), but that seems like an orthogonal concern:
![Screenshot 2024-08-01 at 10 04 39 AM](https://github.com/user-attachments/assets/c6493fdf-9fe2-4a03-b8de-5869752b77c3)

### Related Issues
Addresses #1808 

### Verification steps
1. Uninstall and reinstall app
2. Open the app (shouldn't see location permission prompt)
3. Get past the welcome screen and log in (now should see location permission prompt)