### PR TITLE
fix: Auto-add 'bug' label to mobile bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
@@ -1,52 +1,52 @@
 name: "Mobile App Bug Report"
 description: Used for reporting bugs and defects in mobile apps.
-labels: "needs triage"
+labels: ["bug", "needs triage"]
 body:
-- type: input
-  id: app-version
-  attributes:
-    label: App Version
-    placeholder: 1.0.0 (40)
-  validations:
-    required: true
-- type: input
-  id: email
-  attributes:
-    label: Account
-    placeholder: jdoe@example.com
-    description: Provide an email address only if the problem is account-related/account-specific.
-- type: checkboxes
-  id: platform
-  attributes:
-    label: Platforms
-    description: If the problem is limited to a specific platform, indicate which one.
-    options:
-      - label: "iOS"
-      - label: "Android"
-      - label: "iOS simulator"
-      - label: "Android emulator"
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Description
-    description: A clear and concise description of the problem.
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Steps to Reproduce
-    placeholder: |
-      1. ...
-      1. ...
-      1. ...
-- type: textarea
-  attributes:
-    label: Expected behavior
-- type: textarea
-  attributes:
-    label: Actual behavior
-- type: textarea
-  attributes:
-    label: Additional context
-    description: Include screen shots, videos, backtraces, etc.
+  - type: input
+    id: app-version
+    attributes:
+      label: App Version
+      placeholder: 1.0.0 (40)
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Account
+      placeholder: jdoe@example.com
+      description: Provide an email address only if the problem is account-related/account-specific.
+  - type: checkboxes
+    id: platform
+    attributes:
+      label: Platforms
+      description: If the problem is limited to a specific platform, indicate which one.
+      options:
+        - label: "iOS"
+        - label: "Android"
+        - label: "iOS simulator"
+        - label: "Android emulator"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. ...
+        1. ...
+        1. ...
+  - type: textarea
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    attributes:
+      label: Actual behavior
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Include screen shots, videos, backtraces, etc.


### PR DESCRIPTION
Based on [GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)

@paulschreiber From [this PR](https://github.com/techmatters/terraso-mobile-client/pull/1735/commits/b345a92649dc9f3bda021b2933e1677a91a87764), it looks intentional that we removed the "bug" label, do you remember why? 