### PR TITLE
fix: when clearing steepness precent or degree, clear counterpart

### DIFF
--- a/dev-client/src/screens/SlopeScreen/components/ManualSteepnessModal.tsx
+++ b/dev-client/src/screens/SlopeScreen/components/ManualSteepnessModal.tsx
@@ -144,7 +144,9 @@ export const ManualSteepnessModal = ({siteId}: Props) => {
                 onChangeText={text => {
                   handleChange('slopeSteepnessPercent')(text);
                   setLastTouched('slopeSteepnessPercent');
-                  if (
+                  if (text === '') {
+                    handleChange('slopeSteepnessDegree')('');
+                  } else if (
                     (
                       yup.reach(
                         schema,
@@ -170,7 +172,9 @@ export const ManualSteepnessModal = ({siteId}: Props) => {
                 onChangeText={text => {
                   handleChange('slopeSteepnessDegree')(text);
                   setLastTouched('slopeSteepnessDegree');
-                  if (
+                  if (text === '') {
+                    handleChange('slopeSteepnessPercent')('');
+                  } else if (
                     (
                       yup.reach(
                         schema,


### PR DESCRIPTION
## Description
When clearing steepness precent or degree, clear counterpart.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/841