### PR TITLE
fix: remove site data entry for viewers

### DIFF
--- a/dev-client/__tests__/snapshot/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -2403,7 +2403,7 @@ exports[`renders correctly 1`] = `
                                                   lineHeight="24px"
                                                   style={
                                                     {
-                                                      "color": "#1A202C",
+                                                      "color": "#9EA8AB",
                                                       "fontSize": 16,
                                                       "fontWeight": "400",
                                                     }
@@ -2413,7 +2413,7 @@ exports[`renders correctly 1`] = `
                                                 </Text>
                                               </View>
                                               <Icon
-                                                color="#1A202C"
+                                                color="#8B9498"
                                                 name="arrow-drop-down"
                                                 size={24}
                                                 style={{}}

--- a/dev-client/src/components/inputs/Select.tsx
+++ b/dev-client/src/components/inputs/Select.tsx
@@ -94,11 +94,16 @@ export const Select = <T, Nullable extends boolean>({
               ) : (
                 <></>
               )}
-              <Text variant="input-text">
+              <Text
+                variant="input-text"
+                color={disabled ? 'text.disabled' : 'text.primary'}>
                 {value === null ? label : renderValue(value)}
               </Text>
             </Column>
-            <Icon color="action.active" name="arrow-drop-down" />
+            <Icon
+              color={disabled ? 'action.disabled' : 'action.active'}
+              name="arrow-drop-down"
+            />
           </Row>
         </Pressable>
       )}>

--- a/dev-client/src/components/inputs/Select.tsx
+++ b/dev-client/src/components/inputs/Select.tsx
@@ -128,7 +128,7 @@ export const Select = <T, Nullable extends boolean>({
             if (optionKey) {
               key = option === null ? null : optionKey(option);
             } else {
-              key = itemLabel;
+              key = itemLabel === undefined ? '' : itemLabel;
             }
             return (
               <MenuItem

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -15,6 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {ProjectMembershipProjectRoleChoices} from 'terraso-client-shared/graphqlSchema/graphql';
 import {SiteUserRole} from 'terraso-client-shared/selectors';
 
 export const matchesOne =
@@ -36,6 +37,11 @@ export const SITE_EDITOR_ROLES: SiteUserRole[] = [
   {kind: 'project', role: 'MANAGER'},
   {kind: 'project', role: 'CONTRIBUTOR'},
   {kind: 'site', role: 'OWNER'},
+];
+
+export const PROJECT_EDITOR_ROLES: ProjectMembershipProjectRoleChoices[] = [
+  'MANAGER',
+  'CONTRIBUTOR',
 ];
 
 export const isProjectViewer = (userRole: SiteUserRole | null) => {

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -32,3 +32,18 @@ export const isSiteManager = matchesRole([
   {kind: 'project', role: 'MANAGER'},
 ]);
 
+export const SITE_EDITOR_ROLES: SiteUserRole[] = [
+  {kind: 'project', role: 'MANAGER'},
+  {kind: 'project', role: 'CONTRIBUTOR'},
+  {kind: 'site', role: 'OWNER'},
+];
+
+export const isProjectViewer = (userRole: SiteUserRole | null) => {
+  return Boolean(userRole && ['VIEWER'].includes(userRole.role));
+};
+
+export const isProjectEditor = (userRole: SiteUserRole | null) => {
+  return Boolean(
+    userRole && ['MANAGER', 'CONTRIBUTOR', 'OWNER'].includes(userRole.role),
+  );
+};

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {SiteUserRole} from 'terraso-client-shared/selectors';
+
+export const matchesOne =
+  <T>(cmp: (a: T, b: T) => boolean) =>
+  (examples: T[]) =>
+  (sample: T) =>
+    examples.filter(x => cmp(x, sample)).length > 0;
+
+export const matchesRole = matchesOne(
+  (a: SiteUserRole, b: SiteUserRole) => a.kind === b.kind && a.role === b.role,
+);
+
+export const isSiteManager = matchesRole([
+  {kind: 'site', role: 'OWNER'},
+  {kind: 'project', role: 'MANAGER'},
+]);
+

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -22,7 +22,7 @@ export const matchesOne =
   <T>(cmp: (a: T, b: T) => boolean) =>
   (examples: T[]) =>
   (sample: T) =>
-    examples.filter(x => cmp(x, sample)).length > 0;
+    examples.find(x => cmp(x, sample)) !== undefined;
 
 export const matchesRole = matchesOne(
   (a: SiteUserRole, b: SiteUserRole) => a.kind === b.kind && a.role === b.role,

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -44,6 +44,10 @@ export const PROJECT_EDITOR_ROLES: ProjectMembershipProjectRoleChoices[] = [
   'CONTRIBUTOR',
 ];
 
+export const PROJECT_MANAGER_ROLES: ProjectMembershipProjectRoleChoices[] = [
+  'MANAGER',
+];
+
 export const isProjectViewer = (userRole: SiteUserRole | null) => {
   return Boolean(userRole && ['VIEWER'].includes(userRole.role));
 };

--- a/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardScreen.tsx
@@ -23,6 +23,7 @@ import {useSoilIdData} from 'terraso-client-shared/soilId/soilIdHooks';
 import {Coords} from 'terraso-client-shared/types';
 
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {isSiteManager} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AppBarIconButton} from 'terraso-mobile-client/navigation/components/AppBarIconButton';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -33,7 +34,6 @@ import {
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
-import {isSiteManager} from 'terraso-mobile-client/util';
 
 type Props = ({siteId: string} | {coords: Coords} | {elevation: number}) & {
   initialTab?: SiteTabName;

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSlopeDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSlopeDataSection.tsx
@@ -31,6 +31,7 @@ import {
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {
   renderSlopeSteepnessDegree,
@@ -79,12 +80,7 @@ export const SiteSlopeDataSection = ({siteId}: Props) => {
           )}
         </Box>
 
-        <RestrictBySiteRole
-          role={[
-            {kind: 'site', role: 'OWNER'},
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <Box paddingVertical="lg">
             <Button
               _text={{textTransform: 'uppercase'}}

--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteSoilPropertiesDataSection.tsx
@@ -33,6 +33,7 @@ import {
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {rowsFromSiteSoilData} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesData';
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesDataTable';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteLocationDashboardTabNavigator';
 import {useSelector} from 'terraso-mobile-client/store';
@@ -62,12 +63,7 @@ export const SiteSoilPropertiesDataSection = ({siteId}: Props) => {
 
       <Box marginTop="sm" />
       <SoilPropertiesDataTable rows={dataTableRows} />
-      <RestrictBySiteRole
-        role={[
-          {kind: 'site', role: 'OWNER'},
-          {kind: 'project', role: 'MANAGER'},
-          {kind: 'project', role: 'CONTRIBUTOR'},
-        ]}>
+      <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
         <Box paddingVertical="lg">
           <Button
             _text={{textTransform: 'uppercase'}}

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -36,6 +36,7 @@ import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {DataPrivacyInfoSheetButton} from 'terraso-mobile-client/components/sheets/privacy/DataPrivacyInfoSheetButton';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
+import {PROJECT_MANAGER_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {
   TabRoutes,
   TabStackParamList,
@@ -103,7 +104,7 @@ export const ProjectInputScreen = ({
               allDisabled={!allowEditing}
             />
           </Row>
-          <RestrictByProjectRole role="MANAGER">
+          <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
             <Text bold>{t('projects.inputs.instructions.title')}</Text>
             <Text>{t('projects.inputs.instructions.description')}</Text>
             <Button
@@ -138,7 +139,7 @@ export const ProjectInputScreen = ({
           <RequiredDataSettings projectId={projectId} enabled={allowEditing} />
         </Accordion>
       </ScrollView>
-      <RestrictByProjectRole role="MANAGER">
+      <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
         <Fab
           onPress={() => onSave()}
           textTransform="uppercase"

--- a/dev-client/src/screens/ProjectInputScreen/SoilPitSettings.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/SoilPitSettings.tsx
@@ -43,6 +43,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
+import {PROJECT_MANAGER_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {DepthTable} from 'terraso-mobile-client/screens/ProjectInputScreen/DepthTable';
 import {useDispatch} from 'terraso-mobile-client/store';
 
@@ -125,7 +126,7 @@ export const SoilPitSettings = ({projectId}: {projectId: string}) => {
         />
       )}
       {isCustom && (
-        <RestrictByProjectRole role="MANAGER">
+        <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
           <Modal
             trigger={onOpen => (
               <Button

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -33,6 +33,7 @@ import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
+import {PROJECT_MANAGER_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {
   TabRoutes,
   TabStackParamList,
@@ -82,7 +83,7 @@ export function ProjectSettingsScreen({
           description={description}
           userRole={userRole}
         />
-        <RestrictByProjectRole role="MANAGER">
+        <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
           <ConfirmModal
             title={t('projects.settings.delete_button_prompt')}
             actionName={t('projects.settings.delete_button')}

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -54,6 +54,7 @@ import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictBy
 import {SiteCard} from 'terraso-mobile-client/components/SiteCard';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
+import {PROJECT_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {
   TabRoutes,
   TabStackParamList,
@@ -279,12 +280,12 @@ export function ProjectSitesScreen({
       {isEmpty && (
         <>
           <Text>{t('projects.sites.empty_viewer')}</Text>
-          <RestrictByProjectRole role={['MANAGER', 'CONTRIBUTOR']}>
+          <RestrictByProjectRole role={PROJECT_EDITOR_ROLES}>
             <Text>{t('projects.sites.empty_contributor')}</Text>
           </RestrictByProjectRole>
         </>
       )}
-      <RestrictByProjectRole role={['MANAGER', 'CONTRIBUTOR']}>
+      <RestrictByProjectRole role={PROJECT_EDITOR_ROLES}>
         <Button
           onPress={transferCallback}
           alignSelf="flex-start"

--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -34,6 +34,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
+import {PROJECT_MANAGER_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {
   TabRoutes,
   TabStackParamList,
@@ -92,7 +93,7 @@ export const ProjectTeamScreen = ({route}: Props) => {
 
   return (
     <Column height="full" p={4} space={3} backgroundColor="background.default">
-      <RestrictByProjectRole role="MANAGER">
+      <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
         <Box alignSelf="flex-start">
           <AddButton
             text={t('projects.team.add')}

--- a/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
@@ -30,6 +30,7 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteInstructionsCard} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteInstructionsCard';
 import {SiteNoteCard} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteCard';
@@ -67,12 +68,7 @@ export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
         {project?.siteInstructions && (
           <SiteInstructionsCard siteInstructions={project?.siteInstructions} />
         )}
-        <RestrictBySiteRole
-          role={[
-            {kind: 'site', role: 'OWNER'},
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <Box pl={4} pb={4} alignItems="flex-start">
             <Button
               size="lg"

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -47,6 +47,7 @@ import {
   Heading,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -153,7 +154,14 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
           minimumPerRow={3}
         />
       </ScrollView>
-      <DoneButton />
+      <RestrictBySiteRole
+        role={[
+          {kind: 'site', role: 'OWNER'},
+          {kind: 'project', role: 'MANAGER'},
+          {kind: 'project', role: 'CONTRIBUTOR'},
+        ]}>
+        <DoneButton />
+      </RestrictBySiteRole>
     </ScreenScaffold>
   );
 };

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -166,12 +166,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
             minimumPerRow={3}
           />
         </ScrollView>
-        <RestrictBySiteRole
-          role={[
-            {kind: 'site', role: 'OWNER'},
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <DoneButton />
         </RestrictBySiteRole>
       </SiteRoleContextProvider>

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -53,6 +53,10 @@ import {
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {
+  isProjectViewer,
+  SITE_EDITOR_ROLES,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {SlopeShapeInfoContent} from 'terraso-mobile-client/screens/SlopeScreen/components/SlopeShapeInfoContent';
@@ -74,10 +78,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
 
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
 
-  const isViewer = useMemo(
-    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
-    [userRole],
-  );
+  const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
   const options = useMemo<Record<CombinedSlope, ImageRadioOption>>(
     () => ({

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -49,6 +49,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {SlopeShapeInfoContent} from 'terraso-mobile-client/screens/SlopeScreen/components/SlopeShapeInfoContent';
@@ -132,36 +133,38 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
 
   return (
     <ScreenScaffold AppBar={<AppBar title={name} />} BottomNavigation={null}>
-      <ScrollView
-        bg="primary.contrast"
-        _contentContainerStyle={styles.scrollContentContainer}>
-        <Column>
-          <Column p="15px" bg="primary.contrast">
-            <Row alignItems="center">
-              <Heading variant="h6">{t('slope.shape.long_title')}</Heading>
-              <InfoOverlaySheetButton Header={t('slope.shape.info.title')}>
-                <SlopeShapeInfoContent />
-              </InfoOverlaySheetButton>
-            </Row>
+      <SiteRoleContextProvider siteId={siteId}>
+        <ScrollView
+          bg="primary.contrast"
+          _contentContainerStyle={styles.scrollContentContainer}>
+          <Column>
+            <Column p="15px" bg="primary.contrast">
+              <Row alignItems="center">
+                <Heading variant="h6">{t('slope.shape.long_title')}</Heading>
+                <InfoOverlaySheetButton Header={t('slope.shape.info.title')}>
+                  <SlopeShapeInfoContent />
+                </InfoOverlaySheetButton>
+              </Row>
+            </Column>
           </Column>
-        </Column>
-        <ImageRadio
-          value={
-            downSlope && crossSlope ? `${downSlope}:${crossSlope}` : undefined
-          }
-          options={options}
-          onChange={onChange}
-          minimumPerRow={3}
-        />
-      </ScrollView>
-      <RestrictBySiteRole
-        role={[
-          {kind: 'site', role: 'OWNER'},
-          {kind: 'project', role: 'MANAGER'},
-          {kind: 'project', role: 'CONTRIBUTOR'},
-        ]}>
-        <DoneButton />
-      </RestrictBySiteRole>
+          <ImageRadio
+            value={
+              downSlope && crossSlope ? `${downSlope}:${crossSlope}` : undefined
+            }
+            options={options}
+            onChange={onChange}
+            minimumPerRow={3}
+          />
+        </ScrollView>
+        <RestrictBySiteRole
+          role={[
+            {kind: 'site', role: 'OWNER'},
+            {kind: 'project', role: 'MANAGER'},
+            {kind: 'project', role: 'CONTRIBUTOR'},
+          ]}>
+          <DoneButton />
+        </RestrictBySiteRole>
+      </SiteRoleContextProvider>
     </ScreenScaffold>
   );
 };

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -25,7 +25,10 @@ import {
   SoilIdSoilDataCrossSlopeChoices,
   SoilIdSoilDataDownSlopeChoices,
 } from 'terraso-client-shared/graphqlSchema/graphql';
-import {selectSoilData} from 'terraso-client-shared/selectors';
+import {
+  selectSoilData,
+  selectUserRoleSite,
+} from 'terraso-client-shared/selectors';
 import {updateSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
 
 import ConcaveConcave from 'terraso-mobile-client/assets/slope/shape/concave-concave.svg';
@@ -68,6 +71,13 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
   const {t} = useTranslation();
   const {downSlope, crossSlope} = useSelector(selectSoilData(siteId));
   const dispatch = useDispatch();
+
+  const userRole = useSelector(state => selectUserRoleSite(state, siteId));
+
+  const isViewer = useMemo(
+    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
+    [userRole],
+  );
 
   const options = useMemo<Record<CombinedSlope, ImageRadioOption>>(
     () => ({
@@ -152,7 +162,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
               downSlope && crossSlope ? `${downSlope}:${crossSlope}` : undefined
             }
             options={options}
-            onChange={onChange}
+            onChange={isViewer ? () => {} : onChange}
             minimumPerRow={3}
           />
         </ScrollView>

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -48,6 +48,10 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {
+  isProjectViewer,
+  SITE_EDITOR_ROLES,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -75,10 +79,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
 
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
 
-  const isViewer = useMemo(
-    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
-    [userRole],
-  );
+  const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
   const steepnessOptions = useMemo(
     () =>

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -22,7 +22,10 @@ import {Image, StyleSheet} from 'react-native';
 import {Button, ScrollView} from 'native-base';
 
 import {SoilIdSoilDataSlopeSteepnessSelectChoices} from 'terraso-client-shared/graphqlSchema/graphql';
-import {selectSoilData} from 'terraso-client-shared/selectors';
+import {
+  selectSoilData,
+  selectUserRoleSite,
+} from 'terraso-client-shared/selectors';
 import {updateSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
@@ -69,6 +72,13 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
     useState<SoilIdSoilDataSlopeSteepnessSelectChoices | null>(null);
   const confirmationModalRef = useRef<ModalHandle>(null);
   const navigation = useNavigation();
+
+  const userRole = useSelector(state => selectUserRoleSite(state, siteId));
+
+  const isViewer = useMemo(
+    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
+    [userRole],
+  );
 
   const steepnessOptions = useMemo(
     () =>
@@ -179,7 +189,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
           <ImageRadio
             value={soilData.slopeSteepnessSelect}
             options={steepnessOptions as any}
-            onChange={onSteepnessOptionSelected}
+            onChange={isViewer ? () => {} : onSteepnessOptionSelected}
             minimumPerRow={2}
           />
         </ScrollView>

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -145,12 +145,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
             </Column>
           </Column>
           <Column p="15px" bg="grey.300">
-            <RestrictBySiteRole
-              role={[
-                {kind: 'site', role: 'OWNER'},
-                {kind: 'project', role: 'MANAGER'},
-                {kind: 'project', role: 'CONTRIBUTOR'},
-              ]}>
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
               <Text variant="body1">{t('slope.steepness.description')}</Text>
               <Box height="30px" />
               <Row justifyContent="space-between">
@@ -193,12 +188,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
             minimumPerRow={2}
           />
         </ScrollView>
-        <RestrictBySiteRole
-          role={[
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-            {kind: 'site', role: 'OWNER'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <DoneButton />
         </RestrictBySiteRole>
       </SiteRoleContextProvider>

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -120,12 +120,7 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
               </InfoOverlaySheetButton>
             </Row>
             <Box flex={1} />
-            <RestrictBySiteRole
-              role={[
-                {kind: 'project', role: 'MANAGER'},
-                {kind: 'project', role: 'CONTRIBUTOR'},
-                {kind: 'site', role: 'OWNER'},
-              ]}>
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
               {(workflow === 'CAMERA' || color) && (
                 <SwitchWorkflowButton {...props} />
               )}
@@ -146,12 +141,7 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
             {workflow === 'CAMERA' && <PhotoConditions {...props} />}
           </>
         )}
-        <RestrictBySiteRole
-          role={[
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-            {kind: 'site', role: 'OWNER'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <Box position="absolute" right="0" bottom="0">
             <DoneButton isDisabled={!color} />
           </Box>

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -41,6 +41,10 @@ import {
   isColorComplete,
   MunsellColor,
 } from 'terraso-mobile-client/model/color/munsellConversions';
+import {
+  isProjectEditor,
+  SITE_EDITOR_ROLES,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {CameraWorkflow} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/CameraWorkflow';
 import {ColorDisplay} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/ColorDisplay';
 import {ManualWorkflow} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/ManualWorkflow';
@@ -75,11 +79,7 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
     selectUserRoleSite(state, props.siteId),
   );
 
-  const canDelete = useMemo(
-    () =>
-      userRole && ['MANAGER', 'CONTRIBUTOR', 'OWNER'].includes(userRole.role),
-    [userRole],
-  );
+  const canDelete = useMemo(() => isProjectEditor(userRole), [userRole]);
 
   const onClearValues = useCallback(() => {
     dispatch(

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/CameraWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/CameraWorkflow.tsx
@@ -30,6 +30,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
@@ -54,12 +55,7 @@ export const CameraWorkflow = (props: SoilPitInputScreenProps) => {
 
   return (
     <SiteRoleContextProvider siteId={props.siteId}>
-      <RestrictBySiteRole
-        role={[
-          {kind: 'project', role: 'MANAGER'},
-          {kind: 'project', role: 'CONTRIBUTOR'},
-          {kind: 'site', role: 'OWNER'},
-        ]}>
+      <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
         <Column>
           <Box alignItems="center" paddingVertical="lg">
             <PickImageButton

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/CameraWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/CameraWorkflow.tsx
@@ -28,6 +28,8 @@ import {
   Column,
   Paragraph,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
@@ -51,26 +53,35 @@ export const CameraWorkflow = (props: SoilPitInputScreenProps) => {
   );
 
   return (
-    <Column>
-      <Box alignItems="center" paddingVertical="lg">
-        <PickImageButton
-          featureName={t('soil.color.featureName')}
-          onPick={onPickImage}
-        />
-      </Box>
-      <Column
-        backgroundColor="grey.300"
-        paddingHorizontal="md"
-        paddingVertical="lg"
-        alignItems="flex-start">
-        <Paragraph>{t('soil.color.photo_need_help')}</Paragraph>
-        <Button
-          _text={{textTransform: 'uppercase'}}
-          onPress={onUseGuide}
-          rightIcon={<Icon name="chevron-right" />}>
-          {t('soil.color.use_guide_label')}
-        </Button>
-      </Column>
-    </Column>
+    <SiteRoleContextProvider siteId={props.siteId}>
+      <RestrictBySiteRole
+        role={[
+          {kind: 'project', role: 'MANAGER'},
+          {kind: 'project', role: 'CONTRIBUTOR'},
+          {kind: 'site', role: 'OWNER'},
+        ]}>
+        <Column>
+          <Box alignItems="center" paddingVertical="lg">
+            <PickImageButton
+              featureName={t('soil.color.featureName')}
+              onPick={onPickImage}
+            />
+          </Box>
+          <Column
+            backgroundColor="grey.300"
+            paddingHorizontal="md"
+            paddingVertical="lg"
+            alignItems="flex-start">
+            <Paragraph>{t('soil.color.photo_need_help')}</Paragraph>
+            <Button
+              _text={{textTransform: 'uppercase'}}
+              onPress={onUseGuide}
+              rightIcon={<Icon name="chevron-right" />}>
+              {t('soil.color.use_guide_label')}
+            </Button>
+          </Column>
+        </Column>
+      </RestrictBySiteRole>
+    </SiteRoleContextProvider>
   );
 };

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
@@ -20,7 +20,10 @@ import {useTranslation} from 'react-i18next';
 import {StyleSheet} from 'react-native';
 import Animated, {LinearTransition} from 'react-native-reanimated';
 
-import {selectDepthDependentData} from 'terraso-client-shared/selectors';
+import {
+  selectDepthDependentData,
+  selectUserRoleSite,
+} from 'terraso-client-shared/selectors';
 import {
   ColorChroma,
   ColorHueSubstep,
@@ -39,6 +42,8 @@ import {
   Paragraph,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {
   isColorComplete,
   parseMunsellHue,
@@ -58,6 +63,15 @@ export const ManualWorkflow = (props: SoilPitInputScreenProps) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const data = useSelector(selectDepthDependentData(props));
+
+  const userRole = useSelector(state =>
+    selectUserRoleSite(state, props.siteId),
+  );
+
+  const isViewer = useMemo(
+    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
+    [userRole],
+  );
 
   const {hue: initialHue, substep: initialSubstep} = renderMunsellHue(data);
 
@@ -115,78 +129,91 @@ export const ManualWorkflow = (props: SoilPitInputScreenProps) => {
   const validOptions = useMemo(() => validProperties(color), [color]);
 
   return (
-    <Column>
-      <Row padding="md" rowGap={24} flexWrap="wrap" alignItems="center">
-        {color.hue !== 'N' && (
-          <>
+    <SiteRoleContextProvider siteId={props.siteId}>
+      <Column>
+        <Row padding="md" rowGap={24} flexWrap="wrap" alignItems="center">
+          {color.hue !== 'N' && (
+            <>
+              <Select
+                disabled={isViewer}
+                nullable
+                options={validOptions.substeps}
+                value={color.substep}
+                label={t('soil.color.hue')}
+                onValueChange={onUpdateSubstep}
+                renderValue={value => value.toString()}
+                {...styles.propertySelect}
+              />
+              <Box flex={1} />
+            </>
+          )}
+          <Animated.View layout={LinearTransition}>
             <Select
+              disabled={isViewer}
               nullable
-              options={validOptions.substeps}
-              value={color.substep}
+              options={soilColorHues}
+              value={color.hue}
               label={t('soil.color.hue')}
-              onValueChange={onUpdateSubstep}
-              renderValue={value => value.toString()}
+              onValueChange={onUpdateHue}
+              renderValue={value => value}
               {...styles.propertySelect}
             />
-            <Box flex={1} />
-          </>
-        )}
-        <Animated.View layout={LinearTransition}>
-          <Select
-            nullable
-            options={soilColorHues}
-            value={color.hue}
-            label={t('soil.color.hue')}
-            onValueChange={onUpdateHue}
-            renderValue={value => value}
-            {...styles.propertySelect}
-          />
-        </Animated.View>
-        {color.hue === 'N' && <Box flex={1} />}
-        <Animated.View layout={LinearTransition}>
-          <Select
-            nullable
-            value={color.value}
-            options={validOptions.values}
-            onValueChange={onUpdateValue}
-            renderValue={value => value.toString()}
-            label={t('soil.color.value')}
-            {...styles.propertySelect}
-          />
-        </Animated.View>
-        <Animated.View layout={LinearTransition} style={styles.slash}>
-          <Heading variant="h6" textAlign="center">
-            /
-          </Heading>
-        </Animated.View>
-        {color.chroma !== 0 && (
-          <Select
-            nullable
-            value={color.chroma}
-            options={validOptions.chromas}
-            onValueChange={onUpdateChroma}
-            renderValue={chroma => chroma.toString()}
-            label={t('soil.color.chroma')}
-            {...styles.propertySelect}
-          />
-        )}
-      </Row>
-      {!isColorComplete(data) && (
-        <Column
-          paddingHorizontal="md"
-          paddingVertical="lg"
-          backgroundColor="grey.300"
-          alignItems="flex-start">
-          <Paragraph variant="body1">
-            {t('soil.color.use_photo_instead')}
-          </Paragraph>
-          <SwitchWorkflowButton
-            {...props}
-            rightIcon={<Icon name="chevron-right" />}
-          />
-        </Column>
-      )}
-    </Column>
+          </Animated.View>
+          {color.hue === 'N' && <Box flex={1} />}
+          <Animated.View layout={LinearTransition}>
+            <Select
+              disabled={isViewer}
+              nullable
+              value={color.value}
+              options={validOptions.values}
+              onValueChange={onUpdateValue}
+              renderValue={value => value.toString()}
+              label={t('soil.color.value')}
+              {...styles.propertySelect}
+            />
+          </Animated.View>
+          <Animated.View layout={LinearTransition} style={styles.slash}>
+            <Heading variant="h6" textAlign="center">
+              /
+            </Heading>
+          </Animated.View>
+          {color.chroma !== 0 && (
+            <Select
+              disabled={isViewer}
+              nullable
+              value={color.chroma}
+              options={validOptions.chromas}
+              onValueChange={onUpdateChroma}
+              renderValue={chroma => chroma.toString()}
+              label={t('soil.color.chroma')}
+              {...styles.propertySelect}
+            />
+          )}
+        </Row>
+        <RestrictBySiteRole
+          role={[
+            {kind: 'project', role: 'MANAGER'},
+            {kind: 'project', role: 'CONTRIBUTOR'},
+            {kind: 'site', role: 'OWNER'},
+          ]}>
+          {!isColorComplete(data) && (
+            <Column
+              paddingHorizontal="md"
+              paddingVertical="lg"
+              backgroundColor="grey.300"
+              alignItems="flex-start">
+              <Paragraph variant="body1">
+                {t('soil.color.use_photo_instead')}
+              </Paragraph>
+              <SwitchWorkflowButton
+                {...props}
+                rightIcon={<Icon name="chevron-right" />}
+              />
+            </Column>
+          )}
+        </RestrictBySiteRole>
+      </Column>
+    </SiteRoleContextProvider>
   );
 };
 

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
@@ -190,12 +190,7 @@ export const ManualWorkflow = (props: SoilPitInputScreenProps) => {
             />
           )}
         </Row>
-        <RestrictBySiteRole
-          role={[
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-            {kind: 'site', role: 'OWNER'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           {!isColorComplete(data) && (
             <Column
               paddingHorizontal="md"

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
@@ -55,6 +55,10 @@ import {
   updateColorSelections,
   validProperties,
 } from 'terraso-mobile-client/model/color/soilColorValidation';
+import {
+  isProjectViewer,
+  SITE_EDITOR_ROLES,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {SwitchWorkflowButton} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/SwitchWorkflowButton';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
@@ -68,10 +72,7 @@ export const ManualWorkflow = (props: SoilPitInputScreenProps) => {
     selectUserRoleSite(state, props.siteId),
   );
 
-  const isViewer = useMemo(
-    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
-    [userRole],
-  );
+  const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
   const {hue: initialHue, substep: initialSubstep} = renderMunsellHue(data);
 

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/PhotoConditions.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/PhotoConditions.tsx
@@ -24,6 +24,8 @@ import {fromEntries} from 'terraso-client-shared/utils';
 
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
@@ -96,17 +98,26 @@ export const PhotoConditions = (props: SoilPitInputScreenProps) => {
   );
 
   return (
-    <Column paddingHorizontal="md">
-      <RadioBlock
-        label={t('soil.color.soil_condition')}
-        options={soilOptions}
-        groupProps={soilGroupProps}
-      />
-      <RadioBlock
-        label={t('soil.color.lighting_condition')}
-        options={lightingOptions}
-        groupProps={lightingGroupProps}
-      />
-    </Column>
+    <SiteRoleContextProvider siteId={props.siteId}>
+      <RestrictBySiteRole
+        role={[
+          {kind: 'project', role: 'MANAGER'},
+          {kind: 'project', role: 'CONTRIBUTOR'},
+          {kind: 'site', role: 'OWNER'},
+        ]}>
+        <Column paddingHorizontal="md">
+          <RadioBlock
+            label={t('soil.color.soil_condition')}
+            options={soilOptions}
+            groupProps={soilGroupProps}
+          />
+          <RadioBlock
+            label={t('soil.color.lighting_condition')}
+            options={lightingOptions}
+            groupProps={lightingGroupProps}
+          />
+        </Column>
+      </RestrictBySiteRole>
+    </SiteRoleContextProvider>
   );
 };

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/PhotoConditions.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/PhotoConditions.tsx
@@ -26,6 +26,7 @@ import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
@@ -99,12 +100,7 @@ export const PhotoConditions = (props: SoilPitInputScreenProps) => {
 
   return (
     <SiteRoleContextProvider siteId={props.siteId}>
-      <RestrictBySiteRole
-        role={[
-          {kind: 'project', role: 'MANAGER'},
-          {kind: 'project', role: 'CONTRIBUTOR'},
-          {kind: 'site', role: 'OWNER'},
-        ]}>
+      <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
         <Column paddingHorizontal="md">
           <RadioBlock
             label={t('soil.color.soil_condition')}

--- a/dev-client/src/screens/SoilScreen/SoilScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SoilScreen.tsx
@@ -45,6 +45,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {OverlaySheet} from 'terraso-mobile-client/components/sheets/OverlaySheet';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {EditSiteSoilDepthPreset} from 'terraso-mobile-client/screens/SoilScreen/components/EditSiteSoilDepthPreset';
 import {SoilDepthSummary} from 'terraso-mobile-client/screens/SoilScreen/components/SoilDepthSummary';
 import {SoilSurfaceStatus} from 'terraso-mobile-client/screens/SoilScreen/components/SoilSurfaceStatus';
@@ -118,12 +119,7 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
           requiredInputs={projectRequiredInputs}
         />
       ))}
-      <RestrictBySiteRole
-        role={[
-          {kind: 'project', role: 'MANAGER'},
-          {kind: 'project', role: 'CONTRIBUTOR'},
-          {kind: 'site', role: 'OWNER'},
-        ]}>
+      <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
         <Modal
           trigger={onOpen => (
             <Button

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -44,7 +44,9 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {RockFragmentVolumeInfoContent} from 'terraso-mobile-client/screens/SoilScreen/components/RockFragmentVolumeInfoContent';
 import {
@@ -140,54 +142,78 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
 
   return (
     <SoilPitInputScreenScaffold {...props}>
-      <ScrollView bg="grey.300">
-        <Column p="15px" bg="primary.contrast">
-          <Row alignItems="center">
-            <Heading variant="h6">{t('soil.texture.title')}</Heading>
-            <InfoOverlaySheetButton Header={t('soil.texture.info.title')}>
-              <TextureInfoContent />
-            </InfoOverlaySheetButton>
-          </Row>
-          <Box height="sm" />
-          <Select
-            nullable
-            label={t('soil.texture.label')}
-            options={textures}
-            value={depthData?.texture ?? null}
-            onValueChange={onTextureChange}
-            renderValue={renderTexture}
-          />
-        </Column>
-        <Column p="15px" alignItems="flex-start">
-          <Text variant="body1">{t('soil.texture.guide_intro')}</Text>
-          <Box height="10px" />
-          <Button
-            onPress={onGuide}
-            rightIcon={<Icon name="chevron-right" />}
-            _text={{textTransform: 'uppercase'}}>
-            {t('soil.texture.use_guide_label')}
-          </Button>
-        </Column>
-        <Column p="15px" bg="primary.contrast">
-          <Row alignItems="center">
-            <Text variant="body1-strong">
-              {t('soil.texture.fragment_title')}
-            </Text>
-            <InfoOverlaySheetButton
-              Header={t('soil.texture.fragment.info.title')}>
-              <RockFragmentVolumeInfoContent />
-            </InfoOverlaySheetButton>
-          </Row>
-          <Box height="10px" />
-          <ImageRadio
-            value={depthData?.rockFragmentVolume}
-            options={fragmentOptions}
-            minimumPerRow={2}
-            onChange={onFragmentChange}
-          />
-        </Column>
-      </ScrollView>
-      <DoneButton />
+      <SiteRoleContextProvider siteId={siteId}>
+        <ScrollView>
+          <Column p="15px" bg="primary.contrast">
+            <Row alignItems="center">
+              <Heading variant="h6">{t('soil.texture.title')}</Heading>
+              <InfoOverlaySheetButton Header={t('soil.texture.info.title')}>
+                <TextureInfoContent />
+              </InfoOverlaySheetButton>
+            </Row>
+            <RestrictBySiteRole
+              role={[
+                {kind: 'project', role: 'MANAGER'},
+                {kind: 'project', role: 'CONTRIBUTOR'},
+                {kind: 'site', role: 'OWNER'},
+              ]}>
+              <Box height="sm" />
+              <Select
+                nullable
+                label={t('soil.texture.label')}
+                options={textures}
+                value={depthData?.texture ?? null}
+                onValueChange={onTextureChange}
+                renderValue={renderTexture}
+              />
+            </RestrictBySiteRole>
+          </Column>
+          <RestrictBySiteRole
+            role={[
+              {kind: 'project', role: 'MANAGER'},
+              {kind: 'project', role: 'CONTRIBUTOR'},
+              {kind: 'site', role: 'OWNER'},
+            ]}>
+            <Column p="15px" alignItems="flex-start" bg="grey.300">
+              <Text variant="body1">{t('soil.texture.guide_intro')}</Text>
+              <Box height="10px" />
+              <Button
+                onPress={onGuide}
+                rightIcon={<Icon name="chevron-right" />}
+                _text={{textTransform: 'uppercase'}}>
+                {t('soil.texture.use_guide_label')}
+              </Button>
+            </Column>
+          </RestrictBySiteRole>
+
+          <Column p="15px" bg="primary.contrast">
+            <Row alignItems="center">
+              <Text variant="body1-strong">
+                {t('soil.texture.fragment_title')}
+              </Text>
+              <InfoOverlaySheetButton
+                Header={t('soil.texture.fragment.info.title')}>
+                <RockFragmentVolumeInfoContent />
+              </InfoOverlaySheetButton>
+            </Row>
+            <Box height="10px" />
+            <ImageRadio
+              value={depthData?.rockFragmentVolume}
+              options={fragmentOptions}
+              minimumPerRow={2}
+              onChange={onFragmentChange}
+            />
+          </Column>
+        </ScrollView>
+        <RestrictBySiteRole
+          role={[
+            {kind: 'project', role: 'MANAGER'},
+            {kind: 'project', role: 'CONTRIBUTOR'},
+            {kind: 'site', role: 'OWNER'},
+          ]}>
+          <DoneButton />
+        </RestrictBySiteRole>
+      </SiteRoleContextProvider>
     </SoilPitInputScreenScaffold>
   );
 };

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -50,6 +50,10 @@ import {
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {InfoOverlaySheetButton} from 'terraso-mobile-client/components/sheets/InfoOverlaySheetButton';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {
+  isProjectViewer,
+  SITE_EDITOR_ROLES,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {RockFragmentVolumeInfoContent} from 'terraso-mobile-client/screens/SoilScreen/components/RockFragmentVolumeInfoContent';
 import {
@@ -79,10 +83,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
 
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
 
-  const isViewer = useMemo(
-    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
-    [userRole],
-  );
+  const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
   const onTextureChange = useCallback(
     (texture: SoilTexture | null) => {

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -161,12 +161,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
                 <TextureInfoContent />
               </InfoOverlaySheetButton>
             </Row>
-            <RestrictBySiteRole
-              role={[
-                {kind: 'project', role: 'MANAGER'},
-                {kind: 'project', role: 'CONTRIBUTOR'},
-                {kind: 'site', role: 'OWNER'},
-              ]}>
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
               <Box height="sm" />
               <Select
                 nullable
@@ -178,12 +173,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
               />
             </RestrictBySiteRole>
           </Column>
-          <RestrictBySiteRole
-            role={[
-              {kind: 'project', role: 'MANAGER'},
-              {kind: 'project', role: 'CONTRIBUTOR'},
-              {kind: 'site', role: 'OWNER'},
-            ]}>
+          <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
             <Column p="15px" alignItems="flex-start" bg="grey.300">
               <Text variant="body1">{t('soil.texture.guide_intro')}</Text>
               <Box height="10px" />
@@ -215,12 +205,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
             />
           </Column>
         </ScrollView>
-        <RestrictBySiteRole
-          role={[
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-            {kind: 'site', role: 'OWNER'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <DoneButton />
         </RestrictBySiteRole>
       </SiteRoleContextProvider>

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -162,17 +162,16 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
                 <TextureInfoContent />
               </InfoOverlaySheetButton>
             </Row>
-            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-              <Box height="sm" />
-              <Select
-                nullable
-                label={t('soil.texture.label')}
-                options={textures}
-                value={depthData?.texture ?? null}
-                onValueChange={onTextureChange}
-                renderValue={renderTexture}
-              />
-            </RestrictBySiteRole>
+            <Box height="sm" />
+            <Select
+              disabled={isViewer}
+              nullable
+              label={t('soil.texture.label')}
+              options={textures}
+              value={depthData?.texture ?? null}
+              onValueChange={onTextureChange}
+              renderValue={renderTexture}
+            />
           </Column>
           <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
             <Column p="15px" alignItems="flex-start" bg="grey.300">

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -21,7 +21,10 @@ import {Image, ImageSourcePropType} from 'react-native';
 
 import {Button, ScrollView} from 'native-base';
 
-import {selectDepthDependentData} from 'terraso-client-shared/selectors';
+import {
+  selectDepthDependentData,
+  selectUserRoleSite,
+} from 'terraso-client-shared/selectors';
 import {
   RockFragmentVolume,
   SoilTexture,
@@ -73,6 +76,13 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
   const depthData = useSelector(selectDepthDependentData(props));
   const dispatch = useDispatch();
   const navigation = useNavigation();
+
+  const userRole = useSelector(state => selectUserRoleSite(state, siteId));
+
+  const isViewer = useMemo(
+    () => Boolean(userRole && ['VIEWER'].includes(userRole.role)),
+    [userRole],
+  );
 
   const onTextureChange = useCallback(
     (texture: SoilTexture | null) => {
@@ -201,7 +211,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
               value={depthData?.rockFragmentVolume}
               options={fragmentOptions}
               minimumPerRow={2}
-              onChange={onFragmentChange}
+              onChange={isViewer ? () => {} : onFragmentChange}
             />
           </Column>
         </ScrollView>

--- a/dev-client/src/screens/SoilScreen/components/DepthEditor.tsx
+++ b/dev-client/src/screens/SoilScreen/components/DepthEditor.tsx
@@ -24,6 +24,7 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {EditDepthModal} from 'terraso-mobile-client/screens/SoilScreen/components/EditDepthModal';
 import {renderDepth} from 'terraso-mobile-client/screens/SoilScreen/components/RenderValues';
 
@@ -49,12 +50,7 @@ export const DepthEditor = ({
       <Heading variant="h6" color="primary.contrast">
         {renderDepth(t, interval)}
       </Heading>
-      <RestrictBySiteRole
-        role={[
-          {kind: 'project', role: 'MANAGER'},
-          {kind: 'project', role: 'CONTRIBUTOR'},
-          {kind: 'site', role: 'OWNER'},
-        ]}>
+      <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
         <EditDepthModal
           siteId={siteId}
           depthInterval={interval.depthInterval}

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -35,6 +35,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
@@ -64,12 +65,7 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
           <Heading variant="h6">
             {t('soil.collection_method.verticalCracking')}
           </Heading>
-          <RestrictBySiteRole
-            role={[
-              {kind: 'site', role: 'OWNER'},
-              {kind: 'project', role: 'MANAGER'},
-              {kind: 'project', role: 'CONTRIBUTOR'},
-            ]}>
+          <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
             <Select
               nullable
               value={cracking ?? null}
@@ -89,12 +85,7 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
             />
           </Box>
         </Column>
-        <RestrictBySiteRole
-          role={[
-            {kind: 'site', role: 'OWNER'},
-            {kind: 'project', role: 'MANAGER'},
-            {kind: 'project', role: 'CONTRIBUTOR'},
-          ]}>
+        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
           <Box position="absolute" bottom="0" right="0">
             <DoneButton isDisabled={!cracking} />
           </Box>

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -14,11 +14,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Image} from 'react-native';
 
-import {selectSite, selectSoilData} from 'terraso-client-shared/selectors';
+import {
+  selectSite,
+  selectSoilData,
+  selectUserRoleSite,
+} from 'terraso-client-shared/selectors';
 import {updateSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
 import {
   SurfaceCracks,
@@ -35,7 +39,10 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
-import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
+import {
+  isProjectViewer,
+  SITE_EDITOR_ROLES,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
@@ -58,6 +65,10 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
     [t],
   );
 
+  const userRole = useSelector(state => selectUserRoleSite(state, siteId));
+
+  const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
+
   return (
     <ScreenScaffold AppBar={<AppBar title={site.name} />}>
       <SiteRoleContextProvider siteId={siteId}>
@@ -65,16 +76,15 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
           <Heading variant="h6">
             {t('soil.collection_method.verticalCracking')}
           </Heading>
-          <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-            <Select
-              nullable
-              value={cracking ?? null}
-              onValueChange={onUpdate}
-              options={surfaceCracks}
-              renderValue={renderSurfaceCrack}
-            />
-            <Box height="lg" />
-          </RestrictBySiteRole>
+          <Select
+            disabled={isViewer}
+            nullable
+            value={cracking ?? null}
+            onValueChange={onUpdate}
+            options={surfaceCracks}
+            renderValue={renderSurfaceCrack}
+          />
+          <Box height="lg" />
 
           <Paragraph>
             {t('soil.vertical_cracking.description', {units: 'METRIC'})}

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -33,6 +33,8 @@ import {
   Heading,
   Paragraph,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
@@ -57,30 +59,47 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
 
   return (
     <ScreenScaffold AppBar={<AppBar title={site.name} />}>
-      <Column padding="md">
-        <Heading variant="h6">
-          {t('soil.collection_method.verticalCracking')}
-        </Heading>
-        <Select
-          nullable
-          value={cracking ?? null}
-          onValueChange={onUpdate}
-          options={surfaceCracks}
-          renderValue={renderSurfaceCrack}
-        />
-        <Box height="lg" />
-        <Paragraph>
-          {t('soil.vertical_cracking.description', {units: 'METRIC'})}
-        </Paragraph>
-        <Box width="100%" alignItems="center">
-          <Image
-            source={require('terraso-mobile-client/assets/surface/vertical-cracking.png')}
-          />
-        </Box>
-      </Column>
-      <Box position="absolute" bottom="0" right="0">
-        <DoneButton isDisabled={!cracking} />
-      </Box>
+      <SiteRoleContextProvider siteId={siteId}>
+        <Column padding="md">
+          <Heading variant="h6">
+            {t('soil.collection_method.verticalCracking')}
+          </Heading>
+          <RestrictBySiteRole
+            role={[
+              {kind: 'site', role: 'OWNER'},
+              {kind: 'project', role: 'MANAGER'},
+              {kind: 'project', role: 'CONTRIBUTOR'},
+            ]}>
+            <Select
+              nullable
+              value={cracking ?? null}
+              onValueChange={onUpdate}
+              options={surfaceCracks}
+              renderValue={renderSurfaceCrack}
+            />
+            <Box height="lg" />
+          </RestrictBySiteRole>
+
+          <Paragraph>
+            {t('soil.vertical_cracking.description', {units: 'METRIC'})}
+          </Paragraph>
+          <Box width="100%" alignItems="center">
+            <Image
+              source={require('terraso-mobile-client/assets/surface/vertical-cracking.png')}
+            />
+          </Box>
+        </Column>
+        <RestrictBySiteRole
+          role={[
+            {kind: 'site', role: 'OWNER'},
+            {kind: 'project', role: 'MANAGER'},
+            {kind: 'project', role: 'CONTRIBUTOR'},
+          ]}>
+          <Box position="absolute" bottom="0" right="0">
+            <DoneButton isDisabled={!cracking} />
+          </Box>
+        </RestrictBySiteRole>
+      </SiteRoleContextProvider>
     </ScreenScaffold>
   );
 };

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -16,7 +16,6 @@
  */
 import {NativeModules, Platform} from 'react-native';
 
-import {SiteUserRole} from 'terraso-client-shared/selectors';
 import {Coords} from 'terraso-client-shared/types';
 import {
   isValidLatitude,
@@ -145,21 +144,6 @@ export const isValidCoordinates = (input: string) => {
 
   return isValidLatitude(latitude) && isValidLongitude(longitude);
 };
-
-export const matchesOne =
-  <T>(cmp: (a: T, b: T) => boolean) =>
-  (examples: T[]) =>
-  (sample: T) =>
-    examples.filter(x => cmp(x, sample)).length > 0;
-
-export const matchesRole = matchesOne(
-  (a: SiteUserRole, b: SiteUserRole) => a.kind === b.kind && a.role === b.role,
-);
-
-export const isSiteManager = matchesRole([
-  {kind: 'site', role: 'OWNER'},
-  {kind: 'project', role: 'MANAGER'},
-]);
 
 export const getSoilWebUrl = (coords: Coords) => {
   return `https://casoilresource.lawr.ucdavis.edu/gmap/?loc=${coords.latitude},${coords.longitude}`;


### PR DESCRIPTION
## Description
Remove site data entry for viewers
- for soil color, hide delete button and done button from viewers
- hide texture menu, use guide button and done button from viewers
- hide vertical cracks menu and done button from viewers
- hide slope shape done button for viewers
- disable steepness, shape and texture ImageRadio buttons for viewers

also:
- avoid key error when a single label is blank/undefined
- style disabled `<Select>` item

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1350