### PR TITLE
fix: wrap title on non-popover site cards

### DIFF
--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -61,10 +61,7 @@ export const SiteCard = ({
   return (
     <Card
       Header={
-        <Heading
-          variant="h6"
-          color="primary.main"
-          flex={isPopover ? 1 : undefined}>
+        <Heading variant="h6" color="primary.main" flex={1}>
           {site.name}
         </Heading>
       }


### PR DESCRIPTION
## Description
Wrap title on non-popover site cards.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/1894

Before / After
<img width="230" alt="image" src="https://github.com/user-attachments/assets/ed8f0097-85e4-465b-b4fc-4962deb279ef"> <img width="230" alt="image" src="https://github.com/user-attachments/assets/7c9e84a1-f796-48f7-a22b-4629ab59c273">
