### PR TITLE
fix: ios color bug

### DIFF
--- a/dev-client/src/components/tables/soilProperties/SoilPropertiesData.tsx
+++ b/dev-client/src/components/tables/soilProperties/SoilPropertiesData.tsx
@@ -32,7 +32,7 @@ import {
 import {
   fullMunsellColor,
   munsellToString,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+} from 'terraso-mobile-client/model/color/colorConversions';
 
 export type SoilPropertiesDataTableRow = {
   depth: DepthInterval;

--- a/dev-client/src/model/color/colorConversions.test.tsx
+++ b/dev-client/src/model/color/colorConversions.test.tsx
@@ -21,7 +21,7 @@ import {
   LABToMunsell,
   munsellHVCToLAB,
   munsellToRGB,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+} from 'terraso-mobile-client/model/color/colorConversions';
 
 describe('isColorComplete', () => {
   test('returns true if complete', () => {

--- a/dev-client/src/model/color/colorDetection.ts
+++ b/dev-client/src/model/color/colorDetection.ts
@@ -32,7 +32,7 @@ import {
 } from 'terraso-mobile-client/model/color/types';
 
 const SOIL_COLOR_SIMILARITY_THRESHOLD = 5;
-const COLOR_COUNT = 16;
+const COLOR_COUNT = 5;
 
 // Correction values obtain from spectrophotometer Observer. = 2°, Illuminant = D65
 export const REFERENCES = {
@@ -108,12 +108,17 @@ export const dominantColor = (pixels: RGBA[]): RGB => {
   });
 
   // Quantize.js performs median cut algorithm, and returns a palette of the "top 16" colors in the picture
-  var cmap = quantize(pixelArray, COLOR_COUNT);
-  if (cmap === false) {
+  var colorMap = quantize(pixelArray, COLOR_COUNT);
+  if (colorMap === false) {
     throw new Error('Unexpected color algorithm failure!');
   }
 
-  return cmap.palette()[0];
+  const colorsWithCounts = colorMap.vboxes.map(
+    vbox => [vbox.color, vbox.vbox.count()] as const,
+  );
+  const [dominantColor] = colorsWithCounts.sort(([, c1], [, c2]) => c2 - c1)[0];
+
+  return dominantColor;
 };
 
 const nearestSoilColor = (color: MunsellHVC) =>

--- a/dev-client/src/model/color/colorDetection.ts
+++ b/dev-client/src/model/color/colorDetection.ts
@@ -34,6 +34,7 @@ import {
 const SOIL_COLOR_SIMILARITY_THRESHOLD = 5;
 const COLOR_COUNT = 16;
 
+// Correction values obtain from spectrophotometer Observer. = 2°, Illuminant = D65
 export const REFERENCES = {
   CAMERA_TRAX: [210.15, 213.95, 218.42],
   CANARY_POST_IT: [249.92, 242.07, 161.42],
@@ -45,44 +46,9 @@ export const getColor = (
   pixelSoil: RGBA[],
   referenceRGB: RGB,
 ): ColorResult => {
-  const getPalette = (pixels: RGBA[]) => {
-    // Transform pixel info from canvas so quantize can use it
-    const pixelArray = pixels.flatMap(([r, g, b, a]) => {
-      // If pixel is mostly opaque and not white
-      if (a >= 125) {
-        if (!(r > 250 && g > 250 && b > 250)) {
-          return [[r, g, b] as quantize.RgbPixel];
-        }
-      }
-      return [];
-    });
-    // Quantize.js performs median cut algorithm, and returns a palette of the "top 16" colors in the picture
-    var cmap = quantize(pixelArray, COLOR_COUNT);
-    if (cmap === false) {
-      throw new Error('Unexpected color algorithm failure!');
-    }
-
-    return cmap.palette();
-  };
-
-  // Get the color palettes of both soil and card
-  const paletteCard = getPalette(pixelCard);
-  const paletteSample = getPalette(pixelSoil);
-
-  // Correction values obtain from spectrophotometer Observer. = 2°, Illuminant = D65
-  const correctSampleRGB = (cardPixel: RGB, samplePixel: RGB) => {
-    const corrected = cardPixel.map(
-      (cardV, index) => (referenceRGB[index] / cardV) * samplePixel[index],
-    ) as RGB;
-
-    return {
-      rgb: corrected,
-      rgbRaw: samplePixel,
-    };
-  };
-
-  const sample = correctSampleRGB(paletteCard[0], paletteSample[0]);
-  const predicted = rgb255ToMhvc(...sample.rgb);
+  const predicted = rgb255ToMhvc(
+    ...predictColorFromReference(pixelSoil, pixelCard, referenceRGB),
+  );
 
   // take the minimum by distance to predicted color
   const nearest = nearestSoilColor(predicted);
@@ -107,12 +73,55 @@ export const getColor = (
   };
 };
 
-export const nearestSoilColor = (color: MunsellHVC) =>
+export const predictColorFromReference = (
+  samplePixels: RGBA[],
+  referencePixels: RGBA[],
+  referenceRGB: RGB,
+) => {
+  return correctSampleRGB(
+    dominantColor(referencePixels),
+    dominantColor(samplePixels),
+    referenceRGB,
+  );
+};
+
+const correctSampleRGB = (
+  cardPixel: RGB,
+  samplePixel: RGB,
+  referenceRGB: RGB,
+): RGB => {
+  return cardPixel.map(
+    (cardV, index) => (referenceRGB[index] / cardV) * samplePixel[index],
+  ) as RGB;
+};
+
+export const dominantColor = (pixels: RGBA[]): RGB => {
+  // Transform pixel info from canvas so quantize can use it
+  const pixelArray = pixels.flatMap(([r, g, b, a]) => {
+    // If pixel is mostly opaque and not white
+    if (a >= 125) {
+      if (!(r > 250 && g > 250 && b > 250)) {
+        return [[r, g, b] as quantize.RgbPixel];
+      }
+    }
+    return [];
+  });
+
+  // Quantize.js performs median cut algorithm, and returns a palette of the "top 16" colors in the picture
+  var cmap = quantize(pixelArray, COLOR_COUNT);
+  if (cmap === false) {
+    throw new Error('Unexpected color algorithm failure!');
+  }
+
+  return cmap.palette()[0];
+};
+
+const nearestSoilColor = (color: MunsellHVC) =>
   FLATTENED_SOIL_COLORS.reduce((a, b) =>
     munsellDistance(a, color) < munsellDistance(b, color) ? a : b,
   );
 
-export const munsellDistance = (a: MunsellHVC, b: MunsellHVC): number =>
+const munsellDistance = (a: MunsellHVC, b: MunsellHVC): number =>
   getDeltaE00(munsellHVCToLAB(a), munsellHVCToLAB(b));
 
 const FLATTENED_SOIL_COLORS: MunsellHVC[] = entries(SOIL_COLORS).flatMap(

--- a/dev-client/src/model/color/colorDetection.ts
+++ b/dev-client/src/model/color/colorDetection.ts
@@ -116,9 +116,9 @@ export const dominantColor = (pixels: RGBA[]): RGB => {
   const colorsWithCounts = colorMap.vboxes.map(
     vbox => [vbox.color, vbox.vbox.count()] as const,
   );
-  const [dominantColor] = colorsWithCounts.sort(([, c1], [, c2]) => c2 - c1)[0];
+  const [color] = colorsWithCounts.sort(([, c1], [, c2]) => c2 - c1)[0];
 
-  return dominantColor;
+  return color;
 };
 
 const nearestSoilColor = (color: MunsellHVC) =>

--- a/dev-client/src/model/color/colorDetection.ts
+++ b/dev-client/src/model/color/colorDetection.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {getDeltaE00} from 'delta-e';
+import {rgb255ToMhvc} from 'munsell';
+import quantize from 'quantize';
+
+import {nonNeutralColorHues} from 'terraso-client-shared/soilId/soilIdTypes';
+import {entries} from 'terraso-client-shared/utils';
+
+import {munsellHVCToLAB} from 'terraso-mobile-client/model/color/colorConversions';
+import {SOIL_COLORS} from 'terraso-mobile-client/model/color/soilColors';
+import {
+  ColorResult,
+  MunsellHVC,
+  RGB,
+  RGBA,
+} from 'terraso-mobile-client/model/color/types';
+
+const SOIL_COLOR_SIMILARITY_THRESHOLD = 5;
+const COLOR_COUNT = 16;
+
+export const REFERENCES = {
+  CAMERA_TRAX: [210.15, 213.95, 218.42],
+  CANARY_POST_IT: [249.92, 242.07, 161.42],
+  WHITE_BALANCE: [192.96, 192.0, 191.74],
+} as const satisfies Record<string, RGB>;
+
+export const getColor = (
+  pixelCard: RGBA[],
+  pixelSoil: RGBA[],
+  referenceRGB: RGB,
+): ColorResult => {
+  const getPalette = (pixels: RGBA[]) => {
+    // Transform pixel info from canvas so quantize can use it
+    const pixelArray = pixels.flatMap(([r, g, b, a]) => {
+      // If pixel is mostly opaque and not white
+      if (a >= 125) {
+        if (!(r > 250 && g > 250 && b > 250)) {
+          return [[r, g, b] as quantize.RgbPixel];
+        }
+      }
+      return [];
+    });
+    // Quantize.js performs median cut algorithm, and returns a palette of the "top 16" colors in the picture
+    var cmap = quantize(pixelArray, COLOR_COUNT);
+    if (cmap === false) {
+      throw new Error('Unexpected color algorithm failure!');
+    }
+
+    return cmap.palette();
+  };
+
+  // Get the color palettes of both soil and card
+  const paletteCard = getPalette(pixelCard);
+  const paletteSample = getPalette(pixelSoil);
+
+  // Correction values obtain from spectrophotometer Observer. = 2°, Illuminant = D65
+  const correctSampleRGB = (cardPixel: RGB, samplePixel: RGB) => {
+    const corrected = cardPixel.map(
+      (cardV, index) => (referenceRGB[index] / cardV) * samplePixel[index],
+    ) as RGB;
+
+    return {
+      rgb: corrected,
+      rgbRaw: samplePixel,
+    };
+  };
+
+  const sample = correctSampleRGB(paletteCard[0], paletteSample[0]);
+  const predicted = rgb255ToMhvc(...sample.rgb);
+
+  // take the minimum by distance to predicted color
+  const nearest = nearestSoilColor(predicted);
+
+  const nearestResult = {
+    colorHue: nearest[0],
+    colorValue: nearest[1],
+    colorChroma: nearest[2],
+  };
+
+  if (munsellDistance(nearest, predicted) < SOIL_COLOR_SIMILARITY_THRESHOLD) {
+    return {result: nearestResult};
+  }
+
+  return {
+    nearestValidResult: nearestResult,
+    invalidResult: {
+      colorHue: predicted[0],
+      colorValue: predicted[1],
+      colorChroma: predicted[2],
+    },
+  };
+};
+
+export const nearestSoilColor = (color: MunsellHVC) =>
+  FLATTENED_SOIL_COLORS.reduce((a, b) =>
+    munsellDistance(a, color) < munsellDistance(b, color) ? a : b,
+  );
+
+export const munsellDistance = (a: MunsellHVC, b: MunsellHVC): number =>
+  getDeltaE00(munsellHVCToLAB(a), munsellHVCToLAB(b));
+
+const FLATTENED_SOIL_COLORS: MunsellHVC[] = entries(SOIL_COLORS).flatMap(
+  ([hue, substepValueChromas]) =>
+    substepValueChromas.flatMap(([substep, valueChromas]) =>
+      valueChromas.flatMap(([value, chromas]) =>
+        chromas.map(
+          chroma =>
+            [
+              hue === 'N' ? 0 : nonNeutralColorHues.indexOf(hue) * 10 + substep,
+              value,
+              chroma,
+            ] as const,
+        ),
+      ),
+    ),
+);

--- a/dev-client/src/model/color/colorDetection.ts
+++ b/dev-client/src/model/color/colorDetection.ts
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {Buffer} from '@craftzdog/react-native-buffer';
+import * as Sentry from '@sentry/react-native';
 import {getDeltaE00} from 'delta-e';
 import {rgb255ToMhvc} from 'munsell';
 import quantize from 'quantize';
@@ -22,6 +24,10 @@ import quantize from 'quantize';
 import {nonNeutralColorHues} from 'terraso-client-shared/soilId/soilIdTypes';
 import {entries} from 'terraso-client-shared/utils';
 
+import {
+  decodeBase64Jpg,
+  PhotoWithBase64,
+} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {munsellHVCToLAB} from 'terraso-mobile-client/model/color/colorConversions';
 import {SOIL_COLORS} from 'terraso-mobile-client/model/color/soilColors';
 import {
@@ -31,17 +37,71 @@ import {
   RGBA,
 } from 'terraso-mobile-client/model/color/types';
 
+// Threshold used to determine whether to accept the algorithm's output
+// as a valid soil color, or consider it an unknown soil color and provide
+// a suggested alternative. This value was arrived at via ad-hoc testing.
 const SOIL_COLOR_SIMILARITY_THRESHOLD = 5;
-const COLOR_COUNT = 5;
+// Number of colors into which images are quantized while determining their dominant color.
+// This value was arrived at via ad-hoc testing.
+const QUANTIZATION_COLOR_COUNT = 5;
 
-// Correction values obtain from spectrophotometer Observer. = 2°, Illuminant = D65
-export const REFERENCES = {
+// These are the theoretical "correct" colors for several different reference objects.
+// The algorithm compares the color of the reference object in the picture to these colors
+// to figure out how to adjust the color of the soil. I don't really fully understand it,
+// but I'm leaving the following science-y note about the conditions under which these values
+// were measured in case they are needed in the future: Observer = 2°, Illuminant = D65
+const REFERENCES = {
   CAMERA_TRAX: [210.15, 213.95, 218.42],
   CANARY_POST_IT: [249.92, 242.07, 161.42],
   WHITE_BALANCE: [192.96, 192.0, 191.74],
 } as const satisfies Record<string, RGB>;
 
-export const getColor = (
+export const getColorFromImages = ({
+  reference,
+  soil,
+}: Record<'soil' | 'reference', PhotoWithBase64>) => {
+  const [referencePixels, soilPixels] = [reference, soil].map(({base64}) => {
+    const {data, height, width} = decodeBase64Jpg(base64);
+    const pixels: RGBA[] = [];
+    for (var y = 0; y < height; y++) {
+      for (var x = 0; x < height; x++) {
+        const offset = (y * width + x) * 4;
+        pixels.push([...data.slice(offset, offset + 4)] as RGBA);
+      }
+    }
+    return pixels;
+  });
+
+  try {
+    return getColorFromPixels(
+      referencePixels,
+      soilPixels,
+      REFERENCES.CANARY_POST_IT,
+    );
+  } catch (e) {
+    Sentry.captureEvent(
+      {message: 'color algorithm failure'},
+      {
+        attachments: [
+          {
+            filename: 'reference.jpg',
+            data: Buffer.from(reference.base64, 'base64'),
+          },
+          {
+            filename: 'soil.jpg',
+            data: Buffer.from(soil.base64, 'base64'),
+          },
+        ],
+      },
+    );
+
+    // TODO: we've never hit this catch block before so it's low priority, ideally we'd
+    // return something that eventually gets displayed to the user here instead of throwing.
+    throw e;
+  }
+};
+
+export const getColorFromPixels = (
   pixelCard: RGBA[],
   pixelSoil: RGBA[],
   referenceRGB: RGB,
@@ -107,8 +167,8 @@ export const dominantColor = (pixels: RGBA[]): RGB => {
     return [];
   });
 
-  // Quantize.js performs median cut algorithm, and returns a palette of the "top 16" colors in the picture
-  var colorMap = quantize(pixelArray, COLOR_COUNT);
+  // quantize.js performs median cut algorithm, and returns a palette of the dominant colors in the picture
+  var colorMap = quantize(pixelArray, QUANTIZATION_COLOR_COUNT);
   if (colorMap === false) {
     throw new Error('Unexpected color algorithm failure!');
   }
@@ -116,7 +176,9 @@ export const dominantColor = (pixels: RGBA[]): RGB => {
   const colorsWithCounts = colorMap.vboxes.map(
     vbox => [vbox.color, vbox.vbox.count()] as const,
   );
-  const [color] = colorsWithCounts.sort(([, c1], [, c2]) => c2 - c1)[0];
+  const [color] = colorsWithCounts.sort(
+    ([, count1], [, count2]) => count2 - count1,
+  )[0];
 
   return color;
 };

--- a/dev-client/src/model/color/types.ts
+++ b/dev-client/src/model/color/types.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+export type RGBA = [number, number, number, number];
+export type RGB = [number, number, number];
+// Munsell hue/value/chroma tuple
+export type MunsellHVC = readonly [number, number, number];
+export type MunsellColor = {
+  colorHue: number;
+  colorChroma: number;
+  colorValue: number;
+};
+
+export type PartialMunsellColor = {
+  colorHue?: number | null;
+  colorChroma?: number | null;
+  colorValue?: number | null;
+};
+
+export type ValidColorResult = {result: MunsellColor};
+export type InvalidColorResult = {
+  invalidResult: MunsellColor;
+  nearestValidResult: MunsellColor;
+};
+export type ColorResult = ValidColorResult | InvalidColorResult;

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
@@ -26,10 +26,6 @@ import {updateDepthDependentSoilData} from 'terraso-client-shared/soilId/soilIdS
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
-  decodeBase64Jpg,
-  PhotoWithBase64,
-} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
-import {
   ActionButton,
   ActionsModal,
 } from 'terraso-mobile-client/components/modals/ActionsModal';
@@ -41,14 +37,10 @@ import {
   Text,
   View,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {
-  getColor,
-  REFERENCES,
-} from 'terraso-mobile-client/model/color/colorDetection';
+import {getColorFromImages} from 'terraso-mobile-client/model/color/colorDetection';
 import {
   InvalidColorResult,
   MunsellColor,
-  RGBA,
 } from 'terraso-mobile-client/model/color/types';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {useColorAnalysisContext} from 'terraso-mobile-client/screens/ColorAnalysisScreen/context/colorAnalysisContext';
@@ -57,25 +49,6 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {ColorDisplay} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/ColorDisplay';
 import {PhotoConditions} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/PhotoConditions';
 import {useDispatch} from 'terraso-mobile-client/store';
-
-const analyzeImage = async ({
-  reference,
-  soil,
-}: Record<'soil' | 'reference', PhotoWithBase64>) => {
-  const [referencePixels, soilPixels] = [reference, soil].map(({base64}) => {
-    const {data, height, width} = decodeBase64Jpg(base64);
-    const pixels: RGBA[] = [];
-    for (var y = 0; y < height; y++) {
-      for (var x = 0; x < height; x++) {
-        const offset = (y * width + x) * 4;
-        pixels.push([...data.slice(offset, offset + 4)] as RGBA);
-      }
-    }
-    return pixels;
-  });
-
-  return getColor(referencePixels, soilPixels, REFERENCES.CANARY_POST_IT);
-};
 
 export const ColorAnalysisHomeScreen = () => {
   const {
@@ -112,8 +85,8 @@ export const ColorAnalysisHomeScreen = () => {
       return null;
     }
 
-    return async () => {
-      const color = await analyzeImage({
+    return () => {
+      const color = getColorFromImages({
         reference: reference.photo,
         soil: soil.photo,
       });

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
@@ -43,11 +43,13 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   getColor,
+  REFERENCES,
+} from 'terraso-mobile-client/model/color/colorDetection';
+import {
   InvalidColorResult,
   MunsellColor,
-  REFERENCES,
   RGBA,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+} from 'terraso-mobile-client/model/color/types';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {useColorAnalysisContext} from 'terraso-mobile-client/screens/ColorAnalysisScreen/context/colorAnalysisContext';
 import {useColorAnalysisNavigation} from 'terraso-mobile-client/screens/ColorAnalysisScreen/navigation/navigation';

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -39,10 +39,8 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
-import {
-  isColorComplete,
-  MunsellColor,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+import {isColorComplete} from 'terraso-mobile-client/model/color/colorConversions';
+import {MunsellColor} from 'terraso-mobile-client/model/color/types';
 import {
   isProjectEditor,
   SITE_EDITOR_ROLES,

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/ColorDisplay.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/ColorDisplay.tsx
@@ -26,10 +26,10 @@ import {
   View,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
-  MunsellColor,
   munsellToRGB,
   munsellToString,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+} from 'terraso-mobile-client/model/color/colorConversions';
+import {MunsellColor} from 'terraso-mobile-client/model/color/types';
 
 type Props = {
   color: MunsellColor;

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/ManualWorkflow.tsx
@@ -48,7 +48,7 @@ import {
   isColorComplete,
   parseMunsellHue,
   renderMunsellHue,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+} from 'terraso-mobile-client/model/color/colorConversions';
 import {
   ColorProperties,
   ColorPropertyUpdate,

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/SwitchWorkflowButton.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/SwitchWorkflowButton.tsx
@@ -24,7 +24,7 @@ import {selectDepthDependentData} from 'terraso-client-shared/selectors';
 import {updateDepthDependentSoilData} from 'terraso-client-shared/soilId/soilIdSlice';
 
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
-import {isColorComplete} from 'terraso-mobile-client/model/color/munsellConversions';
+import {isColorComplete} from 'terraso-mobile-client/model/color/colorConversions';
 import {updatePreferences} from 'terraso-mobile-client/model/preferences/preferencesSlice';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';

--- a/dev-client/src/screens/SoilScreen/components/RenderValues.tsx
+++ b/dev-client/src/screens/SoilScreen/components/RenderValues.tsx
@@ -27,7 +27,7 @@ import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   isColorComplete,
   munsellToString,
-} from 'terraso-mobile-client/model/color/munsellConversions';
+} from 'terraso-mobile-client/model/color/colorConversions';
 import {ColorDisplay} from 'terraso-mobile-client/screens/SoilScreen/ColorScreen/components/ColorDisplay';
 
 export const renderDepth = (


### PR DESCRIPTION
## Description
Please review by commit. The first two are no-op refactors. The last commit tweaks the way we're calling the color quantization algorithm to be more robust to unexpected pixels on the edges of images. [A bug on iOS](https://github.com/techmatters/terraso-mobile-client/issues/1352) reliably produces such pixels, but we'd also like to be robust in these cases regardless in case the user gives us a sloppy croppy.

I tested this on my iphone and can no longer reproduce #1352, but if someone else could also attempt to reproduce that would bring me peace of mind.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
https://github.com/techmatters/terraso-mobile-client/issues/1352

### Verification steps
Should no longer be able to reproduce https://github.com/techmatters/terraso-mobile-client/issues/1352
