### PR TITLE
fix: adjust strings to avoid rock_fragment.VOLUME_XX_YY being treated as plural

### DIFF
--- a/dev-client/locales/po/en.po
+++ b/dev-client/locales/po/en.po
@@ -5,30 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-08-05T23:26:07.544Z\n"
-"PO-Revision-Date: 2024-08-05T23:26:07.545Z\n"
-
-msgctxt "0"
-msgid "soil##texture##rock##VOLUME"
-msgstr "0–1%"
-
-msgctxt "1"
-msgid "soil##texture##rock##VOLUME"
-msgid_plural "soil##texture##rock##VOLUME"
-msgstr[0] ""
-msgstr[1] "1–15%"
-
-msgctxt "15"
-msgid "soil##texture##rock##VOLUME"
-msgid_plural "soil##texture##rock##VOLUME"
-msgstr[0] ""
-msgstr[1] "15–35%"
-
-msgctxt "35"
-msgid "soil##texture##rock##VOLUME"
-msgid_plural "soil##texture##rock##VOLUME"
-msgstr[0] ""
-msgstr[1] "35–60%"
+"POT-Creation-Date: 2024-08-15T04:59:04.894Z\n"
+"PO-Revision-Date: 2024-08-15T04:59:04.895Z\n"
 
 msgid "welcome##title"
 msgstr "Welcome to LandPKS Soil ID"
@@ -807,6 +785,21 @@ msgstr "Sand"
 msgid "soil##texture##class##SILT"
 msgstr "Silt"
 
+msgid "soil##texture##rockfragment##VOLUME:0:1"
+msgstr "0–1%"
+
+msgid "soil##texture##rockfragment##VOLUME:1:15"
+msgstr "1–15%"
+
+msgid "soil##texture##rockfragment##VOLUME:15:35"
+msgstr "15–35%"
+
+msgid "soil##texture##rockfragment##VOLUME:35:60"
+msgstr "35–60%"
+
+msgid "soil##texture##rockfragment##VOLUME:60"
+msgstr ">60%"
+
 msgid "soil##color##title"
 msgstr "Soil Color"
 
@@ -1086,11 +1079,6 @@ msgstr "Convex"
 
 msgid "slope##shape##select##LINEAR"
 msgstr "Linear"
-
-msgid "soil##texture##rock##VOLUME"
-msgid_plural "soil##texture##rock##VOLUME"
-msgstr[0] ""
-msgstr[1] ">60%"
 
 msgctxt "more"
 msgid "welcome##learn"

--- a/dev-client/scripts/localization/transform-to.mjs
+++ b/dev-client/scripts/localization/transform-to.mjs
@@ -69,20 +69,33 @@ const toPoOptions = {
   project: 'Terraso',
 };
 const toPo = () =>
-  transform('PO', '../../src/translations/', (locale, filePath) =>
-    i18nextToPo(locale, readFileSync(filePath), toPoOptions).then(
+  transform('PO', '../../src/translations/', (locale, filePath) => {
+    let data = readFileSync(filePath).toString();
+    data = data
+      .replace(/"VOLUME_(\d+)_(\d+)"/g, '"VOLUME:$1:$2"')
+      .replace(/"VOLUME_(\d+)"/g, '"VOLUME:$1"');
+
+    return i18nextToPo(locale, data, toPoOptions).then(
       save(`locales/po/${locale}.po`),
-    ),
-  );
+    );
+  });
 
 // JSON transform
 const toJsonOptions = {};
 const toJson = () =>
-  transform('JSON', '../../locales/po/', (locale, filePath) =>
-    gettextToI18next(locale, readFileSync(filePath), toJsonOptions).then(
-      save(`src/translations/${locale}.json`),
-    ),
-  );
+  transform('JSON', '../../locales/po/', (locale, filePath) => {
+    let data = gettextToI18next(
+      locale,
+      readFileSync(filePath),
+      toJsonOptions,
+    ).then(data =>
+      data
+        .replace(/"VOLUME:(\d+):(\d+)"/g, '"VOLUME_$1_$2"')
+        .replace(/VOLUME:(\d+)/g, 'VOLUME_$1'),
+    );
+
+    return data.then(save(`src/translations/${locale}.json`));
+  });
 
 // Scripts entry
 if (transformTo === 'po') {

--- a/dev-client/scripts/localization/transform-to.mjs
+++ b/dev-client/scripts/localization/transform-to.mjs
@@ -64,6 +64,16 @@ const transform = (process, from, i18Transform) => {
     .catch(error => console.error(`Error transforming to ${process}`, error));
 };
 
+/* i18next-conv treats the rock fragemnt volume labels (VOLUME_0_1, VOLUME_1_15,
+ * VOLUME_15_35, VOLUME_35_60, VOLUME_60) as plurals, resulting in a msgctext
+ * and one or two msgstr(s).
+ *
+ * To avoid this, we change the labels to VOLUME:0:1, VOLUME:1:15, etc. before
+ * converting to .po.
+ *
+ * We reverse this conversion when going from .po to .json.
+ */
+
 // PO transform
 const toPoOptions = {
   project: 'Terraso',

--- a/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
+++ b/dev-client/src/components/tables/soilProperties/SoilPropertiesDataTable.tsx
@@ -143,7 +143,7 @@ export const SoilPropertiesDataTable = ({rows}: Props) => {
               <DataTableCell
                 text={
                   row.rockFragment
-                    ? t(`soil.texture.rock_fragment.${row.rockFragment}`)
+                    ? t(`soil.texture.rockfragment.${row.rockFragment}`)
                     : ''
                 }
                 width={columnWidthRockFragment}

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -130,7 +130,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
         entries(FRAGMENT_IMAGES).map(([value, image]) => [
           value,
           {
-            label: t(`soil.texture.rock_fragment.${value}`),
+            label: t(`soil.texture.rockfragment.${value}`),
             image: <Image style={radioImage} source={image} />,
           },
         ]),

--- a/dev-client/src/screens/SoilScreen/components/RenderValues.tsx
+++ b/dev-client/src/screens/SoilScreen/components/RenderValues.tsx
@@ -58,7 +58,7 @@ export const pitMethodSummary = (
   if (method === 'soilTexture' && soilData.texture) {
     summary = t(`soil.texture.class.${soilData?.texture}`);
   } else if (method === 'rockFragmentVolume' && soilData.rockFragmentVolume) {
-    summary = t(`soil.texture.rock_fragment.${soilData.rockFragmentVolume}`);
+    summary = t(`soil.texture.rockfragment.${soilData.rockFragmentVolume}`);
   } else if (method === 'soilColor' && isColorComplete(soilData)) {
     summary = (
       <Row alignItems="center" space="sm">

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -722,7 +722,7 @@
         "SILTY_CLAY_LOAM": "Silty Clay Loam",
         "SILT_LOAM": "Silt Loam"
       },
-      "rock_fragment": {
+      "rockfragment": {
         "VOLUME_0_1": "0–1%",
         "VOLUME_1_15": "1–15%",
         "VOLUME_15_35": "15–35%",


### PR DESCRIPTION
## Description
adjust strings to avoid rock_fragment.VOLUME_XX_YY being treated as plural
- change rock_fragment to rockfragment
- replace _ with : when converting to po, and replace back with : when converting to JSON