### PR TITLE
fix: ios icon border

### DIFF
--- a/dev-client/__tests__/snapshot/__snapshots__/CreateProjectScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/CreateProjectScreen-test.tsx.snap
@@ -209,6 +209,16 @@ exports[`renders correctly 1`] = `
                             onResponderTerminate={[Function]}
                             onResponderTerminationRequest={[Function]}
                             onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "borderRadius": 100,
+                                },
+                                {
+                                  "backgroundColor": "#00000000",
+                                },
+                              ]
+                            }
                           >
                             <Icon
                               name="close"
@@ -220,11 +230,9 @@ exports[`renders correctly 1`] = `
                                     "verticalAlign": "middle",
                                   },
                                   {
-                                    "borderRadius": 100,
                                     "padding": 12,
                                   },
                                   {
-                                    "backgroundColor": "#00000000",
                                     "color": "#FFFFFF",
                                   },
                                 ]
@@ -901,6 +909,16 @@ exports[`renders correctly 1`] = `
                                         onResponderTerminate={[Function]}
                                         onResponderTerminationRequest={[Function]}
                                         onStartShouldSetResponder={[Function]}
+                                        style={
+                                          [
+                                            {
+                                              "borderRadius": 100,
+                                            },
+                                            {
+                                              "backgroundColor": "#00000000",
+                                            },
+                                          ]
+                                        }
                                       >
                                         <Icon
                                           name="info"
@@ -912,11 +930,9 @@ exports[`renders correctly 1`] = `
                                                 "verticalAlign": "middle",
                                               },
                                               {
-                                                "borderRadius": 100,
                                                 "padding": 4,
                                               },
                                               {
-                                                "backgroundColor": "#00000000",
                                                 "color": "#001923B3",
                                               },
                                             ]
@@ -1014,6 +1030,16 @@ exports[`renders correctly 1`] = `
                                               onResponderTerminate={[Function]}
                                               onResponderTerminationRequest={[Function]}
                                               onStartShouldSetResponder={[Function]}
+                                              style={
+                                                [
+                                                  {
+                                                    "borderRadius": 100,
+                                                  },
+                                                  {
+                                                    "backgroundColor": "#EEEEEE",
+                                                  },
+                                                ]
+                                              }
                                             >
                                               <Icon
                                                 name="close"
@@ -1025,11 +1051,9 @@ exports[`renders correctly 1`] = `
                                                       "verticalAlign": "middle",
                                                     },
                                                     {
-                                                      "borderRadius": 100,
                                                       "padding": 12,
                                                     },
                                                     {
-                                                      "backgroundColor": "#EEEEEE",
                                                       "color": "#001923B3",
                                                     },
                                                   ]

--- a/dev-client/__tests__/snapshot/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -209,6 +209,16 @@ exports[`renders correctly 1`] = `
                             onResponderTerminate={[Function]}
                             onResponderTerminationRequest={[Function]}
                             onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "borderRadius": 100,
+                                },
+                                {
+                                  "backgroundColor": "#00000000",
+                                },
+                              ]
+                            }
                           >
                             <Icon
                               name="close"
@@ -220,11 +230,9 @@ exports[`renders correctly 1`] = `
                                     "verticalAlign": "middle",
                                   },
                                   {
-                                    "borderRadius": 100,
                                     "padding": 12,
                                   },
                                   {
-                                    "backgroundColor": "#00000000",
                                     "color": "#FFFFFF",
                                   },
                                 ]
@@ -1166,6 +1174,16 @@ exports[`renders correctly 1`] = `
                                     onResponderTerminate={[Function]}
                                     onResponderTerminationRequest={[Function]}
                                     onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "borderRadius": 100,
+                                        },
+                                        {
+                                          "backgroundColor": "#00000000",
+                                        },
+                                      ]
+                                    }
                                   >
                                     <Icon
                                       name="info"
@@ -1177,11 +1195,9 @@ exports[`renders correctly 1`] = `
                                             "verticalAlign": "middle",
                                           },
                                           {
-                                            "borderRadius": 100,
                                             "padding": 4,
                                           },
                                           {
-                                            "backgroundColor": "#00000000",
                                             "color": "#001923B3",
                                           },
                                         ]
@@ -1279,6 +1295,16 @@ exports[`renders correctly 1`] = `
                                           onResponderTerminate={[Function]}
                                           onResponderTerminationRequest={[Function]}
                                           onStartShouldSetResponder={[Function]}
+                                          style={
+                                            [
+                                              {
+                                                "borderRadius": 100,
+                                              },
+                                              {
+                                                "backgroundColor": "#EEEEEE",
+                                              },
+                                            ]
+                                          }
                                         >
                                           <Icon
                                             name="close"
@@ -1290,11 +1316,9 @@ exports[`renders correctly 1`] = `
                                                   "verticalAlign": "middle",
                                                 },
                                                 {
-                                                  "borderRadius": 100,
                                                   "padding": 12,
                                                 },
                                                 {
-                                                  "backgroundColor": "#EEEEEE",
                                                   "color": "#001923B3",
                                                 },
                                               ]

--- a/dev-client/__tests__/snapshot/__snapshots__/LocationDashboardScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/LocationDashboardScreen-test.tsx.snap
@@ -209,6 +209,16 @@ exports[`renders correctly 1`] = `
                             onResponderTerminate={[Function]}
                             onResponderTerminationRequest={[Function]}
                             onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "borderRadius": 100,
+                                },
+                                {
+                                  "backgroundColor": "#00000000",
+                                },
+                              ]
+                            }
                           >
                             <Icon
                               name="arrow-back"
@@ -220,11 +230,9 @@ exports[`renders correctly 1`] = `
                                     "verticalAlign": "middle",
                                   },
                                   {
-                                    "borderRadius": 100,
                                     "padding": 12,
                                   },
                                   {
-                                    "backgroundColor": "#00000000",
                                     "color": "#FFFFFF",
                                   },
                                 ]

--- a/dev-client/__tests__/snapshot/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -209,6 +209,16 @@ exports[`renders correctly 1`] = `
                             onResponderTerminate={[Function]}
                             onResponderTerminationRequest={[Function]}
                             onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "borderRadius": 100,
+                                },
+                                {
+                                  "backgroundColor": "#00000000",
+                                },
+                              ]
+                            }
                           >
                             <Icon
                               name="arrow-back"
@@ -220,11 +230,9 @@ exports[`renders correctly 1`] = `
                                     "verticalAlign": "middle",
                                   },
                                   {
-                                    "borderRadius": 100,
                                     "padding": 12,
                                   },
                                   {
-                                    "backgroundColor": "#00000000",
                                     "color": "#FFFFFF",
                                   },
                                 ]
@@ -1259,6 +1267,16 @@ exports[`renders correctly 1`] = `
                                                 onResponderTerminate={[Function]}
                                                 onResponderTerminationRequest={[Function]}
                                                 onStartShouldSetResponder={[Function]}
+                                                style={
+                                                  [
+                                                    {
+                                                      "borderRadius": 100,
+                                                    },
+                                                    {
+                                                      "backgroundColor": "#00000000",
+                                                    },
+                                                  ]
+                                                }
                                               >
                                                 <Icon
                                                   name="info"
@@ -1270,11 +1288,9 @@ exports[`renders correctly 1`] = `
                                                         "verticalAlign": "middle",
                                                       },
                                                       {
-                                                        "borderRadius": 100,
                                                         "padding": 4,
                                                       },
                                                       {
-                                                        "backgroundColor": "#00000000",
                                                         "color": "#001923B3",
                                                       },
                                                     ]
@@ -1372,6 +1388,16 @@ exports[`renders correctly 1`] = `
                                                       onResponderTerminate={[Function]}
                                                       onResponderTerminationRequest={[Function]}
                                                       onStartShouldSetResponder={[Function]}
+                                                      style={
+                                                        [
+                                                          {
+                                                            "borderRadius": 100,
+                                                          },
+                                                          {
+                                                            "backgroundColor": "#EEEEEE",
+                                                          },
+                                                        ]
+                                                      }
                                                     >
                                                       <Icon
                                                         name="close"
@@ -1383,11 +1409,9 @@ exports[`renders correctly 1`] = `
                                                               "verticalAlign": "middle",
                                                             },
                                                             {
-                                                              "borderRadius": 100,
                                                               "padding": 12,
                                                             },
                                                             {
-                                                              "backgroundColor": "#EEEEEE",
                                                               "color": "#001923B3",
                                                             },
                                                           ]
@@ -2236,6 +2260,16 @@ exports[`renders correctly 1`] = `
                                         onResponderTerminate={[Function]}
                                         onResponderTerminationRequest={[Function]}
                                         onStartShouldSetResponder={[Function]}
+                                        style={
+                                          [
+                                            {
+                                              "borderRadius": 100,
+                                            },
+                                            {
+                                              "backgroundColor": "#00000000",
+                                            },
+                                          ]
+                                        }
                                       >
                                         <Icon
                                           name="expand-less"
@@ -2247,11 +2281,9 @@ exports[`renders correctly 1`] = `
                                                 "verticalAlign": "middle",
                                               },
                                               {
-                                                "borderRadius": 100,
                                                 "padding": 4,
                                               },
                                               {
-                                                "backgroundColor": "#00000000",
                                                 "color": "#001923B3",
                                               },
                                             ]
@@ -3516,6 +3548,16 @@ exports[`renders correctly 1`] = `
                                         onResponderTerminate={[Function]}
                                         onResponderTerminationRequest={[Function]}
                                         onStartShouldSetResponder={[Function]}
+                                        style={
+                                          [
+                                            {
+                                              "borderRadius": 100,
+                                            },
+                                            {
+                                              "backgroundColor": "#00000000",
+                                            },
+                                          ]
+                                        }
                                       >
                                         <Icon
                                           name="expand-less"
@@ -3527,11 +3569,9 @@ exports[`renders correctly 1`] = `
                                                 "verticalAlign": "middle",
                                               },
                                               {
-                                                "borderRadius": 100,
                                                 "padding": 4,
                                               },
                                               {
-                                                "backgroundColor": "#00000000",
                                                 "color": "#001923B3",
                                               },
                                             ]

--- a/dev-client/__tests__/snapshot/__snapshots__/SlopeScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/SlopeScreen-test.tsx.snap
@@ -215,6 +215,16 @@ exports[`renders correctly 1`] = `
                         onResponderTerminate={[Function]}
                         onResponderTerminationRequest={[Function]}
                         onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "borderRadius": 100,
+                            },
+                            {
+                              "backgroundColor": "#00000000",
+                            },
+                          ]
+                        }
                       >
                         <Icon
                           name="info"
@@ -226,11 +236,9 @@ exports[`renders correctly 1`] = `
                                 "verticalAlign": "middle",
                               },
                               {
-                                "borderRadius": 100,
                                 "padding": 4,
                               },
                               {
-                                "backgroundColor": "#00000000",
                                 "color": "#001923B3",
                               },
                             ]
@@ -317,6 +325,16 @@ exports[`renders correctly 1`] = `
                               onResponderTerminate={[Function]}
                               onResponderTerminationRequest={[Function]}
                               onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "borderRadius": 100,
+                                  },
+                                  {
+                                    "backgroundColor": "#EEEEEE",
+                                  },
+                                ]
+                              }
                             >
                               <Icon
                                 name="close"
@@ -328,11 +346,9 @@ exports[`renders correctly 1`] = `
                                       "verticalAlign": "middle",
                                     },
                                     {
-                                      "borderRadius": 100,
                                       "padding": 12,
                                     },
                                     {
-                                      "backgroundColor": "#EEEEEE",
                                       "color": "#001923B3",
                                     },
                                   ]

--- a/dev-client/src/components/buttons/icons/IconButton.tsx
+++ b/dev-client/src/components/buttons/icons/IconButton.tsx
@@ -61,12 +61,13 @@ export const IconButton = forwardRef<View, IconButtonProps>(
         ref={ref}
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
+        style={[containerStyleForType(type), containerStyleForVariant(variant)]}
         onPress={onPress}>
         <MaterialIcon
           name={name}
           size={convertIconSize(type === 'sq' ? 'md' : type)}
           style={[
-            styles.base,
+            styles.icon,
             iconStyleForType(type),
             iconStyleForVariant(variant),
           ]}
@@ -76,69 +77,111 @@ export const IconButton = forwardRef<View, IconButtonProps>(
   },
 );
 
+const containerStyleForType = (type: IconButtonType) => {
+  switch (type) {
+    case 'sm':
+      return styles.containerSm;
+    case 'md':
+      return styles.containerMd;
+    case 'sq':
+      return styles.containerSq;
+  }
+};
+
 const iconStyleForType = (type: IconButtonType) => {
   switch (type) {
     case 'sm':
-      return styles.sm;
+      return styles.iconSm;
     case 'md':
-      return styles.md;
+      return styles.iconMd;
     case 'sq':
-      return styles.sq;
+      return styles.iconSq;
+  }
+};
+
+const containerStyleForVariant = (variant: IconButtonVariant) => {
+  switch (variant) {
+    case 'normal-filled':
+      return styles.containerNormalFilled;
+    case 'light':
+      return styles.containerLight;
+    case 'light-filled':
+      return styles.containerLightFilled;
+    case 'location':
+      return styles.containerLocation;
+    default:
+      return styles.containerNormal;
   }
 };
 
 const iconStyleForVariant = (variant: IconButtonVariant) => {
   switch (variant) {
     case 'normal-filled':
-      return styles.normalFilled;
+      return styles.iconNormalFilled;
     case 'light':
-      return styles.light;
+      return styles.iconLight;
     case 'light-filled':
-      return styles.lightFilled;
+      return styles.iconLightFilled;
     case 'location':
-      return styles.location;
+      return styles.iconLocation;
     default:
-      return styles.normal;
+      return styles.iconNormal;
   }
 };
 
 const styles = StyleSheet.create({
-  base: {
+  icon: {
     verticalAlign: 'middle',
     textAlign: 'center',
   },
-  sm: {
+  containerSm: {
+    borderRadius: 100,
+  },
+  iconSm: {
     padding: 4,
+  },
+  containerMd: {
     borderRadius: 100,
   },
-  md: {
+  iconMd: {
     padding: 12,
-    borderRadius: 100,
   },
-  sq: {
-    padding: 8,
+  containerSq: {
     borderRadius: 5,
   },
-  normal: {
-    color: convertColorProp('text.icon'),
+  iconSq: {
+    padding: 8,
+  },
+  containerNormal: {
     backgroundColor: convertColorProp('transparent'),
   },
-  normalFilled: {
+  iconNormal: {
     color: convertColorProp('text.icon'),
+  },
+  containerNormalFilled: {
     backgroundColor: convertColorProp('grey.200'),
   },
-  light: {
-    color: convertColorProp('primary.contrast'),
+  iconNormalFilled: {
+    color: convertColorProp('text.icon'),
+  },
+  containerLight: {
     backgroundColor: convertColorProp('transparent'),
   },
-  lightFilled: {
-    color: convertColorProp('text.icon'),
+  iconLight: {
+    color: convertColorProp('primary.contrast'),
+  },
+  containerLightFilled: {
     backgroundColor: convertColorProp('primary.contrast'),
   },
-  location: {
-    color: convertColorProp('secondary.dark'),
+  iconLightFilled: {
+    color: convertColorProp('text.icon'),
+  },
+  containerLocation: {
     backgroundColor: convertColorProp('transparent'),
     borderColor: convertColorProp('secondary.dark'),
     borderWidth: 1,
+  },
+  iconLocation: {
+    color: convertColorProp('secondary.dark'),
   },
 });


### PR DESCRIPTION
## Description

A [known bug in react native ](https://github.com/facebook/react-native/issues/13760) prevents border radius from displaying as expected in some cases on iOS. One available fix is to move the radius to a containing `View` (or equivalent) component. Apply this fix to the new `IconButton` component to fix the filled-in variants not displaying their rounded corners correctly.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Oversight in #1331

### Verification steps

Run application in iOS and observe that icons with border or background have correct radius.