### PR TITLE
fix: add missing parenthesis to delete dialog text

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -488,7 +488,7 @@
       "p3": "The following won’t be deleted:",
       "p4": {
         "b0": "data you contributed to a project for which you aren’t the only manager",
-        "b1": "your Terraso account (including groups, landscapes, and story maps"
+        "b1": "your Terraso account (including groups, landscapes, and story maps)"
       },
       "p5": "<bold>Type your email address to confirm deletion:</bold>",
       "cancel": "Cancel",


### PR DESCRIPTION
## Description
Add missing parenthesis to delete dialog text.

Addresses https://github.com/techmatters/terraso-mobile-client/issues/1984