### PR TITLE
fix: Make camera permissions immediately take effect on slope meter

### DIFF
--- a/dev-client/src/components/modals/PermissionsRequestWrapper.tsx
+++ b/dev-client/src/components/modals/PermissionsRequestWrapper.tsx
@@ -34,6 +34,9 @@ type Props = {
   children: (onOpen: () => void) => React.ReactNode;
 };
 
+// FYI if a calling component uses the permission hook and needs to
+// update when permissions are granted, it can set permissionedAction
+// to the GetPermissionMethod returned by the hook
 export const PermissionsRequestWrapper = ({
   requestModalTitle,
   requestModalBody,

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -47,7 +47,7 @@ const toDegrees = (rad: number) => Math.round(Math.abs((rad * 180) / Math.PI));
 
 export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
   const {t} = useTranslation();
-  const [permission] = useCameraPermissions();
+  const [permission, _, getCameraPermissionAsync] = useCameraPermissions();
   const [deviceTiltDeg, setDeviceTiltDeg] = useState<number | null>(null);
   const navigation = useNavigation();
   const dispatch = useDispatch();
@@ -106,7 +106,8 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
               requestModalBody={t('permissions.camera_body', {
                 feature: t('slope.steepness.slope_meter'),
               })}
-              permissionHook={useCameraPermissions}>
+              permissionHook={useCameraPermissions}
+              permissionedAction={getCameraPermissionAsync}>
               {onRequest => (
                 <Button size="lg" onPress={onRequest}>
                   {t('slope.steepness.camera_grant')}


### PR DESCRIPTION
## Description
The slope meter camera was not immediately opening when the user granted permissions. I believe the issue was because the useCameraPermission hook exists separately in both the parent component (SlopeMeterScreen) and the child (PermissionsRequestWrapper). A change in the permission state for the child does not update the permission state in the parent. I’m not sure how expo's useCameraPermission is implemented, but I believe this is how React works in general. I suspect it would work when you come back to the screen because the component gets re-mounted (not just re-rendered), so the permission object would get figured out anew.

So the fix is for the SlopeMeterScreen to specify an action that happens upon granting permissions, that will update its permissions object. This is the [GetPermissionMethod noted in the docs here](https://docs.expo.dev/versions/latest/sdk/camera/#hooks).

I considered instead making a change to PermissionsRequestWrapper, to accept the permission and requestPermission objects instead of the hook itself, but none of the other usages needed that. 

### Related Issues
Addresses [#1806](https://github.com/techmatters/terraso-mobile-client/issues/1806)

### Verification steps
1. Uninstall and re-install app
2. Go to slope steepness screen for a site you can edit, and press "Slope Meter >" button
3. Press big green button to grant camera permissions