### PR TITLE
feat: add permissions unit tests

### DIFF
--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -19,6 +19,7 @@ import {useCallback} from 'react';
 
 import {Project, ProjectRole} from 'terraso-client-shared/project/projectSlice';
 
+import {userHasProjectRole} from 'terraso-mobile-client/model/permissions/permissions';
 import {useSelector} from 'terraso-mobile-client/store';
 
 type ProjectFilter = (project: Project) => boolean;
@@ -28,23 +29,7 @@ export const useProjectUserRolesFilter = (
 ): ProjectFilter => {
   const currentUser = useSelector(state => state.account.currentUser.data);
   return useCallback(
-    project => {
-      if (!userRoles) {
-        return true;
-      }
-
-      /*
-       * Filter returns whether we can find a membership for the project
-       * that matches the current user and has a role in the accepted list
-       */
-      return Boolean(
-        Object.values(project.memberships).find(
-          membership =>
-            currentUser?.id === membership.userId &&
-            userRoles.includes(membership.userRole),
-        ),
-      );
-    },
+    project => userHasProjectRole(currentUser, project, userRoles),
     [currentUser, userRoles],
   );
 };

--- a/dev-client/src/model/permissions/permissions.test.ts
+++ b/dev-client/src/model/permissions/permissions.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {User} from 'terraso-client-shared/account/accountSlice';
+import {Project, ProjectRole} from 'terraso-client-shared/project/projectSlice';
+
+import {userHasProjectRole} from 'terraso-mobile-client/model/permissions/permissions';
+
+const emptyUser = null;
+const emptyRoles: ProjectRole[] = [];
+
+const sampleUser: User = {
+  id: '1',
+  email: 'email@example.com',
+  firstName: 'Test',
+  lastName: 'Test',
+  profileImage: '',
+  preferences: {
+    group_notifications: 'true',
+    story_map_notifications: 'true',
+    language: 'en-US',
+  },
+};
+
+const emptyProject: Project = {
+  id: '3',
+  name: 'test',
+  privacy: 'PUBLIC',
+  measurementUnits: 'METRIC',
+  description: 'test description',
+  updatedAt: '8/28/2024',
+  memberships: {},
+  sites: {},
+  archived: false,
+};
+
+const sampleProject: Project = {
+  id: '4',
+  name: 'test',
+  privacy: 'PUBLIC',
+  measurementUnits: 'METRIC',
+  description: 'test description',
+  updatedAt: '8/28/2024',
+  memberships: {sample: {userId: '1', userRole: 'MANAGER', id: '2'}},
+  sites: {},
+  archived: false,
+};
+
+const sampleProject2: Project = {
+  id: '4',
+  name: 'test',
+  privacy: 'PUBLIC',
+  measurementUnits: 'METRIC',
+  description: 'test description',
+  updatedAt: '8/28/2024',
+  memberships: {sample: {userId: '2', userRole: 'VIEWER', id: '2'}},
+  sites: {},
+  archived: false,
+};
+
+const sampleManagerRoles: ProjectRole[] = ['MANAGER'];
+
+describe('permission tests', () => {
+  test('no user', () => {
+    const result = userHasProjectRole(emptyUser, emptyProject, emptyRoles);
+
+    expect(result).toBeFalsy();
+  });
+
+  test('user is in project with no role', () => {
+    const result = userHasProjectRole(sampleUser, sampleProject);
+
+    expect(result).toBeTruthy();
+  });
+
+  test('user is in project with role', () => {
+    const result = userHasProjectRole(
+      sampleUser,
+      sampleProject,
+      sampleManagerRoles,
+    );
+
+    expect(result).toBeTruthy();
+  });
+
+  test('user is not in project', () => {
+    const result = userHasProjectRole(
+      sampleUser,
+      sampleProject2,
+      sampleManagerRoles,
+    );
+
+    expect(result).toBeFalsy();
+  });
+});

--- a/dev-client/src/model/permissions/permissions.test.ts
+++ b/dev-client/src/model/permissions/permissions.test.ts
@@ -16,7 +16,11 @@
  */
 
 import {User} from 'terraso-client-shared/account/accountSlice';
-import {Project, ProjectRole} from 'terraso-client-shared/project/projectSlice';
+import {
+  Project,
+  ProjectMembership,
+  ProjectRole,
+} from 'terraso-client-shared/project/projectSlice';
 
 import {userHasProjectRole} from 'terraso-mobile-client/model/permissions/permissions';
 
@@ -48,29 +52,29 @@ const emptyProject: Project = {
   archived: false,
 };
 
-const sampleProject: Project = {
-  id: '4',
-  name: 'test',
-  privacy: 'PUBLIC',
-  measurementUnits: 'METRIC',
-  description: 'test description',
-  updatedAt: '8/28/2024',
-  memberships: {sample: {userId: '1', userRole: 'MANAGER', id: '2'}},
-  sites: {},
-  archived: false,
+const projectWithMembersjips = (
+  memberships: Record<string, ProjectMembership>,
+): Project => {
+  return {
+    id: '4',
+    name: 'test',
+    privacy: 'PUBLIC',
+    measurementUnits: 'METRIC',
+    description: 'test description',
+    updatedAt: '8/28/2024',
+    memberships: memberships,
+    sites: {},
+    archived: false,
+  };
 };
 
-const sampleProject2: Project = {
-  id: '4',
-  name: 'test',
-  privacy: 'PUBLIC',
-  measurementUnits: 'METRIC',
-  description: 'test description',
-  updatedAt: '8/28/2024',
-  memberships: {sample: {userId: '2', userRole: 'VIEWER', id: '2'}},
-  sites: {},
-  archived: false,
-};
+const sampleProject = projectWithMembersjips({
+  sample: {userId: '1', userRole: 'MANAGER', id: '2'},
+});
+
+const sampleProject2 = projectWithMembersjips({
+  sample: {userId: '2', userRole: 'VIEWER', id: '3'},
+});
 
 const sampleManagerRoles: ProjectRole[] = ['MANAGER'];
 

--- a/dev-client/src/model/permissions/permissions.test.ts
+++ b/dev-client/src/model/permissions/permissions.test.ts
@@ -41,18 +41,6 @@ describe('permission tests', () => {
     },
   };
 
-  const emptyProject: Project = {
-    id: '3',
-    name: 'test',
-    privacy: 'PUBLIC',
-    measurementUnits: 'METRIC',
-    description: 'test description',
-    updatedAt: '8/28/2024',
-    memberships: {},
-    sites: {},
-    archived: false,
-  };
-
   const projectWithMemberships = (
     memberships: Record<string, ProjectMembership>,
   ): Project => {
@@ -69,30 +57,32 @@ describe('permission tests', () => {
     };
   };
 
-  const sampleProject = projectWithMemberships({
-    sample: {userId: '1', userRole: 'MANAGER', id: '2'},
-  });
-
-  const sampleProject2 = projectWithMemberships({
-    sample: {userId: '2', userRole: 'VIEWER', id: '3'},
-  });
-
   const sampleManagerRoles: ProjectRole[] = ['MANAGER'];
   const sampleViewerRoles: ProjectRole[] = ['VIEWER'];
 
   test('no user', () => {
+    const emptyProject = projectWithMemberships({});
+
     const result = userHasProjectRole(emptyUser, emptyProject, emptyRoles);
 
     expect(result).toBeFalsy();
   });
 
   test('user is in project with no role', () => {
+    const sampleProject = projectWithMemberships({
+      sample: {userId: sampleUser.id, userRole: 'MANAGER', id: '2'},
+    });
+
     const result = userHasProjectRole(sampleUser, sampleProject);
 
     expect(result).toBeTruthy();
   });
 
   test('user is in project with role', () => {
+    const sampleProject = projectWithMemberships({
+      sample: {userId: sampleUser.id, userRole: 'MANAGER', id: '2'},
+    });
+
     const result = userHasProjectRole(
       sampleUser,
       sampleProject,
@@ -103,6 +93,10 @@ describe('permission tests', () => {
   });
 
   test('user is in project with unexpected role', () => {
+    const sampleProject = projectWithMemberships({
+      sample: {userId: sampleUser.id, userRole: 'MANAGER', id: '2'},
+    });
+
     const result = userHasProjectRole(
       sampleUser,
       sampleProject,
@@ -113,9 +107,13 @@ describe('permission tests', () => {
   });
 
   test('user is not in project', () => {
+    const sampleProject = projectWithMemberships({
+      sample: {userId: sampleUser.id, userRole: 'VIEWER', id: '3'},
+    });
+
     const result = userHasProjectRole(
       sampleUser,
-      sampleProject2,
+      sampleProject,
       sampleManagerRoles,
     );
 

--- a/dev-client/src/model/permissions/permissions.test.ts
+++ b/dev-client/src/model/permissions/permissions.test.ts
@@ -77,6 +77,7 @@ const sampleProject2 = projectWithMembersjips({
 });
 
 const sampleManagerRoles: ProjectRole[] = ['MANAGER'];
+const sampleViewerRoles: ProjectRole[] = ['VIEWER'];
 
 describe('permission tests', () => {
   test('no user', () => {
@@ -99,6 +100,16 @@ describe('permission tests', () => {
     );
 
     expect(result).toBeTruthy();
+  });
+
+  test('user is in project with unexpected role', () => {
+    const result = userHasProjectRole(
+      sampleUser,
+      sampleProject,
+      sampleViewerRoles,
+    );
+
+    expect(result).toBeFalsy();
   });
 
   test('user is not in project', () => {

--- a/dev-client/src/model/permissions/permissions.test.ts
+++ b/dev-client/src/model/permissions/permissions.test.ts
@@ -52,7 +52,7 @@ const emptyProject: Project = {
   archived: false,
 };
 
-const projectWithMembersjips = (
+const projectWithMemberships = (
   memberships: Record<string, ProjectMembership>,
 ): Project => {
   return {
@@ -68,11 +68,11 @@ const projectWithMembersjips = (
   };
 };
 
-const sampleProject = projectWithMembersjips({
+const sampleProject = projectWithMemberships({
   sample: {userId: '1', userRole: 'MANAGER', id: '2'},
 });
 
-const sampleProject2 = projectWithMembersjips({
+const sampleProject2 = projectWithMemberships({
   sample: {userId: '2', userRole: 'VIEWER', id: '3'},
 });
 

--- a/dev-client/src/model/permissions/permissions.test.ts
+++ b/dev-client/src/model/permissions/permissions.test.ts
@@ -24,62 +24,62 @@ import {
 
 import {userHasProjectRole} from 'terraso-mobile-client/model/permissions/permissions';
 
-const emptyUser = null;
-const emptyRoles: ProjectRole[] = [];
+describe('permission tests', () => {
+  const emptyUser = null;
+  const emptyRoles: ProjectRole[] = [];
 
-const sampleUser: User = {
-  id: '1',
-  email: 'email@example.com',
-  firstName: 'Test',
-  lastName: 'Test',
-  profileImage: '',
-  preferences: {
-    group_notifications: 'true',
-    story_map_notifications: 'true',
-    language: 'en-US',
-  },
-};
+  const sampleUser: User = {
+    id: '1',
+    email: 'email@example.com',
+    firstName: 'Test',
+    lastName: 'Test',
+    profileImage: '',
+    preferences: {
+      group_notifications: 'true',
+      story_map_notifications: 'true',
+      language: 'en-US',
+    },
+  };
 
-const emptyProject: Project = {
-  id: '3',
-  name: 'test',
-  privacy: 'PUBLIC',
-  measurementUnits: 'METRIC',
-  description: 'test description',
-  updatedAt: '8/28/2024',
-  memberships: {},
-  sites: {},
-  archived: false,
-};
-
-const projectWithMemberships = (
-  memberships: Record<string, ProjectMembership>,
-): Project => {
-  return {
-    id: '4',
+  const emptyProject: Project = {
+    id: '3',
     name: 'test',
     privacy: 'PUBLIC',
     measurementUnits: 'METRIC',
     description: 'test description',
     updatedAt: '8/28/2024',
-    memberships: memberships,
+    memberships: {},
     sites: {},
     archived: false,
   };
-};
 
-const sampleProject = projectWithMemberships({
-  sample: {userId: '1', userRole: 'MANAGER', id: '2'},
-});
+  const projectWithMemberships = (
+    memberships: Record<string, ProjectMembership>,
+  ): Project => {
+    return {
+      id: '4',
+      name: 'test',
+      privacy: 'PUBLIC',
+      measurementUnits: 'METRIC',
+      description: 'test description',
+      updatedAt: '8/28/2024',
+      memberships: memberships,
+      sites: {},
+      archived: false,
+    };
+  };
 
-const sampleProject2 = projectWithMemberships({
-  sample: {userId: '2', userRole: 'VIEWER', id: '3'},
-});
+  const sampleProject = projectWithMemberships({
+    sample: {userId: '1', userRole: 'MANAGER', id: '2'},
+  });
 
-const sampleManagerRoles: ProjectRole[] = ['MANAGER'];
-const sampleViewerRoles: ProjectRole[] = ['VIEWER'];
+  const sampleProject2 = projectWithMemberships({
+    sample: {userId: '2', userRole: 'VIEWER', id: '3'},
+  });
 
-describe('permission tests', () => {
+  const sampleManagerRoles: ProjectRole[] = ['MANAGER'];
+  const sampleViewerRoles: ProjectRole[] = ['VIEWER'];
+
   test('no user', () => {
     const result = userHasProjectRole(emptyUser, emptyProject, emptyRoles);
 

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -15,7 +15,9 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {User} from 'terraso-client-shared/account/accountSlice';
 import {ProjectMembershipProjectRoleChoices} from 'terraso-client-shared/graphqlSchema/graphql';
+import {Project, ProjectRole} from 'terraso-client-shared/project/projectSlice';
 import {SiteUserRole} from 'terraso-client-shared/selectors';
 
 export const matchesOne =
@@ -55,5 +57,31 @@ export const isProjectViewer = (userRole: SiteUserRole | null) => {
 export const isProjectEditor = (userRole: SiteUserRole | null) => {
   return Boolean(
     userRole && ['MANAGER', 'CONTRIBUTOR', 'OWNER'].includes(userRole.role),
+  );
+};
+
+export const userHasProjectRole = (
+  currentUser: User | null,
+  project: Project,
+  userRoles?: ProjectRole[],
+) => {
+  if (!currentUser) {
+    return false;
+  }
+
+  if (!userRoles) {
+    return true;
+  }
+
+  /*
+   * Filter returns whether we can find a membership for the project
+   * that matches the current user and has a role in the accepted list
+   */
+  return Boolean(
+    Object.values(project.memberships).find(
+      membership =>
+        currentUser?.id === membership.userId &&
+        userRoles.includes(membership.userRole),
+    ),
   );
 };


### PR DESCRIPTION
## Description
Extract `userHasProjectRole` in to a function and refactor `permissionHooks` to use this function.

Add tests for `userHasProjectRole`.

### Related Issues
Fixes #1853.