### PR TITLE
fix: use ExternalLink for soil info pages

### DIFF
--- a/dev-client/src/components/content/info/privacy/DataPrivacyContent.tsx
+++ b/dev-client/src/components/content/info/privacy/DataPrivacyContent.tsx
@@ -19,7 +19,7 @@ import {useTranslation} from 'react-i18next';
 
 import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
 import {ExternalLink} from 'terraso-mobile-client/components/links/ExternalLink';
-import InternalLink from 'terraso-mobile-client/components/links/InternalLink';
+import {InternalLink} from 'terraso-mobile-client/components/links/InternalLink';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 
 export const DataPrivacyContent = () => {

--- a/dev-client/src/components/links/InternalLink.tsx
+++ b/dev-client/src/components/links/InternalLink.tsx
@@ -29,7 +29,7 @@ type InternalLinkProps = {
   url: string;
 };
 
-export function InternalLink({label, onPress, url}: InternalLinkProps) {
+export const InternalLink = ({label, onPress, url}: InternalLinkProps) => {
   const isValidUrl = useMemo(() => validateUrl(url), [url]);
   const openUrl = useCallback(() => openBrowserAsync(url), [url]);
   const [pressed, setPressed] = useState(false);
@@ -48,4 +48,4 @@ export function InternalLink({label, onPress, url}: InternalLinkProps) {
       </Text>
     )
   );
-}
+};

--- a/dev-client/src/components/links/InternalLink.tsx
+++ b/dev-client/src/components/links/InternalLink.tsx
@@ -29,7 +29,7 @@ type InternalLinkProps = {
   url: string;
 };
 
-export default function InternalLink({label, onPress, url}: InternalLinkProps) {
+export function InternalLink({label, onPress, url}: InternalLinkProps) {
   const isValidUrl = useMemo(() => validateUrl(url), [url]);
   const openUrl = useCallback(() => openBrowserAsync(url), [url]);
   const [pressed, setPressed] = useState(false);

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
@@ -20,7 +20,7 @@ import {useTranslation} from 'react-i18next';
 import {SoilInfo} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
-import InternalLink from 'terraso-mobile-client/components/links/InternalLink';
+import {ExternalLink} from 'terraso-mobile-client/components/links/ExternalLink';
 import {
   Box,
   Column,
@@ -42,7 +42,7 @@ export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
         {soilInfo.soilSeries.taxonomySubgroup}
       </Heading>
       <Text variant="body1">{soilInfo.soilSeries.description}</Text>
-      <InternalLink
+      <ExternalLink
         label={t('site.soil_id.soil_info.series_descr_url')}
         url={soilInfo.soilSeries.fullDescriptionUrl}
       />
@@ -62,7 +62,7 @@ export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
               }}
             />
           </Box>
-          <InternalLink
+          <ExternalLink
             label={t('site.soil_id.soil_info.eco_descr_url')}
             url={soilInfo.ecologicalSite.url}
           />


### PR DESCRIPTION
## Description
Use ExternalLink for soil info pages. 

Also clean up external link to use a non-default export.

### Related Issues
Addresses #1023.