### PR TITLE
fix: add 'Engineering' label to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
@@ -1,6 +1,6 @@
 name: "Mobile App Bug Report"
 description: Used for reporting bugs and defects in mobile apps.
-labels: ["bug", "needs triage"]
+labels: ["bug", "needs triage", "Engineering"]
 body:
   - type: input
     id: app-version


### PR DESCRIPTION
## Description
Adds "Engineering" label to mobile bug template, per Derek's request [in slack](https://tech-matters.slack.com/archives/C01C1FZANBG/p1725377122948789)