### PR TITLE
fix: allow zooming to user location on first map view 

### DIFF
--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -49,10 +49,6 @@ export const BottomTabsScreen = memo(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  console.log(
-    'Rerender BottomTabsScreen. Permission? ',
-    locationPermission?.granted,
-  );
   useEffect(() => {
     if (locationPermission?.granted) {
       locationManager.getLastKnownLocation().then(initCoords => {

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -38,11 +38,11 @@ import {useDispatch} from 'terraso-mobile-client/store';
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
-  const [locationPermission, requestLocationPermission] =
+  const [potentiallyOutdatedLocationPermission, _, requestLocationPermission] =
     useForegroundPermissions();
 
   useEffect(() => {
-    if (!locationPermission?.granted) {
+    if (!potentiallyOutdatedLocationPermission?.granted) {
       requestLocationPermission();
     }
     // disable depcheck because we only want to run on mount
@@ -50,7 +50,7 @@ export const BottomTabsScreen = memo(() => {
   }, []);
 
   useEffect(() => {
-    if (locationPermission?.granted) {
+    if (potentiallyOutdatedLocationPermission?.granted) {
       locationManager.getLastKnownLocation().then(initCoords => {
         if (initCoords !== null) {
           dispatch(
@@ -73,7 +73,7 @@ export const BottomTabsScreen = memo(() => {
 
       return () => locationManager.removeListener(listener);
     }
-  }, [dispatch, locationPermission]);
+  }, [dispatch, potentiallyOutdatedLocationPermission]);
 
   return (
     <BottomTabs.Navigator

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -17,6 +17,8 @@
 
 import {memo, useEffect} from 'react';
 
+import {useForegroundPermissions} from 'expo-location';
+
 import {NavigationHelpers} from '@react-navigation/native';
 import {Location, locationManager} from '@rnmapbox/maps';
 
@@ -36,30 +38,46 @@ import {useDispatch} from 'terraso-mobile-client/store';
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
+  const [locationPermission, requestLocationPermission] =
+    useForegroundPermissions();
 
   useEffect(() => {
-    locationManager.getLastKnownLocation().then(initCoords => {
-      if (initCoords !== null) {
+    if (!locationPermission?.granted) {
+      requestLocationPermission();
+    }
+    // disable depcheck because we only want to run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  console.log(
+    'Rerender BottomTabsScreen. Permission? ',
+    locationPermission?.granted,
+  );
+  useEffect(() => {
+    if (locationPermission?.granted) {
+      locationManager.getLastKnownLocation().then(initCoords => {
+        if (initCoords !== null) {
+          dispatch(
+            updateLocation({
+              coords: initCoords.coords,
+              accuracyM: initCoords.coords.accuracy ?? null,
+            }),
+          );
+        }
+      });
+
+      // add listener to update location on user movement
+      const listener = ({coords}: Location) => {
         dispatch(
-          updateLocation({
-            coords: initCoords.coords,
-            accuracyM: initCoords.coords.accuracy ?? null,
-          }),
+          updateLocation({coords: coords, accuracyM: coords.accuracy ?? null}),
         );
-      }
-    });
+      };
+      locationManager.setMinDisplacement(USER_DISPLACEMENT_MIN_DISTANCE_M);
+      locationManager.addListener(listener);
 
-    // add listener to update location on user movement
-    const listener = ({coords}: Location) => {
-      dispatch(
-        updateLocation({coords: coords, accuracyM: coords.accuracy ?? null}),
-      );
-    };
-    locationManager.setMinDisplacement(USER_DISPLACEMENT_MIN_DISTANCE_M);
-    locationManager.addListener(listener);
-
-    return () => locationManager.removeListener(listener);
-  }, [dispatch]);
+      return () => locationManager.removeListener(listener);
+    }
+  }, [dispatch, locationPermission]);
 
   return (
     <BottomTabs.Navigator

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -26,8 +26,6 @@ import {
   useState,
 } from 'react';
 
-import {useForegroundPermissions} from 'expo-location';
-
 import BottomSheet from '@gorhom/bottom-sheet';
 import Mapbox from '@rnmapbox/maps';
 
@@ -59,16 +57,6 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
 export const HomeScreen = memo(() => {
-  const [locationPermission, requestLocationPermission] =
-    useForegroundPermissions();
-  useEffect(() => {
-    if (!locationPermission?.granted) {
-      requestLocationPermission();
-    }
-    // disable depcheck because we only want to run on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const siteListBottomSheetRef = useRef<BottomSheet>(null);
   const [mapStyleURL, setMapStyleURL] = useState(Mapbox.StyleURL.Street);
   const [calloutState, setCalloutState] = useState<CalloutState>(noneCallout());


### PR DESCRIPTION
**The issue** 
I was only able to repro on a Release version on a physical device, and you can’t console.log, and wasn't able to clearly figure out what series of operations caused the issue. 
- But my best guess is that it was some sort of race condition with requesting permissions in HomeScreen and getting the user’s coordinates with the locationManager in BottomTabsScreen. 
- It seemed to only reproduce after my change to fix bug #1808, which moved the locationManager code from RootNavigator to BottomTabsScreen. This would put its execution much closer to HomeScreen’s.

**The fix** 
The approach in this fix was to guarantee we will ask for permissions whenever we ask for the user’s last known location. I do this by moving the locationPermission logic from HomeScreen to BottomTabsScreen, where the locationManager logic is.
- This resolves the issue, but there may be a better solution, where the locationManager logic lives in RootNavigator again, rather than BottomTabsScreen, and only does a "get" instead of a "request" for permissions -- but still asks for location permissions when the user encounters the HomeScreen. This would help if we want to use the logic outside of BottomTabsScreen.
- But I’ve spent a while looking into the original bug (1808) and still don’t understand what was triggering the permissions request before the home screen (and I am unable to reproduce it when reverting my fix for it). 

**Aside**
There are sadly various unpleasant things going on with permissions that I did not fix (Issues #1749 and #1893). I renamed a couple things accordingly per “honest names are better than dishonest names”.

### Related Issues
Addresses #1780

