### PR TITLE
feat: redux state persistence

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -85,7 +85,7 @@ LogBox.ignoreLogs([
   'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
 ]);
 
-const store = createStore(kvStorage.getMap(PERSISTED_STATE_KEY));
+const store = createStore(kvStorage.getMap(PERSISTED_STATE_KEY) ?? undefined);
 
 function App(): React.JSX.Element {
   const [headerHeight, setHeaderHeight] = useState(0);

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -50,9 +50,9 @@ import {GeospatialProvider} from 'terraso-mobile-client/context/GeospatialContex
 import {HeaderHeightContext} from 'terraso-mobile-client/context/HeaderHeightContext';
 import {HomeScreenContextProvider} from 'terraso-mobile-client/context/HomeScreenContext';
 import {RootNavigator} from 'terraso-mobile-client/navigation/navigators/RootNavigator';
-import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
 import {Toasts} from 'terraso-mobile-client/screens/Toasts';
-import {createStore, PERSISTED_STATE_KEY} from 'terraso-mobile-client/store';
+import {createStore} from 'terraso-mobile-client/store';
+import {loadPersistedStore} from 'terraso-mobile-client/store/persistence';
 import {paperTheme, theme} from 'terraso-mobile-client/theme';
 
 enableFreeze(true);
@@ -85,7 +85,7 @@ LogBox.ignoreLogs([
   'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
 ]);
 
-const store = createStore(kvStorage.getMap(PERSISTED_STATE_KEY) ?? undefined);
+const store = createStore(loadPersistedStore());
 
 function App(): React.JSX.Element {
   const [headerHeight, setHeaderHeight] = useState(0);

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -52,7 +52,7 @@ import {HomeScreenContextProvider} from 'terraso-mobile-client/context/HomeScree
 import {RootNavigator} from 'terraso-mobile-client/navigation/navigators/RootNavigator';
 import {Toasts} from 'terraso-mobile-client/screens/Toasts';
 import {createStore} from 'terraso-mobile-client/store';
-import {loadPersistedStore} from 'terraso-mobile-client/store/persistence';
+import {loadPersistedReduxState} from 'terraso-mobile-client/store/persistence';
 import {paperTheme, theme} from 'terraso-mobile-client/theme';
 
 enableFreeze(true);
@@ -85,7 +85,7 @@ LogBox.ignoreLogs([
   'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
 ]);
 
-const store = createStore(loadPersistedStore());
+const store = createStore(loadPersistedReduxState());
 
 function App(): React.JSX.Element {
   const [headerHeight, setHeaderHeight] = useState(0);

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -50,8 +50,9 @@ import {GeospatialProvider} from 'terraso-mobile-client/context/GeospatialContex
 import {HeaderHeightContext} from 'terraso-mobile-client/context/HeaderHeightContext';
 import {HomeScreenContextProvider} from 'terraso-mobile-client/context/HomeScreenContext';
 import {RootNavigator} from 'terraso-mobile-client/navigation/navigators/RootNavigator';
+import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
 import {Toasts} from 'terraso-mobile-client/screens/Toasts';
-import {createStore} from 'terraso-mobile-client/store';
+import {createStore, PERSISTED_STATE_KEY} from 'terraso-mobile-client/store';
 import {paperTheme, theme} from 'terraso-mobile-client/theme';
 
 enableFreeze(true);
@@ -84,7 +85,7 @@ LogBox.ignoreLogs([
   'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
 ]);
 
-const store = createStore();
+const store = createStore(kvStorage.getMap(PERSISTED_STATE_KEY));
 
 function App(): React.JSX.Element {
   const [headerHeight, setHeaderHeight] = useState(0);

--- a/dev-client/src/store/index.ts
+++ b/dev-client/src/store/index.ts
@@ -21,11 +21,7 @@ import {
   TypedUseSelectorHook,
 } from 'react-redux';
 
-import {
-  configureStore,
-  Middleware,
-  StateFromReducersMapObject,
-} from '@reduxjs/toolkit';
+import {configureStore, StateFromReducersMapObject} from '@reduxjs/toolkit';
 
 import {
   DispatchFromStoreFactory,
@@ -39,15 +35,7 @@ import {reducer as preferencesReducer} from 'terraso-mobile-client/model/prefere
 import projectReducer from 'terraso-mobile-client/model/project/projectSlice';
 import siteReducer from 'terraso-mobile-client/model/site/siteSlice';
 import soilIdReducer from 'terraso-mobile-client/model/soilId/soilIdSlice';
-import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
-
-export const PERSISTED_STATE_KEY = 'persisted-state';
-const serializationMiddleware: Middleware = store => next => action => {
-  const result = next(action);
-  const newState = store.getState();
-  kvStorage.setMap(PERSISTED_STATE_KEY, newState);
-  return result;
-};
+import {persistenceMiddleware} from 'terraso-mobile-client/store/persistence';
 
 const reducers = {
   ...sharedReducers,
@@ -70,7 +58,7 @@ export const createStore = (intialState?: Partial<AppState>) =>
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware()
         .concat(handleAbortMiddleware)
-        .concat(serializationMiddleware),
+        .concat(persistenceMiddleware),
     reducer: reducers,
     preloadedState: intialState,
   });

--- a/dev-client/src/store/persistence.test.ts
+++ b/dev-client/src/store/persistence.test.ts
@@ -78,6 +78,9 @@ test('can initialize store with persisted state', () => {
 
 test('persistence middleware does nothing without feature flag', () => {
   jest.isolateModules(() => {
+    const {kvStorage} = require('terraso-mobile-client/persistence/kvStorage');
+    kvStorage.setBool('FF_offline', false);
+
     const {
       persistenceMiddleware,
       loadPersistedReduxState,

--- a/dev-client/src/store/persistence.test.ts
+++ b/dev-client/src/store/persistence.test.ts
@@ -35,7 +35,7 @@ test('persistence middleware saves state to disk', () => {
 
     const {
       persistenceMiddleware,
-      loadPersistedStore,
+      loadPersistedReduxState,
     } = require('terraso-mobile-client/store/persistence');
 
     const store = configureStore({
@@ -43,11 +43,11 @@ test('persistence middleware saves state to disk', () => {
       reducer,
     });
 
-    expect(loadPersistedStore()).toBe(undefined);
+    expect(loadPersistedReduxState()).toBe(undefined);
 
     store.dispatch(increment());
 
-    expect(loadPersistedStore()).toEqual({counter: 1});
+    expect(loadPersistedReduxState()).toEqual({counter: 1});
   });
 });
 
@@ -58,21 +58,21 @@ test('can initialize store with persisted state', () => {
 
     const {
       persistenceMiddleware,
-      loadPersistedStore,
+      loadPersistedReduxState,
     } = require('terraso-mobile-client/store/persistence');
 
     kvStorage.setMap('persisted-redux-state', {counter: 1});
     const store = configureStore({
       middleware: [persistenceMiddleware],
       reducer,
-      preloadedState: loadPersistedStore(),
+      preloadedState: loadPersistedReduxState(),
     });
 
     expect(store.getState()).toEqual({counter: 1});
 
     store.dispatch(increment());
 
-    expect(loadPersistedStore()).toEqual({counter: 2});
+    expect(loadPersistedReduxState()).toEqual({counter: 2});
   });
 });
 
@@ -80,7 +80,7 @@ test('persistence middleware does nothing without feature flag', () => {
   jest.isolateModules(() => {
     const {
       persistenceMiddleware,
-      loadPersistedStore,
+      loadPersistedReduxState,
     } = require('terraso-mobile-client/store/persistence');
 
     const store = configureStore({
@@ -88,10 +88,10 @@ test('persistence middleware does nothing without feature flag', () => {
       reducer,
     });
 
-    expect(loadPersistedStore()).toBe(undefined);
+    expect(loadPersistedReduxState()).toBe(undefined);
 
     store.dispatch(increment());
 
-    expect(loadPersistedStore()).toBe(undefined);
+    expect(loadPersistedReduxState()).toBe(undefined);
   });
 });

--- a/dev-client/src/store/persistence.ts
+++ b/dev-client/src/store/persistence.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Middleware} from '@reduxjs/toolkit';
+
+import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
+import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
+import {AppState} from 'terraso-mobile-client/store';
+
+const PERSISTED_STATE_KEY = 'persisted-redux-state';
+export const persistenceMiddleware: Middleware = store => next => action => {
+  const result = next(action);
+  if (isFlagEnabled('FF_offline')) {
+    const newState = store.getState();
+    kvStorage.setMap(PERSISTED_STATE_KEY, newState);
+  }
+  return result;
+};
+
+export const loadPersistedStore = () => {
+  if (isFlagEnabled('FF_offline')) {
+    kvStorage.getMap<Partial<AppState>>(PERSISTED_STATE_KEY) ?? undefined;
+  }
+};

--- a/dev-client/src/store/persistence.ts
+++ b/dev-client/src/store/persistence.ts
@@ -31,8 +31,10 @@ export const persistenceMiddleware: Middleware = store => next => action => {
   return result;
 };
 
-export const loadPersistedStore = () => {
+export const loadPersistedReduxState = () => {
   if (isFlagEnabled('FF_offline')) {
-    kvStorage.getMap<Partial<AppState>>(PERSISTED_STATE_KEY) ?? undefined;
+    return (
+      kvStorage.getMap<Partial<AppState>>(PERSISTED_STATE_KEY) ?? undefined
+    );
   }
 };


### PR DESCRIPTION
## Description
Minimal implementation of redux state persistence! Currently the behavior is behind the offline feature flag.

This small amount of code is surprisingly effective. With just these changes, the app now goes to directly to the home screen and (if you comment out the hardwired `fetchSoilDataForUser` call) immediately displays all the user's data on launch:

[Launching straight to home screen](https://github.com/user-attachments/assets/b18167d6-283c-4de1-87fd-7ca0ebaed9e8)

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Related to #1931 
Fixes #2164 