### PR TITLE
feat: Add feature flag to gate offline functionality

### DIFF
--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -28,6 +28,7 @@ import {APP_CONFIG, MMKV} from 'terraso-mobile-client/config';
 export const FeatureFlagControl = () => {
   // It may cause issues to toggle a feature flag state while the app is running,
   // so expect the user to restart the app if they want to change the feature flag state.
+  // This should never be exposed in production.
 
   const currentFlagState = APP_CONFIG.FF_offline;
   const [nextFlagState, setNextFlagState] = useState<boolean>(
@@ -41,16 +42,20 @@ export const FeatureFlagControl = () => {
   };
 
   return (
-    <View>
-      <Heading mb="10px">Feature Flags</Heading>
-      <Text bold={true}>FF_offline</Text>
-      <Text>{`Currently: ${currentFlagState ? 'ON' : 'OFF'}`}</Text>
-      <View style={styles.nextFlagStateView}>
-        <Text>{`On next startup, flag will be: `}</Text>
-        <Switch value={nextFlagState} onValueChange={onToggle} />
-        <Text>{` ${nextFlagState ? 'ON' : 'OFF'}`}</Text>
-      </View>
-    </View>
+    <>
+      {APP_CONFIG.environment !== 'production' && (
+        <View>
+          <Heading mb="10px">Feature Flags</Heading>
+          <Text bold={true}>FF_offline</Text>
+          <Text>{`Currently: ${currentFlagState ? 'ON' : 'OFF'}`}</Text>
+          <View style={styles.nextFlagStateView}>
+            <Text>{`On next startup, flag will be: `}</Text>
+            <Switch value={nextFlagState} onValueChange={onToggle} />
+            <Text>{` ${nextFlagState ? 'ON' : 'OFF'}`}</Text>
+          </View>
+        </View>
+      )}
+    </>
   );
 };
 

--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -14,10 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-
 import {useState} from 'react';
 import {StyleSheet, View} from 'react-native';
-import {Switch} from 'react-native-paper';
+import {Divider, Switch} from 'react-native-paper';
 
 import {
   Heading,
@@ -44,16 +43,19 @@ export const FeatureFlagControl = () => {
   return (
     <>
       {APP_CONFIG.environment !== 'production' && (
-        <View>
-          <Heading mb="10px">Feature Flags</Heading>
-          <Text bold={true}>FF_offline</Text>
-          <Text>{`Currently: ${currentFlagState ? 'ON' : 'OFF'}`}</Text>
-          <View style={styles.nextFlagStateView}>
-            <Text>{`On next startup, flag will be: `}</Text>
-            <Switch value={nextFlagState} onValueChange={onToggle} />
-            <Text>{` ${nextFlagState ? 'ON' : 'OFF'}`}</Text>
+        <>
+          <Divider />
+          <View>
+            <Heading mb="10px">Feature Flags</Heading>
+            <Text bold={true}>FF_offline</Text>
+            <Text>{`Currently: ${currentFlagState ? 'ON' : 'OFF'}`}</Text>
+            <View style={styles.nextFlagStateView}>
+              <Text>{`On next startup will be: `}</Text>
+              <Switch value={nextFlagState} onValueChange={onToggle} />
+              <Text>{` ${nextFlagState ? 'ON' : 'OFF'}`}</Text>
+            </View>
           </View>
-        </View>
+        </>
       )}
     </>
   );

--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -24,7 +24,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {APP_CONFIG, MMKV} from 'terraso-mobile-client/config';
 
-export const FeatureFlagControlOrEmptyInProd = () => {
+export const FeatureFlagControl = () => {
   // It may cause issues to toggle a feature flag state while the app is running,
   // so expect the user to restart the app if they want to change the feature flag state.
   // This should never be exposed in production.

--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useState} from 'react';
+import {StyleSheet, View} from 'react-native';
+import {Switch} from 'react-native-paper';
+
+import {
+  Heading,
+  Text,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {APP_CONFIG, MMKV} from 'terraso-mobile-client/config';
+
+export const FeatureFlagControl = () => {
+  // It may cause issues to toggle a feature flag state while the app is running,
+  // so expect the user to restart the app if they want to change the feature flag state.
+
+  const currentFlagState = APP_CONFIG.FF_offline;
+  const [nextFlagState, setNextFlagState] = useState<boolean>(
+    MMKV.getBool('FF_offline') ?? APP_CONFIG.FF_offline,
+  );
+
+  // nextFlagState and MMKV state should be kept in sync
+  const onToggle = () => {
+    MMKV.setBool('FF_offline', !nextFlagState);
+    setNextFlagState(!nextFlagState);
+  };
+
+  return (
+    <View>
+      <Heading mb="10px">Feature Flags</Heading>
+      <Text bold={true}>FF_offline</Text>
+      <Text>{`Currently: ${currentFlagState ? 'ON' : 'OFF'}`}</Text>
+      <View style={styles.nextFlagStateView}>
+        <Text>{`On next startup, flag will be: `}</Text>
+        <Switch value={nextFlagState} onValueChange={onToggle} />
+        <Text>{` ${nextFlagState ? 'ON' : 'OFF'}`}</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  nextFlagStateView: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});

--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -24,7 +24,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {APP_CONFIG, MMKV} from 'terraso-mobile-client/config';
 
-export const FeatureFlagControl = () => {
+export const FeatureFlagControlOrEmptyInProd = () => {
   // It may cause issues to toggle a feature flag state while the app is running,
   // so expect the user to restart the app if they want to change the feature flag state.
   // This should never be exposed in production.

--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -71,7 +71,7 @@ const FeatureFlagControl = ({flag}: FeatureFlagControlProps) => {
       <Text>{featureFlags[flag].description}</Text>
       <Text>{`Currently: ${currentFlagState ? 'ON' : 'OFF'}`}</Text>
       <View style={styles.nextFlagStateView}>
-        <Text>{`On next startup will be: `}</Text>
+        <Text>{`On next app launch will be: `}</Text>
         <Switch value={nextFlagState} onValueChange={onToggle} />
         <Text>{` ${nextFlagState ? 'ON' : 'OFF'}`}</Text>
       </View>

--- a/dev-client/src/config/featureFlags.ts
+++ b/dev-client/src/config/featureFlags.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {APP_CONFIG, MMKV} from 'terraso-mobile-client/config';
+
+// When you add a new flag:
+// 1) Add it to featureFlags here
+// 2) Set it in APP_CONFIG
+// 3) Add a FeatureFlagControl for it
+export const featureFlags = {
+  FF_offline: {
+    defaultIsEnabled: false,
+    description: 'Enables support for offline mode',
+  },
+};
+
+export type FeatureFlagName = keyof typeof featureFlags;
+
+export const isFlagEnabled = (flag: FeatureFlagName) => {
+  return APP_CONFIG[flag] as boolean;
+};
+
+export const willFlagBeEnabledOnReload = (flag: FeatureFlagName) => {
+  return MMKV.getBool(flag) ?? featureFlags[flag].defaultIsEnabled;
+};
+
+export const setFlagEnabledOnReload = (
+  flag: FeatureFlagName,
+  isEnabled: boolean,
+) => {
+  MMKV.setBool('FF_offline', isEnabled);
+};

--- a/dev-client/src/config/featureFlags.ts
+++ b/dev-client/src/config/featureFlags.ts
@@ -42,5 +42,5 @@ export const setFlagEnabledOnReload = (
   flag: FeatureFlagName,
   isEnabled: boolean,
 ) => {
-  MMKV.setBool('FF_offline', isEnabled);
+  MMKV.setBool(flag, isEnabled);
 };

--- a/dev-client/src/config/index.ts
+++ b/dev-client/src/config/index.ts
@@ -24,7 +24,7 @@ import {setAPIConfig, TerrasoAPIConfig} from 'terraso-client-shared/config';
 
 const ENV_CONFIG = Constants.expoConfig!.extra!;
 
-const MMKV = new MMKVLoader().withEncryption().initialize();
+export const MMKV = new MMKVLoader().withEncryption().initialize();
 
 setAPIConfig({
   terrasoAPIURL: ENV_CONFIG.TERRASO_BACKEND,
@@ -81,4 +81,5 @@ export const APP_CONFIG = {
   googleClientId,
   googleRedirectURI,
   microsoftRedirectURI,
+  FF_offline: MMKV.getBool('FF_offline') ?? false,
 } as const;

--- a/dev-client/src/config/index.ts
+++ b/dev-client/src/config/index.ts
@@ -22,6 +22,8 @@ import Constants from 'expo-constants';
 
 import {setAPIConfig, TerrasoAPIConfig} from 'terraso-client-shared/config';
 
+import {willFlagBeEnabledOnReload} from 'terraso-mobile-client/config/featureFlags';
+
 const ENV_CONFIG = Constants.expoConfig!.extra!;
 
 export const MMKV = new MMKVLoader().withEncryption().initialize();
@@ -81,5 +83,5 @@ export const APP_CONFIG = {
   googleClientId,
   googleRedirectURI,
   microsoftRedirectURI,
-  FF_offline: MMKV.getBool('FF_offline') ?? false,
+  FF_offline: willFlagBeEnabledOnReload('FF_offline'),
 } as const;

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -15,6 +15,9 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {Divider} from 'native-base';
+
+import {FeatureFlagControl} from 'terraso-mobile-client/components/FeatureFlagControl';
 import {MenuList} from 'terraso-mobile-client/components/menus/MenuList';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -34,6 +37,8 @@ export function UserSettingsScreen() {
           <DeleteAccountItem />
         </MenuList>
         <VersionIndicator />
+        <Divider marginY="10px" />
+        <FeatureFlagControl />
       </Column>
     </ScreenScaffold>
   );

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {FeatureFlagControl} from 'terraso-mobile-client/components/FeatureFlagControl';
+import {FeatureFlagControlOrEmptyInProd} from 'terraso-mobile-client/components/FeatureFlagControl';
 import {MenuList} from 'terraso-mobile-client/components/menus/MenuList';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -35,7 +35,7 @@ export function UserSettingsScreen() {
           <DeleteAccountItem />
         </MenuList>
         <VersionIndicator />
-        <FeatureFlagControl />
+        <FeatureFlagControlOrEmptyInProd />
       </Column>
     </ScreenScaffold>
   );

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {FeatureFlagControl} from 'terraso-mobile-client/components/FeatureFlagControl';
+import {FeatureFlagControlPanel} from 'terraso-mobile-client/components/FeatureFlagControl';
 import {MenuList} from 'terraso-mobile-client/components/menus/MenuList';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -35,7 +35,7 @@ export function UserSettingsScreen() {
           <DeleteAccountItem />
         </MenuList>
         <VersionIndicator />
-        <FeatureFlagControl />
+        <FeatureFlagControlPanel />
       </Column>
     </ScreenScaffold>
   );

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -15,8 +15,6 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {Divider} from 'native-base';
-
 import {FeatureFlagControl} from 'terraso-mobile-client/components/FeatureFlagControl';
 import {MenuList} from 'terraso-mobile-client/components/menus/MenuList';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
@@ -37,7 +35,6 @@ export function UserSettingsScreen() {
           <DeleteAccountItem />
         </MenuList>
         <VersionIndicator />
-        <Divider marginY="10px" />
         <FeatureFlagControl />
       </Column>
     </ScreenScaffold>

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {FeatureFlagControlOrEmptyInProd} from 'terraso-mobile-client/components/FeatureFlagControl';
+import {FeatureFlagControl} from 'terraso-mobile-client/components/FeatureFlagControl';
 import {MenuList} from 'terraso-mobile-client/components/menus/MenuList';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -35,7 +35,7 @@ export function UserSettingsScreen() {
           <DeleteAccountItem />
         </MenuList>
         <VersionIndicator />
-        <FeatureFlagControlOrEmptyInProd />
+        <FeatureFlagControl />
       </Column>
     </ScreenScaffold>
   );


### PR DESCRIPTION
## Description
- Adds a feature flag for offline: `FF_offline`
- Allows a user in a non-production environment to toggle the feature flag. The user must restart the app for the new feature flag value to take effect. (This seemed the easiest thing to implement right now, but still allowing for user control.)

### Related Issues
Implements #2100 

### Screenshot
There should be no visible difference in a production environment, but looks like this in a non-prod environment:
<img src="https://github.com/user-attachments/assets/530f7036-3f4e-4b3d-b8b9-6f44846e17d7" height="700">
