### PR TITLE
fix: Changing location permissions should update components immediately

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -45,6 +45,7 @@ import {captureConsoleIntegration} from '@sentry/integrations';
 import * as Sentry from '@sentry/react-native';
 
 import {APP_CONFIG} from 'terraso-mobile-client/config';
+import {ForegroundPermissionsProvider} from 'terraso-mobile-client/context/AppPermissionsContext';
 import {ConnectivityContextProvider} from 'terraso-mobile-client/context/connectivity/ConnectivityContext';
 import {GeospatialProvider} from 'terraso-mobile-client/context/GeospatialContext';
 import {HeaderHeightContext} from 'terraso-mobile-client/context/HeaderHeightContext';
@@ -114,7 +115,9 @@ function App(): React.JSX.Element {
                         <Toasts />
                         <HomeScreenContextProvider>
                           <ConnectivityContextProvider>
-                            <RootNavigator />
+                            <ForegroundPermissionsProvider>
+                              <RootNavigator />
+                            </ForegroundPermissionsProvider>
                           </ConnectivityContextProvider>
                         </HomeScreenContextProvider>
                       </GeospatialProvider>

--- a/dev-client/src/components/modals/PermissionsRequestWrapper.tsx
+++ b/dev-client/src/components/modals/PermissionsRequestWrapper.tsx
@@ -23,11 +23,8 @@ import {createPermissionHook} from 'expo-modules-core';
 
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
-import {UpdatedPermissionsHookType} from 'terraso-mobile-client/hooks/appPermissionsHooks';
 
-type PermissionHook =
-  | ReturnType<typeof createPermissionHook>
-  | UpdatedPermissionsHookType;
+type PermissionHook = ReturnType<typeof createPermissionHook>;
 
 type Props = {
   requestModalTitle: string;
@@ -37,9 +34,6 @@ type Props = {
   children: (onOpen: () => void) => React.ReactNode;
 };
 
-// FYI if a calling component uses the permission hook and needs to
-// update when permissions are granted, it can set permissionedAction
-// to the GetPermissionMethod returned by the hook
 export const PermissionsRequestWrapper = ({
   requestModalTitle,
   requestModalBody,
@@ -49,10 +43,10 @@ export const PermissionsRequestWrapper = ({
 }: Props) => {
   const {t} = useTranslation();
   const ref = useRef<ModalHandle>(null);
-  // Issue #1808: These permissions could be outdated if
+  // Issue #1749: Prefer to use this with one of our own "updated" app permissions hooks -- which is a first step
+  // to have a more reactive interface with permissions. Otherwise, the permissions could be outdated if
   // a) nobody has done a "get" or "request" on them since they changed, or
   // b) a descendant component did the "get" or "request", so there is no reason for the given component to re-render
-  // AppPermissionsHooks is a first step to have a more reactive interface with permissions
   const [permissions, requestPermissions] = usePermissions();
 
   const onRequestAction = useCallback(async () => {

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -26,12 +26,16 @@ import {
 
 export type ForegroundPermissionsType = {
   permissions: LocationPermissionResponse | null;
-  get: () => Promise<LocationPermissionResponse>;
-  request: () => Promise<LocationPermissionResponse>;
-} | null;
+  get: (() => Promise<LocationPermissionResponse>) | null;
+  request: (() => Promise<LocationPermissionResponse>) | null;
+};
 
 export const ForegroundPermissionsContext =
-  createContext<ForegroundPermissionsType>(null);
+  createContext<ForegroundPermissionsType>({
+    permissions: null,
+    get: null,
+    request: null,
+  });
 
 export const ForegroundPermissionsProvider = ({
   children,

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -38,47 +38,37 @@ export const ForegroundPermissionsProvider = ({
   const [permissions, request, get] = useForegroundPermissions();
   const [updatedPermissions, setUpdatedPermissions] =
     useState<LocationPermissionResponse | null>(permissions);
-  console.log('---- Permissions Provider re-rendering ----');
 
   const updatedRequest = useCallback(async () => {
     const response = await request();
-    console.log('    Calling updatedRequest(), got', response.status);
     setUpdatedPermissions(response);
     return response;
   }, [request, setUpdatedPermissions]);
 
   const updatedGet = useCallback(async () => {
     const response = await get();
-    console.log('    Called updatedGet(), got', response.status);
     setUpdatedPermissions(response);
     return response;
   }, [get, setUpdatedPermissions]);
 
   useEffect(() => {
-    console.log(
-      'Considering adding a new app state listener... --> updatedPermissions',
-      updatedPermissions?.status,
-    );
     // Don't start listening until someone asks about location permissions.
-    // If app switches from background to foreground, update permissions in case they changed
-    if (updatedPermissions) {
-      console.log('YES, add AppState listener');
+    //   updatedPermissions will only be non-null if permissions have been gotten/requested so far
+    //   For this to be fully correct, all components must use the updated hook, rather than useForegroundPermissions
 
+    if (updatedPermissions) {
+      // If app switches from background to foreground, update permissions in case they changed
       const onAppStateChange = async (state: AppStateStatus) => {
-        console.log('App state changed to', state);
         if (state === 'active') {
-          console.log('    Calling updatedGet()');
           updatedGet();
         }
       };
-
       const appStateListener = AppState.addEventListener(
         'change',
         onAppStateChange,
       );
 
       return () => {
-        console.log('Destroying AppState listener');
         appStateListener.remove();
       };
     }

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {createContext, useCallback, useEffect, useState} from 'react';
+import {AppState, AppStateStatus} from 'react-native';
+
+import {
+  LocationPermissionResponse,
+  requestForegroundPermissionsAsync,
+  useForegroundPermissions,
+} from 'expo-location';
+
+export type ForegroundPermissionsType = {
+  permissions: LocationPermissionResponse | null;
+  get: () => Promise<LocationPermissionResponse>;
+  request: () => Promise<LocationPermissionResponse>;
+} | null;
+
+export const ForegroundPermissionsContext =
+  createContext<ForegroundPermissionsType>(null);
+
+export const ForegroundPermissionsProvider = ({
+  children,
+}: React.PropsWithChildren) => {
+  const [permissions, get, _] = useForegroundPermissions();
+  const [updatedPermissions, setUpdatedPermissions] =
+    useState<LocationPermissionResponse | null>(permissions);
+  console.log('Calling the Provider', updatedPermissions);
+
+  const updatedGet = useCallback(async () => {
+    console.log('Calling get');
+    const response = await get();
+    setUpdatedPermissions(response);
+    return response;
+    // TODO-cknipe: Or should we not return the response here and below to encourage using updatedPermissions instead?
+  }, [get, setUpdatedPermissions]);
+
+  const updatedRequest = useCallback(async () => {
+    // I don't know why, but calling the request function returned by the library's hook
+    // instead of requestForegroundPermissionsAsync() won't pop the permissions dialog
+    console.log('Calling updatedRequest');
+    const response = await requestForegroundPermissionsAsync();
+    setUpdatedPermissions(response);
+    return response;
+  }, [setUpdatedPermissions]);
+
+  // TODO-cknipe: Only do this once the permissions are ... existent?
+  // I suspect if we put updatedPermissions in the dependency list, it'll add multiple listeners?
+  // Maybe we want to keep track such there is only a single listener for each provider
+  useEffect(() => {
+    if (updatedPermissions?.granted) {
+      console.log('UseEffect to add the event listener');
+      const onAppStateChange = (state: AppStateStatus) => {
+        console.log('App state changed to', state);
+        if (state === 'active') {
+          updatedGet();
+        }
+      };
+
+      const appStateListener = AppState.addEventListener(
+        'change',
+        onAppStateChange,
+      );
+
+      return () => {
+        appStateListener.remove();
+      };
+    }
+    // TODO-cknipe: Make sure we want to do this; for now I'm just trying to satisfy the linter so I can commit
+    // disable depcheck because we only want to run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updatedGet]);
+
+  return (
+    <ForegroundPermissionsContext.Provider
+      value={{
+        permissions: updatedPermissions,
+        get: updatedGet,
+        request: updatedRequest,
+      }}>
+      {children}
+    </ForegroundPermissionsContext.Provider>
+  );
+};

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -23,14 +23,12 @@ import {
   useForegroundPermissions,
 } from 'expo-location';
 
-export type ForegroundPermissionsType = [
-  LocationPermissionResponse | null, // permissions
-  (() => Promise<LocationPermissionResponse>) | null, // request
-  (() => Promise<LocationPermissionResponse>) | null, // get
-];
+import {UpdatedPermissionsHookReturnType} from 'terraso-mobile-client/hooks/appPermissionsHooks';
+
+export type ForegroundPermissionsType = UpdatedPermissionsHookReturnType | null;
 
 export const ForegroundPermissionsContext =
-  createContext<ForegroundPermissionsType>([null, null, null]);
+  createContext<ForegroundPermissionsType>(null);
 
 export const ForegroundPermissionsProvider = ({
   children,

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -54,7 +54,6 @@ export const ForegroundPermissionsProvider = ({
   useEffect(() => {
     // Don't start listening until someone asks about location permissions.
     //   updatedPermissions will only be non-null if permissions have been gotten/requested so far
-    //   For this to be fully correct, all components must use the updated hook, rather than useForegroundPermissions
     if (updatedPermissions) {
       // If app switches from background to foreground, update permissions in case they changed
       const onAppStateChange = async (state: AppStateStatus) => {

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -24,18 +24,14 @@ import {
   useForegroundPermissions,
 } from 'expo-location';
 
-export type ForegroundPermissionsType = {
-  permissions: LocationPermissionResponse | null;
-  get: (() => Promise<LocationPermissionResponse>) | null;
-  request: (() => Promise<LocationPermissionResponse>) | null;
-};
+export type ForegroundPermissionsType = [
+  LocationPermissionResponse | null, // permissions
+  (() => Promise<LocationPermissionResponse>) | null, // get
+  (() => Promise<LocationPermissionResponse>) | null, // request
+];
 
 export const ForegroundPermissionsContext =
-  createContext<ForegroundPermissionsType>({
-    permissions: null,
-    get: null,
-    request: null,
-  });
+  createContext<ForegroundPermissionsType>([null, null, null]);
 
 export const ForegroundPermissionsProvider = ({
   children,
@@ -91,11 +87,7 @@ export const ForegroundPermissionsProvider = ({
 
   return (
     <ForegroundPermissionsContext.Provider
-      value={{
-        permissions: updatedPermissions,
-        get: updatedGet,
-        request: updatedRequest,
-      }}>
+      value={[updatedPermissions, updatedGet, updatedRequest]}>
       {children}
     </ForegroundPermissionsContext.Provider>
   );

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -55,7 +55,6 @@ export const ForegroundPermissionsProvider = ({
     // Don't start listening until someone asks about location permissions.
     //   updatedPermissions will only be non-null if permissions have been gotten/requested so far
     //   For this to be fully correct, all components must use the updated hook, rather than useForegroundPermissions
-
     if (updatedPermissions) {
       // If app switches from background to foreground, update permissions in case they changed
       const onAppStateChange = async (state: AppStateStatus) => {

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -40,7 +40,7 @@ export const ForegroundPermissionsProvider = ({
   const [updatedPermissions, setUpdatedPermissions] =
     useState<LocationPermissionResponse | null>(permissions);
   const appStateListener = useRef<NativeEventSubscription | null>(null);
-  console.log('Calling the Provider with permissions -->', updatedPermissions);
+  console.log('Calling the Provider');
 
   const updatedGet = useCallback(async () => {
     console.log('Calling get');
@@ -60,8 +60,8 @@ export const ForegroundPermissionsProvider = ({
   }, [setUpdatedPermissions]);
 
   useEffect(() => {
-    // Start listening when we first care about location permissions. Listener is a singleton.
-    // If we switched from background to foreground, check permissions and update if changed
+    // Don't start listening until someone asks about location permissions. Listener is a singleton.
+    // If we switched from background to foreground, update permissions in case they changed
     if (updatedPermissions && !appStateListener.current) {
       console.log(
         'Gonna add AppState listener (should only happen once? Or once per new permission state??)',

--- a/dev-client/src/context/AppPermissionsContext.tsx
+++ b/dev-client/src/context/AppPermissionsContext.tsx
@@ -72,7 +72,11 @@ export const ForegroundPermissionsProvider = ({
 
   return (
     <ForegroundPermissionsContext.Provider
-      value={[updatedPermissions, updatedRequest, updatedGet]}>
+      value={{
+        permissions: updatedPermissions,
+        request: updatedRequest,
+        get: updatedGet,
+      }}>
       {children}
     </ForegroundPermissionsContext.Provider>
   );

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -17,16 +17,27 @@
 
 import {useContext} from 'react';
 
-import {
-  ForegroundPermissionsContext,
-  ForegroundPermissionsType,
-} from 'terraso-mobile-client/context/AppPermissionsContext';
+import {PermissionResponse} from 'expo-location';
+
+import {ForegroundPermissionsContext} from 'terraso-mobile-client/context/AppPermissionsContext';
 
 // The app permissions hooks supplied by the expo libraries don't actually trigger components to update when app permissions are updated.
 // The permissions object stays stale until the next call to get() or request().
 // This hook wraps the library-supplied hooks and should cause components to update when permissions are updated
+
+// TODO: Ok but how do make them not null because at this point they won't be
+// Otherwise we're trying as closely as we can to match ReturnType<ReturnType<typeof createPermissionHook>
+export type UpdatedPermissionsHookReturnType = [
+  PermissionResponse | null,
+  (() => Promise<PermissionResponse>) | null,
+  (() => Promise<PermissionResponse>) | null,
+];
+export type UpdatedPermissionsHookType = () => UpdatedPermissionsHookReturnType;
+
 export const useUpdatedForegroundPermissions =
-  (): ForegroundPermissionsType => {
-    const context = useContext(ForegroundPermissionsContext);
-    return context;
+  (): UpdatedPermissionsHookReturnType => {
+    const {permissions, get, request} = useContext(
+      ForegroundPermissionsContext,
+    );
+    return [permissions, get, request];
   };

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useCallback, useEffect, useState} from 'react';
+import {AppState, AppStateStatus} from 'react-native';
+
+import {
+  LocationPermissionResponse,
+  requestForegroundPermissionsAsync,
+  useForegroundPermissions,
+} from 'expo-location';
+
+// The app permissions hooks supplied by the expo libraries don't actually trigger components to update when app permissions are updated.
+// The permissions object stays stale until the next call to get() or request().
+// This hook wraps the library-supplied hooks and should cause components to update when permissions are updated
+export const useUpdatedForegroundPermissions = (): [
+  LocationPermissionResponse | null,
+  () => Promise<LocationPermissionResponse>,
+  () => Promise<LocationPermissionResponse>,
+] => {
+  const [permissions, get, _] = useForegroundPermissions();
+  const [updatedPermissions, setUpdatedPermissions] = useState(permissions); // Move this to context?
+  console.log('Calling the hook');
+
+  const updatedGet = useCallback(async () => {
+    const response = await get();
+    setUpdatedPermissions(response);
+    return response;
+    // Or should we not return the response here and below to encourage using updatedPermissions instead?
+  }, [get, setUpdatedPermissions]);
+
+  const updatedRequest = useCallback(async () => {
+    // I don't know why, but calling request() instead of requestForegroundPermissionsAsync() here won't pop the permissions dialog
+    console.log('Calling updatedRequest');
+    const response = await requestForegroundPermissionsAsync();
+    setUpdatedPermissions(response);
+    return response;
+  }, [setUpdatedPermissions]);
+
+  // TODO: Move this to context so we don't have a bunch of listeners running everywhere
+  useEffect(() => {
+    console.log('UseEffect to add the event listener');
+    const onAppStateChange = (state: AppStateStatus) => {
+      if (state === 'active') {
+        updatedGet();
+      }
+    };
+    // Register listeners
+    const appStateListener = AppState.addEventListener(
+      'change',
+      onAppStateChange,
+    );
+
+    return () => {
+      appStateListener.remove();
+    };
+  }, [updatedGet]);
+
+  return [updatedPermissions, updatedGet, updatedRequest];
+};

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -21,8 +21,9 @@ import {PermissionResponse} from 'expo-location';
 
 import {ForegroundPermissionsContext} from 'terraso-mobile-client/context/AppPermissionsContext';
 
-// The app permissions hooks supplied by the expo libraries don't trigger component updates when app permissions
-// are updated. Instead, the permissions object stays stale until the next call to get() or request().
+// As of Sept 2024, the app permissions hooks supplied by the expo libraries don't trigger component updates
+// when app permissions are updated. Instead, the permissions object stays stale until the next call to
+// get() or request().
 // This hook wraps the library-supplied hooks and should cause components to update when permissions are
 // updated in the app or after they are updated outside the app.
 export type UpdatedPermissionsHookReturnType = [
@@ -36,8 +37,8 @@ export const useUpdatedForegroundPermissions = () => {
   const context = useContext(ForegroundPermissionsContext);
 
   const [_, get, request] = context;
+  // Context provider should have populated this on app launch
   if (get === null || request === null) {
-    // Context provider should have populated this on app launch
     throw Error(
       'useUpdatedForegroundPermissions must be used within a ForegroundPermissionsContextProvider',
     );

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -15,60 +15,18 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback, useEffect, useState} from 'react';
-import {AppState, AppStateStatus} from 'react-native';
+import {useContext} from 'react';
 
 import {
-  LocationPermissionResponse,
-  requestForegroundPermissionsAsync,
-  useForegroundPermissions,
-} from 'expo-location';
+  ForegroundPermissionsContext,
+  ForegroundPermissionsType,
+} from 'terraso-mobile-client/context/AppPermissionsContext';
 
 // The app permissions hooks supplied by the expo libraries don't actually trigger components to update when app permissions are updated.
 // The permissions object stays stale until the next call to get() or request().
 // This hook wraps the library-supplied hooks and should cause components to update when permissions are updated
-export const useUpdatedForegroundPermissions = (): [
-  LocationPermissionResponse | null,
-  () => Promise<LocationPermissionResponse>,
-  () => Promise<LocationPermissionResponse>,
-] => {
-  const [permissions, get, _] = useForegroundPermissions();
-  const [updatedPermissions, setUpdatedPermissions] = useState(permissions); // Move this to context?
-  console.log('Calling the hook');
-
-  const updatedGet = useCallback(async () => {
-    const response = await get();
-    setUpdatedPermissions(response);
-    return response;
-    // Or should we not return the response here and below to encourage using updatedPermissions instead?
-  }, [get, setUpdatedPermissions]);
-
-  const updatedRequest = useCallback(async () => {
-    // I don't know why, but calling request() instead of requestForegroundPermissionsAsync() here won't pop the permissions dialog
-    console.log('Calling updatedRequest');
-    const response = await requestForegroundPermissionsAsync();
-    setUpdatedPermissions(response);
-    return response;
-  }, [setUpdatedPermissions]);
-
-  // TODO: Move this to context so we don't have a bunch of listeners running everywhere
-  useEffect(() => {
-    console.log('UseEffect to add the event listener');
-    const onAppStateChange = (state: AppStateStatus) => {
-      if (state === 'active') {
-        updatedGet();
-      }
-    };
-    // Register listeners
-    const appStateListener = AppState.addEventListener(
-      'change',
-      onAppStateChange,
-    );
-
-    return () => {
-      appStateListener.remove();
-    };
-  }, [updatedGet]);
-
-  return [updatedPermissions, updatedGet, updatedRequest];
-};
+export const useUpdatedForegroundPermissions =
+  (): ForegroundPermissionsType => {
+    const context = useContext(ForegroundPermissionsContext);
+    return context;
+  };

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -43,9 +43,8 @@ export type UpdatedPermissionsHookType = () => UpdatedPermissionsHookReturnType;
 export const useUpdatedForegroundPermissions = () => {
   const context = useContext(ForegroundPermissionsContext);
 
-  const [_, request, get] = context;
   // Context provider should have populated this on app launch
-  if (request === null || get === null) {
+  if (context === null) {
     throw Error(
       'useUpdatedForegroundPermissions must be used within a ForegroundPermissionsContextProvider',
     );

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -28,8 +28,8 @@ import {ForegroundPermissionsContext} from 'terraso-mobile-client/context/AppPer
 // updated in the app or after they are updated outside the app.
 export type UpdatedPermissionsHookReturnType = [
   PermissionResponse | null, // permission
-  () => Promise<PermissionResponse>, // get
   () => Promise<PermissionResponse>, // request
+  () => Promise<PermissionResponse>, // get
 ];
 export type UpdatedPermissionsHookType = () => UpdatedPermissionsHookReturnType;
 

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -33,11 +33,12 @@ import {ForegroundPermissionsContext} from 'terraso-mobile-client/context/AppPer
  *   - While the app state is not "active"
  * If you encounter bugs with this hook, check if these assumptions are still correct.
  */
-export type UpdatedPermissionsHookReturnType = [
-  PermissionResponse | null, // permission
-  () => Promise<PermissionResponse>, // request
-  () => Promise<PermissionResponse>, // get
-];
+export type UpdatedPermissionsHookReturnType = {
+  permissions: PermissionResponse | null;
+  request: () => Promise<PermissionResponse>;
+  get: () => Promise<PermissionResponse>;
+};
+
 export type UpdatedPermissionsHookType = () => UpdatedPermissionsHookReturnType;
 
 export const useUpdatedForegroundPermissions = () => {

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -36,7 +36,7 @@ export type UpdatedPermissionsHookType = () => UpdatedPermissionsHookReturnType;
 export const useUpdatedForegroundPermissions = () => {
   const context = useContext(ForegroundPermissionsContext);
 
-  const [_, get, request] = context;
+  const [_, request, get] = context;
   // Context provider should have populated this on app launch
   if (get === null || request === null) {
     throw Error(

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -38,7 +38,7 @@ export const useUpdatedForegroundPermissions = () => {
 
   const [_, request, get] = context;
   // Context provider should have populated this on app launch
-  if (get === null || request === null) {
+  if (request === null || get === null) {
     throw Error(
       'useUpdatedForegroundPermissions must be used within a ForegroundPermissionsContextProvider',
     );

--- a/dev-client/src/hooks/appPermissionsHooks.ts
+++ b/dev-client/src/hooks/appPermissionsHooks.ts
@@ -21,11 +21,18 @@ import {PermissionResponse} from 'expo-location';
 
 import {ForegroundPermissionsContext} from 'terraso-mobile-client/context/AppPermissionsContext';
 
-// As of Sept 2024, the app permissions hooks supplied by the expo libraries don't trigger component updates
-// when app permissions are updated. Instead, the permissions object stays stale until the next call to
-// get() or request().
-// This hook wraps the library-supplied hooks and should cause components to update when permissions are
-// updated in the app or after they are updated outside the app.
+/* As of Sept 2024, the app permissions hooks supplied by the expo libraries don't trigger component updates
+ * when app permissions are updated. Instead, the permissions object stays stale until the next call to
+ * get() or request().
+ * This hook wraps the library-supplied hooks and should cause components to update when permissions are
+ * updated in the app via this hook's request(), or after they are updated outside the app.
+ * For the hook behavior to be fully correct, all components must use the updated hook, not the expo one.
+
+ * Note: There is an assumption here that the only time the permissions will change is: 
+ *   - As a result of calling the context's updated request() method
+ *   - While the app state is not "active"
+ * If you encounter bugs with this hook, check if these assumptions are still correct.
+ */
 export type UpdatedPermissionsHookReturnType = [
   PermissionResponse | null, // permission
   () => Promise<PermissionResponse>, // request

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -49,11 +49,11 @@ export const BottomTabsScreen = memo(() => {
 
     const requestAndAwaitPermissions = async () => {
       console.log('Requesting permissions...');
-      const result = await requestLocationPermissions?.();
+      const result = await requestLocationPermissions();
       console.log('requestPermissions result --> ', result);
     };
 
-    if (!locationPermissions?.granted && requestLocationPermissions) {
+    if (!locationPermissions?.granted) {
       requestAndAwaitPermissions();
     }
 

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -37,20 +37,12 @@ import {useDispatch} from 'terraso-mobile-client/store';
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
-  const [locationPermissions, _, requestLocationPermissions] =
+  const [locationPermissions, requestLocationPermissions, _] =
     useUpdatedForegroundPermissions();
-  console.log('BottomTabs');
 
   useEffect(() => {
-    console.log(
-      'Mounting BottomTabsScreen with permission -->',
-      locationPermissions?.granted,
-    );
-
     const requestAndAwaitPermissions = async () => {
-      console.log('Requesting permissions...');
-      const result = await requestLocationPermissions();
-      console.log('requestPermissions result --> ', result);
+      await requestLocationPermissions();
     };
 
     if (!locationPermissions?.granted) {
@@ -62,10 +54,6 @@ export const BottomTabsScreen = memo(() => {
   }, []);
 
   useEffect(() => {
-    console.log(
-      'Can we set the location/listener? -->',
-      locationPermissions?.status,
-    );
     if (locationPermissions?.granted) {
       locationManager.getLastKnownLocation().then(initCoords => {
         if (initCoords !== null) {

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -37,8 +37,10 @@ import {useDispatch} from 'terraso-mobile-client/store';
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
-  const [locationPermissions, requestLocationPermissions, _] =
-    useUpdatedForegroundPermissions();
+  const {
+    permissions: locationPermissions,
+    request: requestLocationPermissions,
+  } = useUpdatedForegroundPermissions();
 
   useEffect(() => {
     if (!locationPermissions?.granted) {

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -17,15 +17,11 @@
 
 import {memo, useEffect} from 'react';
 
-import {
-  requestForegroundPermissionsAsync,
-  useForegroundPermissions,
-} from 'expo-location';
-
 import {NavigationHelpers} from '@react-navigation/native';
 import {Location, locationManager} from '@rnmapbox/maps';
 
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
+import {useUpdatedForegroundPermissions} from 'terraso-mobile-client/hooks/appPermissionsHooks';
 import {useKeyboardStatus} from 'terraso-mobile-client/hooks/useKeyboardStatus';
 import {updateLocation} from 'terraso-mobile-client/model/map/mapSlice';
 import {
@@ -41,28 +37,32 @@ import {useDispatch} from 'terraso-mobile-client/store';
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
-  const [potentiallyOutdatedLocationPermission, _, requestLocationPermission] =
-    useForegroundPermissions();
+  // const [potentiallyOutdatedLocationPermission, _, requestLocationPermission] =
+  //   useForegroundPermissions();
+  const [locationPermissions, _, requestPermissions] =
+    useUpdatedForegroundPermissions();
+  console.log('BottomTabs');
 
   useEffect(() => {
     console.log(
       'Mounting BottomTabsScreen with permission ',
-      potentiallyOutdatedLocationPermission?.granted,
+      locationPermissions?.granted,
       'and canAskAgain',
-      potentiallyOutdatedLocationPermission?.canAskAgain,
-      'and request is',
-      requestLocationPermission,
+      locationPermissions?.canAskAgain,
     );
 
-    const requestPermissions = async () => {
-      let result = await requestForegroundPermissionsAsync();
-      console.log('Requested permissions; Result:', result);
+    const doRequestPermissions = async () => {
+      // let result = await requestForegroundPermissionsAsync();
+      // let deleteThis = await requestForegroundPermissionsAsync();
+      // console.log('requestForegroundPermissionsAsync result: ', deleteThis);
+      let result = await requestPermissions();
+      console.log('requestPermissions result: ', result);
 
       return result;
     };
 
-    if (!potentiallyOutdatedLocationPermission?.granted) {
-      requestPermissions();
+    if (!locationPermissions?.granted) {
+      doRequestPermissions();
     }
 
     // disable depcheck because we only want to run on mount
@@ -72,9 +72,9 @@ export const BottomTabsScreen = memo(() => {
   useEffect(() => {
     console.log(
       'Permissions useEffect with permission ',
-      potentiallyOutdatedLocationPermission?.granted,
+      locationPermissions?.status,
     );
-    if (potentiallyOutdatedLocationPermission?.granted) {
+    if (locationPermissions?.granted) {
       locationManager.getLastKnownLocation().then(initCoords => {
         if (initCoords !== null) {
           dispatch(
@@ -100,7 +100,7 @@ export const BottomTabsScreen = memo(() => {
 
       return () => locationManager.removeListener(listener);
     }
-  }, [dispatch, potentiallyOutdatedLocationPermission]);
+  }, [dispatch, locationPermissions?.granted, locationPermissions?.status]);
 
   return (
     <BottomTabs.Navigator

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -38,29 +38,29 @@ export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
   const foregroundPermissionsResult = useUpdatedForegroundPermissions();
-  if (foregroundPermissionsResult === null) {
-    // TODO-cknipe: Do something better here
-    throw Error("Somehow foreground permissions haven't yet been initialized");
-  }
-  const {
-    permissions: locationPermissions,
-    request: requestLocationPermissions,
-  } = foregroundPermissionsResult;
-
   console.log('BottomTabs');
+
+  let locationPermissions = foregroundPermissionsResult?.permissions;
+  let requestLocationPermissions = foregroundPermissionsResult?.request;
+
+  if (foregroundPermissionsResult === null) {
+    console.warn("Somehow foreground permissions haven't yet been initialized");
+  } else if (!locationPermissions || !requestLocationPermissions) {
+    console.log("Result isn't null but permissions is");
+  } else {
+    locationPermissions = foregroundPermissionsResult.permissions;
+  }
 
   useEffect(() => {
     console.log(
-      'Mounting BottomTabsScreen with permission ',
+      'Mounting BottomTabsScreen with permission -->',
       locationPermissions?.granted,
-      'and canAskAgain',
-      locationPermissions?.canAskAgain,
     );
 
     const requestAndAwaitPermissions = async () => {
       console.log('Requesting permissions...');
-      const result = await requestLocationPermissions();
-      console.log('requestPermissions result: ', result);
+      const result = await requestLocationPermissions?.();
+      console.log('requestPermissions result --> ', result);
     };
 
     if (!locationPermissions?.granted) {
@@ -73,13 +73,10 @@ export const BottomTabsScreen = memo(() => {
 
   useEffect(() => {
     console.log(
-      'Permissions useEffect with permission ',
+      'Can we set the location/listener? -->',
       locationPermissions?.status,
     );
     if (locationPermissions?.granted) {
-      console.log(
-        'It would make some sense about the locationManager if we see this ever',
-      );
       locationManager.getLastKnownLocation().then(initCoords => {
         if (initCoords !== null) {
           dispatch(
@@ -100,6 +97,7 @@ export const BottomTabsScreen = memo(() => {
           }),
         );
       };
+
       locationManager.setMinDisplacement(USER_DISPLACEMENT_MIN_DISTANCE_M);
       locationManager.addListener(listener);
 

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -17,7 +17,10 @@
 
 import {memo, useEffect} from 'react';
 
-import {useForegroundPermissions} from 'expo-location';
+import {
+  requestForegroundPermissionsAsync,
+  useForegroundPermissions,
+} from 'expo-location';
 
 import {NavigationHelpers} from '@react-navigation/native';
 import {Location, locationManager} from '@rnmapbox/maps';
@@ -42,14 +45,35 @@ export const BottomTabsScreen = memo(() => {
     useForegroundPermissions();
 
   useEffect(() => {
+    console.log(
+      'Mounting BottomTabsScreen with permission ',
+      potentiallyOutdatedLocationPermission?.granted,
+      'and canAskAgain',
+      potentiallyOutdatedLocationPermission?.canAskAgain,
+      'and request is',
+      requestLocationPermission,
+    );
+
+    const requestPermissions = async () => {
+      let result = await requestForegroundPermissionsAsync();
+      console.log('Requested permissions; Result:', result);
+
+      return result;
+    };
+
     if (!potentiallyOutdatedLocationPermission?.granted) {
-      requestLocationPermission();
+      requestPermissions();
     }
+
     // disable depcheck because we only want to run on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
+    console.log(
+      'Permissions useEffect with permission ',
+      potentiallyOutdatedLocationPermission?.granted,
+    );
     if (potentiallyOutdatedLocationPermission?.granted) {
       locationManager.getLastKnownLocation().then(initCoords => {
         if (initCoords !== null) {

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -37,19 +37,9 @@ import {useDispatch} from 'terraso-mobile-client/store';
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
   const {keyboardStatus} = useKeyboardStatus();
-  const foregroundPermissionsResult = useUpdatedForegroundPermissions();
+  const [locationPermissions, _, requestLocationPermissions] =
+    useUpdatedForegroundPermissions();
   console.log('BottomTabs');
-
-  let locationPermissions = foregroundPermissionsResult?.permissions;
-  let requestLocationPermissions = foregroundPermissionsResult?.request;
-
-  if (foregroundPermissionsResult === null) {
-    console.warn("Somehow foreground permissions haven't yet been initialized");
-  } else if (!locationPermissions || !requestLocationPermissions) {
-    console.log("Result isn't null but permissions is");
-  } else {
-    locationPermissions = foregroundPermissionsResult.permissions;
-  }
 
   useEffect(() => {
     console.log(
@@ -63,7 +53,7 @@ export const BottomTabsScreen = memo(() => {
       console.log('requestPermissions result --> ', result);
     };
 
-    if (!locationPermissions?.granted) {
+    if (!locationPermissions?.granted && requestLocationPermissions) {
       requestAndAwaitPermissions();
     }
 

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -41,12 +41,8 @@ export const BottomTabsScreen = memo(() => {
     useUpdatedForegroundPermissions();
 
   useEffect(() => {
-    const requestAndAwaitPermissions = async () => {
-      await requestLocationPermissions();
-    };
-
     if (!locationPermissions?.granted) {
-      requestAndAwaitPermissions();
+      requestLocationPermissions();
     }
 
     // disable depcheck because we only want to run on mount

--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -81,7 +81,7 @@ export const BottomTabsScreen = memo(() => {
 
       return () => locationManager.removeListener(listener);
     }
-  }, [dispatch, locationPermissions?.granted, locationPermissions?.status]);
+  }, [dispatch, locationPermissions?.granted]);
 
   return (
     <BottomTabs.Navigator

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -114,7 +114,6 @@ export const HomeScreen = memo(() => {
       finishedLoading &&
       currentUserCoords !== null
     ) {
-      console.log("...and we're moving!");
       mapRef.current?.moveToPoint(currentUserCoords);
       setFinishedInitialCameraMove(true);
     }

--- a/dev-client/src/screens/HomeScreen/HomeScreen.tsx
+++ b/dev-client/src/screens/HomeScreen/HomeScreen.tsx
@@ -114,6 +114,7 @@ export const HomeScreen = memo(() => {
       finishedLoading &&
       currentUserCoords !== null
     ) {
+      console.log("...and we're moving!");
       mapRef.current?.moveToPoint(currentUserCoords);
       setFinishedInitialCameraMove(true);
     }

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -21,8 +21,6 @@ import {Keyboard} from 'react-native';
 import Autocomplete from 'react-native-autocomplete-input';
 import {Searchbar} from 'react-native-paper';
 
-import {useForegroundPermissions} from 'expo-location';
-
 import {Pressable} from 'native-base';
 
 import {Coords} from 'terraso-client-shared/types';
@@ -39,6 +37,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {MAP_QUERY_MIN_LENGTH} from 'terraso-mobile-client/constants';
 import {useHomeScreenContext} from 'terraso-mobile-client/context/HomeScreenContext';
+import {useUpdatedForegroundPermissions} from 'terraso-mobile-client/hooks/appPermissionsHooks';
 import {useMapSuggestions} from 'terraso-mobile-client/hooks/useMapSuggestions';
 
 type SuggestionProps = {
@@ -163,7 +162,7 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
           <PermissionsRequestWrapper
             requestModalTitle={t('permissions.location_title')}
             requestModalBody={t('permissions.location_body')}
-            permissionHook={useForegroundPermissions}
+            permissionHook={useUpdatedForegroundPermissions}
             permissionedAction={zoomToUser}>
             {onRequest => (
               <IconButton

--- a/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
+++ b/dev-client/src/screens/HomeScreen/components/MapSearch.tsx
@@ -27,7 +27,7 @@ import {Coords} from 'terraso-client-shared/types';
 
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
 import {searchBarStyles} from 'terraso-mobile-client/components/ListFilter';
-import {PermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
+import {UpdatedPermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
 import {
   Box,
   Column,
@@ -159,7 +159,7 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
             type="md"
             onPress={toggleMapLayer}
           />
-          <PermissionsRequestWrapper
+          <UpdatedPermissionsRequestWrapper
             requestModalTitle={t('permissions.location_title')}
             requestModalBody={t('permissions.location_body')}
             permissionHook={useUpdatedForegroundPermissions}
@@ -172,7 +172,7 @@ export default function MapSearch({zoomTo, zoomToUser, toggleMapLayer}: Props) {
                 onPress={onRequest}
               />
             )}
-          </PermissionsRequestWrapper>
+          </UpdatedPermissionsRequestWrapper>
         </Column>
       </Row>
     </Box>


### PR DESCRIPTION
## Description
**Issue**: Various issues with foreground permissions and zooming to the user's location on the map were caused by the expo-location library's `useForegroundPermissions` hook:
1. It only updates permissions on call to get(). 
2. When get() is called, the updated permissions are only local to component using the hook; it does not cause other components to re-render. This means components could be using outdated permissions. 

**Solution**: This PR makes and uses a hook that will update all components when foreground permissions are changed 
within the app (e.g., null to denied, or denied to granted), OR 
outside the app (in app settings there’s “Allow only while using the app”, “Ask every time”, and “Don’t allow”). 

**FYI** I do not recommend looking through the commits; it's chaos in there 😅 

### Related Issues
- Fixes an issue in with my earlier change addressing #1780 
- Is a starting point for #1749 
- (Similar approach to netinfo work in [PR #2135](https://github.com/techmatters/terraso-mobile-client/pull/2135))
