### PR TITLE
fix: use replace() rather than navigate() to avoid issues with back button

### DIFF
--- a/dev-client/src/navigation/navigators/BottomNavigator.tsx
+++ b/dev-client/src/navigation/navigators/BottomNavigator.tsx
@@ -53,7 +53,7 @@ export const BottomNavigator = memo(
 
     useEffect(() => {
       if (!loggedIn) {
-        stackNavigation.navigate('LOGIN');
+        stackNavigation.replace('LOGIN');
       }
     }, [loggedIn, stackNavigation]);
 


### PR DESCRIPTION
## Description

Previously, the user was able to hit 'back' on their device after logging out and access the application screens that are gated behind the login flow. Use a different navigation method when handling logout to prevent this from happening.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1790 

### Verification steps

1) Log in
2) Navigate to some screens
3) Log out
4) Press back
5) Observe that the app closes, rather than going back to previously-seen screens