### PR TITLE
fix: allow projects to be sorted by date

### DIFF
--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -303,7 +303,7 @@ export const SelectFilter = ({
   name,
   options,
   label,
-  nullable = true,
+  nullable = false,
   renderValue,
   ...selectProps
 }: Props) => {

--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -296,12 +296,14 @@ type Props = Omit<
   'value' | 'onValueChange' | 'nullable'
 > & {
   name: string;
+  nullable?: boolean;
 };
 
 export const SelectFilter = ({
   name,
   options,
   label,
+  nullable = true,
   renderValue,
   ...selectProps
 }: Props) => {
@@ -317,7 +319,7 @@ export const SelectFilter = ({
   return (
     <FormControl>
       <Select
-        nullable
+        nullable={nullable}
         value={value ?? null}
         options={options}
         renderValue={renderValue}

--- a/dev-client/src/screens/HomeScreen/components/SiteFilterModal.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteFilterModal.tsx
@@ -79,11 +79,11 @@ export const SiteFilterModal = ({useDistance}: Props) => {
         />
       }>
       <SelectFilter
+        name="sort"
         label={t('site.search.sort.label')}
         options={sortOptions}
-        name="sort"
         renderValue={renderSortOption}
-        unselectedLabel={t('general.filter.no_sort')}
+        nullable={false}
       />
       <SelectFilter
         label={t('site.search.filter_projects')}

--- a/dev-client/src/screens/HomeScreen/components/SiteFilterModal.tsx
+++ b/dev-client/src/screens/HomeScreen/components/SiteFilterModal.tsx
@@ -83,7 +83,6 @@ export const SiteFilterModal = ({useDistance}: Props) => {
         label={t('site.search.sort.label')}
         options={sortOptions}
         renderValue={renderSortOption}
-        nullable={false}
       />
       <SelectFilter
         label={t('site.search.filter_projects')}
@@ -92,6 +91,7 @@ export const SiteFilterModal = ({useDistance}: Props) => {
         renderValue={renderProject}
         name="project"
         unselectedLabel={t('general.filter.no_project')}
+        nullable={true}
       />
       <SelectFilter
         label={t('site.search.filter_role')}
@@ -99,6 +99,7 @@ export const SiteFilterModal = ({useDistance}: Props) => {
         renderValue={renderRole}
         name="role"
         unselectedLabel={t('general.filter.no_role')}
+        nullable={true}
       />
     </ListFilterModal>
   );

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -147,7 +147,7 @@ export const ProjectListScreen = () => {
                 label={t('projects.sort_label')}
                 options={SORT_OPTIONS}
                 renderValue={renderSortOption}
-                unselectedLabel={t('general.filter.no_sort')}
+                nullable={false}
               />
               <SelectFilter
                 name="role"

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -42,7 +42,7 @@ import {useSelector} from 'terraso-mobile-client/store';
 import {selectProjectUserRolesMap} from 'terraso-mobile-client/store/selectors';
 import {equals, searchText} from 'terraso-mobile-client/util';
 
-const SORT_OPTIONS = ['nameAsc', 'nameDesc'];
+const SORT_OPTIONS = ['nameAsc', 'nameDesc', 'lastModAsc', 'lastModDesc'];
 
 export const ProjectListScreen = () => {
   const allProjects = useSelector(state => state.project.projects);
@@ -121,6 +121,14 @@ export const ProjectListScreen = () => {
                   },
                   nameDesc: {
                     key: 'name',
+                    order: 'descending',
+                  },
+                  lastModAsc: {
+                    key: 'updatedAt',
+                    order: 'ascending',
+                  },
+                  lastModDesc: {
+                    key: 'updatedAt',
                     order: 'descending',
                   },
                 },

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -147,7 +147,6 @@ export const ProjectListScreen = () => {
                 label={t('projects.sort_label')}
                 options={SORT_OPTIONS}
                 renderValue={renderSortOption}
-                nullable={false}
               />
               <SelectFilter
                 name="role"
@@ -155,6 +154,7 @@ export const ProjectListScreen = () => {
                 renderValue={renderRole}
                 options={PROJECT_ROLES}
                 unselectedLabel={t('general.filter.no_role')}
+                nullable={true}
               />
             </ListFilterModal>
             <ProjectList />

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -375,8 +375,10 @@
         "search": {
             "placeholder": "Search projects",
             "no_matches": "No projects match the current search and filter options.",
-            "nameAsc": "Sort (A to Z)",
-            "nameDesc": "Sort (Z to A)"
+            "nameAsc": "Name (A to Z)",
+            "nameDesc": "Name (Z to A)",
+            "lastModAsc": "Last Modified (most recent)",
+            "lastModDesc": "Last Modified (least recent)"
         }
     },
     "settings": {

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -371,7 +371,7 @@
             "description_min_length_error": "Project description must be at least {{min}} characters",
             "description_max_length_error": "Project description must be at most {{max}} characters"
         },
-        "sort_label": "Sort projects by:",
+        "sort_label": "Sort projects by",
         "search": {
             "placeholder": "Search projects",
             "no_matches": "No projects match the current search and filter options.",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -371,7 +371,7 @@
             "description_min_length_error": "La descripción del proyecto debe tener un mínimo de {{min}} caracteres",
             "description_max_length_error": "La descripción del proyecto debe tener un máximo de {{max}} caracteres"
         },
-        "sort_label": "Ordenar proyectos por:",
+        "sort_label": "Ordenar proyectos por",
         "search": {
             "placeholder": "Buscar proyectos",
             "nameAsc": "Ordenar (A - Z)",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -374,9 +374,11 @@
         "sort_label": "Ordenar proyectos por",
         "search": {
             "placeholder": "Buscar proyectos",
-            "nameAsc": "Ordenar (A - Z)",
-            "nameDesc": "Ordenar (Z - A)",
-            "no_matches": "Ningún proyecto coincide con las opciones actuales de búsqueda y filtro."
+            "no_matches": "Ningún proyecto coincide con las opciones actuales de búsqueda y filtro.",
+            "nameAsc": "Nombre (A - Z)",
+            "nameDesc": "Nombre (Z - A)",
+            "lastModAsc": "Última modificación (más reciente)",
+            "lastModDesc": "Última modificación (menos reciente)"
         }
     },
     "settings": {


### PR DESCRIPTION
## Description
Allow projects to be sorted by date, not just name.

### Related Issues
Addresses #690.