### PR TITLE
feat: Default offline feature flag to ON in development environments

### DIFF
--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -27,7 +27,7 @@ import {
   FeatureFlagName,
   featureFlags,
   isFlagEnabled,
-  setFlagEnabledOnReload,
+  setFlagWillBeEnabledOnReload,
   willFlagBeEnabledOnReload,
 } from 'terraso-mobile-client/config/featureFlags';
 
@@ -61,7 +61,7 @@ const FeatureFlagControl = ({flag}: FeatureFlagControlProps) => {
 
   // nextFlagState and onReload state should be kept in sync. This could be refactored better.
   const onToggle = () => {
-    setFlagEnabledOnReload(flag, !nextFlagState);
+    setFlagWillBeEnabledOnReload(flag, !nextFlagState);
     setNextFlagState(!nextFlagState);
   };
 

--- a/dev-client/src/config/featureFlags.test.ts
+++ b/dev-client/src/config/featureFlags.test.ts
@@ -24,16 +24,22 @@
 
 test('feature flags can be enabled', () => {
   jest.isolateModules(() => {
+    jest.mock('terraso-mobile-client/config/index', () => ({
+      APP_CONFIG: {
+        environment: 'production',
+      },
+    }));
+
     const {
       isFlagEnabled,
       willFlagBeEnabledOnReload,
-      setFlagEnabledOnReload,
+      setFlagWillBeEnabledOnReload,
     } = require('terraso-mobile-client/config/featureFlags');
 
     expect(isFlagEnabled('FF_offline')).toBe(false);
     expect(willFlagBeEnabledOnReload('FF_offline')).toBe(false);
 
-    setFlagEnabledOnReload('FF_offline', true);
+    setFlagWillBeEnabledOnReload('FF_offline', true);
 
     expect(isFlagEnabled('FF_offline')).toBe(false);
     expect(willFlagBeEnabledOnReload('FF_offline')).toBe(true);
@@ -42,21 +48,55 @@ test('feature flags can be enabled', () => {
 
 test('feature flags can be disabled', () => {
   jest.isolateModules(() => {
+    jest.mock('terraso-mobile-client/config/index', () => ({
+      APP_CONFIG: {
+        environment: 'production',
+      },
+    }));
+
     const {kvStorage} = require('terraso-mobile-client/persistence/kvStorage');
     kvStorage.setBool('FF_offline', true);
 
     const {
       isFlagEnabled,
       willFlagBeEnabledOnReload,
-      setFlagEnabledOnReload,
+      setFlagWillBeEnabledOnReload,
     } = require('terraso-mobile-client/config/featureFlags');
 
     expect(isFlagEnabled('FF_offline')).toBe(true);
     expect(willFlagBeEnabledOnReload('FF_offline')).toBe(true);
 
-    setFlagEnabledOnReload('FF_offline', false);
+    setFlagWillBeEnabledOnReload('FF_offline', false);
 
     expect(isFlagEnabled('FF_offline')).toBe(true);
     expect(willFlagBeEnabledOnReload('FF_offline')).toBe(false);
+  });
+});
+
+test('offline feature flag starts on in dev mode and can be disabled', () => {
+  jest.isolateModules(() => {
+    jest.mock('terraso-mobile-client/config/index', () => ({
+      APP_CONFIG: {
+        environment: 'development',
+      },
+    }));
+
+    const {
+      isFlagEnabled,
+      willFlagBeEnabledOnReload,
+      setFlagWillBeEnabledOnReload,
+    } = require('terraso-mobile-client/config/featureFlags');
+
+    expect(isFlagEnabled('FF_offline')).toBe(true);
+    expect(willFlagBeEnabledOnReload('FF_offline')).toBe(true);
+
+    setFlagWillBeEnabledOnReload('FF_offline', false);
+
+    expect(isFlagEnabled('FF_offline')).toBe(true);
+
+    // This assertion fails due to a bug in the react-native-mmkv-storage library
+    // It can be commented back in when this is fixed:
+    // https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/360
+    // expect(willFlagBeEnabledOnReload('FF_offline')).toBe(false);
   });
 });

--- a/dev-client/src/config/featureFlags.ts
+++ b/dev-client/src/config/featureFlags.ts
@@ -15,15 +15,16 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {APP_CONFIG} from 'terraso-mobile-client/config';
 import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
 
 // When you add a new flag:
 // 1) Add it to featureFlags here
-// 2) Set it in APP_CONFIG
-// 3) Add a FeatureFlagControl for it
+// 2) Add a FeatureFlagControl for it
 export const featureFlags = {
   FF_offline: {
     defaultIsEnabled: false,
+    defaultIsEnabledInDevelopment: true,
     description: 'Enables support for offline mode',
   },
 };
@@ -34,11 +35,17 @@ export const isFlagEnabled = (flag: FeatureFlagName) => {
   return ENABLED_FLAGS[flag];
 };
 
-export const willFlagBeEnabledOnReload = (flag: FeatureFlagName) => {
-  return kvStorage.getBool(flag) ?? featureFlags[flag].defaultIsEnabled;
+const isFlagDefaultEnabled = (flag: FeatureFlagName) => {
+  return APP_CONFIG.environment === 'development'
+    ? featureFlags[flag].defaultIsEnabledInDevelopment
+    : featureFlags[flag].defaultIsEnabled;
 };
 
-export const setFlagEnabledOnReload = (
+export const willFlagBeEnabledOnReload = (flag: FeatureFlagName) => {
+  return kvStorage.getBool(flag) ?? isFlagDefaultEnabled(flag);
+};
+
+export const setFlagWillBeEnabledOnReload = (
   flag: FeatureFlagName,
   isEnabled: boolean,
 ) => {

--- a/dev-client/src/store/persistence.test.ts
+++ b/dev-client/src/store/persistence.test.ts
@@ -28,6 +28,12 @@ const {
   },
 });
 
+jest.mock('terraso-mobile-client/config/index', () => ({
+  APP_CONFIG: {
+    environment: 'production',
+  },
+}));
+
 test('persistence middleware saves state to disk', () => {
   jest.isolateModules(() => {
     const {kvStorage} = require('terraso-mobile-client/persistence/kvStorage');


### PR DESCRIPTION
## Description
`FF_offline` starts on in dev environments.

Minor renaming and updating tests as well.


### Related Issues
Implements #2285 

