### PR TITLE
feat: global redux actions

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -61,7 +61,8 @@
         "react-native-screens": "^3.34.0",
         "react-native-svg": "^15.7.1",
         "react-native-tab-view": "^3.5.2",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#f5d594a",
+        "reduce-reducers": "^1.0.4",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#001f1d5",
         "use-debounce": "^10.0.3",
         "uuid": "^10.0.0",
         "yup": "^1.4.0"
@@ -22069,6 +22070,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/reduce-reducers": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-1.0.4.tgz",
+      "integrity": "sha512-Mb2WZ2bJF597exiqX7owBzrqJ74DHLK3yOQjCyPAaNifRncE8OD0wFIuoMhXxTnHK07+8zZ2SJEKy/qtiyR7vw==",
+      "license": "MIT"
+    },
     "node_modules/redux": {
       "version": "4.2.1",
       "license": "MIT",
@@ -23701,7 +23708,7 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#f5d594a840a8d6841b8090ff256b3001a6ffbbf1",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#001f1d5fa90076f4a887a9cefe1b131a97bd76cc",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,7 +62,7 @@
         "react-native-svg": "^15.7.1",
         "react-native-tab-view": "^3.5.2",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#001f1d5",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#cbab96e",
         "use-debounce": "^10.0.3",
         "uuid": "^10.0.0",
         "yup": "^1.4.0"
@@ -23708,7 +23708,7 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#001f1d5fa90076f4a887a9cefe1b131a97bd76cc",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#cbab96e19c38380fa01e9a8989d181a088f6689d",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -79,7 +79,8 @@
     "react-native-screens": "^3.34.0",
     "react-native-svg": "^15.7.1",
     "react-native-tab-view": "^3.5.2",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#f5d594a",
+    "reduce-reducers": "^1.0.4",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#001f1d5",
     "use-debounce": "^10.0.3",
     "uuid": "^10.0.0",
     "yup": "^1.4.0"

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -80,7 +80,7 @@
     "react-native-svg": "^15.7.1",
     "react-native-tab-view": "^3.5.2",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#001f1d5",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#cbab96e",
     "use-debounce": "^10.0.3",
     "uuid": "^10.0.0",
     "yup": "^1.4.0"

--- a/dev-client/src/components/buttons/SyncButton.tsx
+++ b/dev-client/src/components/buttons/SyncButton.tsx
@@ -21,8 +21,8 @@ import {Button} from 'native-base';
 
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByFlag} from 'terraso-mobile-client/components/RestrictByFlag';
+import {fetchSoilDataForUser} from 'terraso-mobile-client/model/soilId/soilIdGlobalReducer';
 import {selectUnsyncedSiteIds} from 'terraso-mobile-client/model/soilId/soilIdSelectors';
-import {fetchSoilDataForUser} from 'terraso-mobile-client/model/soilId/soilIdSlice';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
 // TODO: I expect this will move or be removed by the time we actually release the offline feature,

--- a/dev-client/src/model/project/projectGlobalReducer.ts
+++ b/dev-client/src/model/project/projectGlobalReducer.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {addUser, updateUsers} from 'terraso-client-shared/account/accountSlice';
+import * as projectService from 'terraso-client-shared/project/projectService';
+import {createAsyncThunk} from 'terraso-client-shared/store/utils';
+
+import {
+  updateMembership,
+  updateProjects,
+} from 'terraso-mobile-client/model/project/projectSlice';
+import {updateSites} from 'terraso-mobile-client/model/site/siteSlice';
+import {updateProjectSettings} from 'terraso-mobile-client/model/soilId/soilIdSlice';
+import {createGlobalReducer} from 'terraso-mobile-client/store/reducers';
+
+export const fetchProject = createAsyncThunk(
+  'project/fetchProject',
+  projectService.fetchProject,
+);
+
+export const addProject = createAsyncThunk(
+  'project/addProject',
+  projectService.addProject,
+);
+
+export const updateProject = createAsyncThunk(
+  'project/updateProject',
+  projectService.updateProject,
+);
+
+export const addUserToProject = createAsyncThunk(
+  'project/addUser',
+  projectService.addUserToProject,
+);
+
+export const projectGlobalReducer = createGlobalReducer(builder => {
+  builder.addCase(addUserToProject.fulfilled, (state, {meta, payload}) => {
+    updateMembership(state.project, {
+      projectId: meta.arg.projectId,
+      membership: payload.membership,
+    });
+    addUser(state.account, payload.user);
+  });
+
+  builder.addCase(fetchProject.fulfilled, (state, {payload}) => {
+    updateProjects(state.project, {[payload.project.id]: payload.project});
+    updateSites(state.site, payload.sites);
+    updateUsers(state.account, payload.users);
+    updateProjectSettings(state.soilId, payload.soilSettings);
+  });
+
+  builder.addCase(addProject.fulfilled, (state, {payload}) => {
+    updateProjects(state.project, {[payload.project.id]: payload.project});
+    updateSites(state.site, payload.sites);
+    updateUsers(state.account, payload.users);
+    updateProjectSettings(state.soilId, payload.soilSettings);
+  });
+
+  builder.addCase(updateProject.fulfilled, (state, {payload}) => {
+    updateProjects(state.project, {[payload.project.id]: payload.project});
+    updateSites(state.site, payload.sites);
+    updateUsers(state.account, payload.users);
+    updateProjectSettings(state.soilId, payload.soilSettings);
+  });
+});

--- a/dev-client/src/model/project/projectSlice.ts
+++ b/dev-client/src/model/project/projectSlice.ts
@@ -17,29 +17,12 @@
 
 import {createSlice, Draft} from '@reduxjs/toolkit';
 
-import {
-  addUser,
-  setUsers,
-  updateUsers,
-} from 'terraso-client-shared/account/accountSlice';
-import {ProjectAddUserMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 import * as projectService from 'terraso-client-shared/project/projectService';
-import {Project} from 'terraso-client-shared/project/projectTypes';
 import {
-  createAsyncThunk,
-  dispatchByKeys,
-} from 'terraso-client-shared/store/utils';
-
-import {
-  setSites,
-  updateSites,
-} from 'terraso-mobile-client/model/site/siteSlice';
-import {updateProjectSettings} from 'terraso-mobile-client/model/soilId/soilIdSlice';
-
-interface SiteKey {
-  projectId: string;
-  siteId: string;
-}
+  Project,
+  ProjectMembership,
+} from 'terraso-client-shared/project/projectTypes';
+import {createAsyncThunk} from 'terraso-client-shared/store/utils';
 
 const initialState = {
   projects: {} as Record<string, Project>,
@@ -112,17 +95,6 @@ const projectSlice = createSlice({
     );
 
     builder.addCase(
-      addUserToProject.fulfilled,
-      (state, {meta, payload: {id: membershipId, userRole, userId}}) => {
-        state.projects[meta.arg.projectId].memberships[membershipId] = {
-          id: membershipId,
-          userRole,
-          userId,
-        };
-      },
-    );
-
-    builder.addCase(
       updateUserRole.fulfilled,
       (state, {payload: {projectId, membershipId, userRole}}) => {
         state.projects[projectId].memberships[membershipId].userRole = userRole;
@@ -138,38 +110,6 @@ const projectSlice = createSlice({
   },
 });
 
-const updateDispatchMap = () => ({
-  project: (project: Project) => updateProjects({[project.id]: project}),
-  sites: updateSites,
-  users: updateUsers,
-  soilSettings: updateProjectSettings,
-});
-
-export const fetchProject = createAsyncThunk(
-  'project/fetchProject',
-  dispatchByKeys(projectService.fetchProject, updateDispatchMap),
-);
-
-export const fetchProjectsForUser = createAsyncThunk(
-  'project/fetchProjectsForUser',
-  dispatchByKeys(projectService.fetchProjectsForUser, () => ({
-    projects: setProjects,
-    sites: setSites,
-    users: setUsers,
-    soilSettings: updateProjectSettings,
-  })),
-);
-
-export const addProject = createAsyncThunk(
-  'project/addProject',
-  dispatchByKeys(projectService.addProject, updateDispatchMap),
-);
-
-export const updateProject = createAsyncThunk(
-  'project/updateProject',
-  dispatchByKeys(projectService.updateProject, updateDispatchMap),
-);
-
 export const deleteProject = createAsyncThunk(
   'project/deleteProject',
   projectService.deleteProject,
@@ -178,15 +118,6 @@ export const deleteProject = createAsyncThunk(
 export const archiveProject = createAsyncThunk(
   'project/archiveProject',
   projectService.archiveProject,
-);
-
-export const addUserToProject = createAsyncThunk(
-  'project/addUser',
-  async (input: ProjectAddUserMutationInput, _, {dispatch}) => {
-    const res = await projectService.addUserToProject(input);
-    dispatch(addUser(res.user));
-    return res.membership;
-  },
 );
 
 export const updateUserRole = createAsyncThunk(

--- a/dev-client/src/model/site/siteGlobalReducer.ts
+++ b/dev-client/src/model/site/siteGlobalReducer.ts
@@ -28,6 +28,7 @@ import {
   updateProjectOfSite,
   updateSites,
 } from 'terraso-mobile-client/model/site/siteSlice';
+import {deleteSoilData} from 'terraso-mobile-client/model/soilId/soilIdSlice';
 import {createGlobalReducer} from 'terraso-mobile-client/store/reducers';
 
 export const addSite = createAsyncThunk('site/addSite', siteService.addSite);
@@ -72,6 +73,7 @@ export const siteGlobalReducer = createGlobalReducer(builder => {
   builder.addCase(deleteSite.fulfilled, (state, {payload}) => {
     removeSiteFromAllProjects(state.project, payload);
     deleteSites(state.site, [payload]);
+    deleteSoilData(state.soilId, [payload]);
   });
 
   builder.addCase(transferSites.fulfilled, (state, {payload}) => {

--- a/dev-client/src/model/site/siteGlobalReducer.ts
+++ b/dev-client/src/model/site/siteGlobalReducer.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import * as siteService from 'terraso-client-shared/site/siteService';
+import {createAsyncThunk} from 'terraso-client-shared/store/utils';
+
+import {
+  addSiteToProject,
+  removeSiteFromAllProjects,
+  removeSiteFromProject,
+} from 'terraso-mobile-client/model/project/projectSlice';
+import {
+  deleteSites,
+  updateProjectOfSite,
+  updateSites,
+} from 'terraso-mobile-client/model/site/siteSlice';
+import {createGlobalReducer} from 'terraso-mobile-client/store/reducers';
+
+export const addSite = createAsyncThunk('site/addSite', siteService.addSite);
+
+export const updateSite = createAsyncThunk(
+  'site/updateSite',
+  siteService.updateSite,
+);
+
+export const deleteSite = createAsyncThunk(
+  'site/deleteSite',
+  siteService.deleteSite,
+);
+
+export const transferSites = createAsyncThunk(
+  'site/transferSites',
+  siteService.transferSitesToProject,
+);
+
+export const siteGlobalReducer = createGlobalReducer(builder => {
+  builder.addCase(addSite.fulfilled, (state, {payload}) => {
+    if (payload.projectId) {
+      addSiteToProject(state.project, {
+        siteId: payload.id,
+        projectId: payload.projectId,
+      });
+    }
+    updateSites(state.site, {[payload.id]: payload});
+  });
+
+  builder.addCase(updateSite.fulfilled, (state, {payload}) => {
+    removeSiteFromAllProjects(state.project, payload.id);
+    if (payload.projectId) {
+      addSiteToProject(state.project, {
+        siteId: payload.id,
+        projectId: payload.projectId,
+      });
+    }
+    updateSites(state.site, {[payload.id]: payload});
+  });
+
+  builder.addCase(deleteSite.fulfilled, (state, {payload}) => {
+    removeSiteFromAllProjects(state.project, payload);
+    deleteSites(state.site, [payload]);
+  });
+
+  builder.addCase(transferSites.fulfilled, (state, {payload}) => {
+    for (const {siteId, oldProjectId} of payload.updated) {
+      if (oldProjectId !== undefined) {
+        removeSiteFromProject(state.project, {
+          siteId,
+          projectId: oldProjectId,
+        });
+      }
+      addSiteToProject(state.project, {siteId, projectId: payload.projectId});
+      updateProjectOfSite(state.site, {siteId, projectId: payload.projectId});
+    }
+  });
+});

--- a/dev-client/src/model/site/siteSlice.ts
+++ b/dev-client/src/model/site/siteSlice.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import {createSlice, Draft} from '@reduxjs/toolkit';
 
 import {
   SiteAddMutationInput,
@@ -35,6 +35,8 @@ import {
 const initialState = {
   sites: {} as Record<string, Site>,
 };
+
+type SiteState = typeof initialState;
 
 export const fetchSite = createAsyncThunk(
   'site/fetchSite',
@@ -114,17 +116,37 @@ export const updateSiteNote = createAsyncThunk(
   siteService.updateSiteNote,
 );
 
+export const setSites = (
+  state: Draft<SiteState>,
+  sites: Record<string, Site>,
+) => {
+  state.sites = sites;
+};
+
+export const updateSites = (
+  state: Draft<SiteState>,
+  sites: Record<string, Site>,
+) => {
+  Object.assign(state.sites, sites);
+};
+
+export const updateProjectOfSite = (
+  state: Draft<SiteState>,
+  args: {siteId: string; projectId: string},
+) => {
+  state.sites[args.siteId].projectId = args.projectId;
+};
+
+export const deleteSites = (state: Draft<SiteState>, siteIds: string[]) => {
+  for (const siteId of siteIds) {
+    delete state.sites[siteId];
+  }
+};
+
 const siteSlice = createSlice({
   name: 'site',
   initialState,
-  reducers: {
-    setSites: (state, {payload}: PayloadAction<Record<string, Site>>) => {
-      state.sites = payload;
-    },
-    updateSites: (state, {payload}: PayloadAction<Record<string, Site>>) => {
-      Object.assign(state.sites, payload.sites);
-    },
-  },
+  reducers: {},
   extraReducers: builder => {
     // TODO: add case to delete site if not found
     builder.addCase(fetchSite.fulfilled, (state, {payload: site}) => {
@@ -186,5 +208,4 @@ const siteSlice = createSlice({
   },
 });
 
-export const {setSites, updateSites} = siteSlice.actions;
 export default siteSlice.reducer;

--- a/dev-client/src/model/site/siteSlice.ts
+++ b/dev-client/src/model/site/siteSlice.ts
@@ -19,13 +19,11 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
 import {
   SiteAddMutationInput,
-  SiteNoteAddMutationInput,
-  SiteNoteUpdateMutationInput,
   SiteTransferMutationInput,
   SiteUpdateMutationInput,
 } from 'terraso-client-shared/graphqlSchema/graphql';
 import * as siteService from 'terraso-client-shared/site/siteService';
-import {Site, SiteNote} from 'terraso-client-shared/site/siteTypes';
+import {Site} from 'terraso-client-shared/site/siteTypes';
 import {createAsyncThunk} from 'terraso-client-shared/store/utils';
 
 import {
@@ -101,29 +99,20 @@ export const transferSites = createAsyncThunk<
   return result;
 });
 
-export const addSiteNote = createAsyncThunk<SiteNote, SiteNoteAddMutationInput>(
+export const addSiteNote = createAsyncThunk(
   'site/addSiteNote',
-  async (siteNote, _) => {
-    let result = await siteService.addSiteNote(siteNote);
-    return siteService.collapseSiteNote(result);
-  },
+  siteService.addSiteNote,
 );
 
-export const deleteSiteNote = createAsyncThunk<SiteNote, SiteNote>(
+export const deleteSiteNote = createAsyncThunk(
   'site/deleteSiteNote',
-  async siteNote => {
-    let result = await siteService.deleteSiteNote(siteNote);
-    return result;
-  },
+  siteService.deleteSiteNote,
 );
 
-export const updateSiteNote = createAsyncThunk<
-  SiteNote,
-  SiteNoteUpdateMutationInput
->('site/updateSiteNote', async (siteNote, _) => {
-  let result = await siteService.updateSiteNote(siteNote);
-  return siteService.collapseSiteNote(result);
-});
+export const updateSiteNote = createAsyncThunk(
+  'site/updateSiteNote',
+  siteService.updateSiteNote,
+);
 
 const siteSlice = createSlice({
   name: 'site',

--- a/dev-client/src/model/soilId/soilIdGlobalReducer.ts
+++ b/dev-client/src/model/soilId/soilIdGlobalReducer.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {setUsers} from 'terraso-client-shared/account/accountSlice';
+import * as soilDataService from 'terraso-client-shared/soilId/soilDataService';
+import {createAsyncThunk} from 'terraso-client-shared/store/utils';
+
+import {setProjects} from 'terraso-mobile-client/model/project/projectSlice';
+import {setSites} from 'terraso-mobile-client/model/site/siteSlice';
+import {
+  setProjectSettings,
+  setSoilData,
+  updateSoilIdStatus,
+} from 'terraso-mobile-client/model/soilId/soilIdSlice';
+import {createGlobalReducer} from 'terraso-mobile-client/store/reducers';
+
+export const fetchSoilDataForUser = createAsyncThunk(
+  'soilId/fetchSoilDataForUser',
+  soilDataService.fetchSoilDataForUser,
+);
+
+export const soilIdGlobalReducer = createGlobalReducer(builder => {
+  builder.addCase(fetchSoilDataForUser.fulfilled, (state, {payload}) => {
+    setProjects(state.project, payload.projects);
+    setSites(state.site, payload.sites);
+    setUsers(state.account, payload.users);
+    setProjectSettings(state.soilId, payload.projectSoilSettings);
+    setSoilData(state.soilId, payload.soilData);
+    updateSoilIdStatus(state.soilId, 'ready');
+  });
+
+  builder.addCase(fetchSoilDataForUser.pending, state => {
+    updateSoilIdStatus(state.soilId, 'loading');
+  });
+
+  builder.addCase(fetchSoilDataForUser.rejected, state => {
+    updateSoilIdStatus(state.soilId, 'error');
+  });
+});

--- a/dev-client/src/model/soilId/soilIdSlice.ts
+++ b/dev-client/src/model/soilId/soilIdSlice.ts
@@ -17,7 +17,6 @@
 
 import {createSlice, Draft, PayloadAction} from '@reduxjs/toolkit';
 
-import {setUsers} from 'terraso-client-shared/account/accountSlice';
 import * as soilDataService from 'terraso-client-shared/soilId/soilDataService';
 import * as soilIdService from 'terraso-client-shared/soilId/soilIdService';
 import {
@@ -29,13 +28,8 @@ import {
   SoilIdEntry,
   SoilIdKey,
 } from 'terraso-client-shared/soilId/soilIdTypes';
-import {
-  createAsyncThunk,
-  dispatchByKeys,
-} from 'terraso-client-shared/store/utils';
+import {createAsyncThunk} from 'terraso-client-shared/store/utils';
 
-import {setProjects} from 'terraso-mobile-client/model/project/projectSlice';
-import {setSites} from 'terraso-mobile-client/model/site/siteSlice';
 import * as soilDataActions from 'terraso-mobile-client/model/soilId/actions/soilDataActions';
 import {
   soilIdEntryDataBased,
@@ -151,18 +145,6 @@ const soilIdSlice = createSlice({
       state.projectSettings[action.meta.arg.projectId] = action.payload;
     });
 
-    builder.addCase(fetchSoilDataForUser.pending, state => {
-      state.status = 'loading';
-    });
-
-    builder.addCase(fetchSoilDataForUser.rejected, state => {
-      state.status = 'error';
-    });
-
-    builder.addCase(fetchSoilDataForUser.fulfilled, state => {
-      state.status = 'ready';
-    });
-
     builder.addCase(fetchLocationBasedSoilMatches.pending, (state, action) => {
       const key = soilIdKey(action.meta.arg);
       state.matches[key] = soilIdEntryForStatus('loading');
@@ -217,17 +199,6 @@ const flushDataBasedMatches = (state: Draft<SoilState>) => {
 };
 
 export const {setSoilIdStatus} = soilIdSlice.actions;
-
-export const fetchSoilDataForUser = createAsyncThunk(
-  'soilId/fetchSoilDataForUser',
-  dispatchByKeys(soilDataService.fetchSoilDataForUser, () => ({
-    projects: setProjects,
-    sites: setSites,
-    projectSoilSettings: setProjectSettings,
-    soilData: setSoilData,
-    users: setUsers,
-  })),
-);
 
 export const updateSoilData = createAsyncThunk(
   'soilId/updateSoilData',

--- a/dev-client/src/model/soilId/soilIdSlice.ts
+++ b/dev-client/src/model/soilId/soilIdSlice.ts
@@ -76,38 +76,40 @@ export const initialState: SoilState = {
   matches: {},
 };
 
+export const setProjectSettings = (
+  state: Draft<SoilState>,
+  settings: Record<string, ProjectSoilSettings>,
+) => {
+  state.projectSettings = settings;
+};
+
+export const updateProjectSettings = (
+  state: Draft<SoilState>,
+  settings: Record<string, ProjectSoilSettings>,
+) => {
+  Object.assign(state.projectSettings, settings);
+};
+
+export const updateSoilIdStatus = (
+  state: Draft<SoilState>,
+  status: LoadingState,
+) => {
+  state.status = status;
+};
+
+export const setSoilData = (
+  state: Draft<SoilState>,
+  soilData: Record<string, SoilData>,
+) => {
+  state.soilData = soilData;
+  state.matches = {};
+  state.soilChanges = {};
+};
+
 const soilIdSlice = createSlice({
   name: 'soilId',
   initialState,
   reducers: {
-    setSoilData: (state, action: PayloadAction<Record<string, SoilData>>) => {
-      state.soilData = action.payload;
-      state.soilChanges = {};
-      state.matches = {};
-    },
-    updateSoilData: (
-      state,
-      action: PayloadAction<Record<string, SoilData>>,
-    ) => {
-      Object.assign(state.soilData, action.payload);
-      markAllChanged(
-        state.soilChanges,
-        Object.keys(action.payload),
-        Date.now(),
-      );
-    },
-    setProjectSettings: (
-      state,
-      action: PayloadAction<Record<string, ProjectSoilSettings>>,
-    ) => {
-      state.projectSettings = action.payload;
-    },
-    updateProjectSettings: (
-      state,
-      action: PayloadAction<Record<string, ProjectSoilSettings>>,
-    ) => {
-      Object.assign(state.projectSettings, action.payload);
-    },
     setSoilIdStatus: (state, action: PayloadAction<LoadingState>) => {
       state.status = action.payload;
     },
@@ -214,12 +216,7 @@ const flushDataBasedMatches = (state: Draft<SoilState>) => {
     .forEach(key => delete state.matches[key as SoilIdKey]);
 };
 
-export const {
-  setProjectSettings,
-  setSoilData,
-  setSoilIdStatus,
-  updateProjectSettings,
-} = soilIdSlice.actions;
+export const {setSoilIdStatus} = soilIdSlice.actions;
 
 export const fetchSoilDataForUser = createAsyncThunk(
   'soilId/fetchSoilDataForUser',

--- a/dev-client/src/model/soilId/soilIdSlice.ts
+++ b/dev-client/src/model/soilId/soilIdSlice.ts
@@ -100,6 +100,13 @@ export const setSoilData = (
   state.soilChanges = {};
 };
 
+export const deleteSoilData = (state: Draft<SoilState>, siteIds: string[]) => {
+  for (const siteId of siteIds) {
+    delete state.soilData[siteId];
+  }
+  flushDataBasedMatches(state);
+};
+
 const soilIdSlice = createSlice({
   name: 'soilId',
   initialState,

--- a/dev-client/src/model/soilId/soilIdSlice.ts
+++ b/dev-client/src/model/soilId/soilIdSlice.ts
@@ -39,7 +39,6 @@ import {
 } from 'terraso-mobile-client/model/soilId/soilIdFunctions';
 import {
   ChangeRecords,
-  markAllChanged,
   markChanged,
 } from 'terraso-mobile-client/model/sync/sync';
 

--- a/dev-client/src/model/soilId/soilIdSlice.ts
+++ b/dev-client/src/model/soilId/soilIdSlice.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import {createSlice, Draft, PayloadAction} from '@reduxjs/toolkit';
 
 import {setUsers} from 'terraso-client-shared/account/accountSlice';
 import * as soilDataService from 'terraso-client-shared/soilId/soilDataService';
@@ -108,10 +108,7 @@ const soilIdSlice = createSlice({
     ) => {
       Object.assign(state.projectSettings, action.payload);
     },
-    setSoilIdStatus: (
-      state,
-      action: PayloadAction<'loading' | 'error' | 'ready'>,
-    ) => {
+    setSoilIdStatus: (state, action: PayloadAction<LoadingState>) => {
       state.status = action.payload;
     },
   },
@@ -207,7 +204,7 @@ const soilIdSlice = createSlice({
   },
 });
 
-const flushDataBasedMatches = (state: SoilState) => {
+const flushDataBasedMatches = (state: Draft<SoilState>) => {
   /*
    * When soil ID input data changes (e.g. samples, intervals), we clear any
    * cached entries that are data-based since they aren't valid anymore.

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -29,7 +29,7 @@ import {
   Column,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {addUserToProject} from 'terraso-mobile-client/model/project/projectSlice';
+import {addUserToProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {TabRoutes} from 'terraso-mobile-client/navigation/constants';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';

--- a/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
+++ b/dev-client/src/screens/CreateProjectScreen/components/CreateProjectForm.tsx
@@ -22,7 +22,7 @@ import {Formik, FormikProps} from 'formik';
 import {Button, KeyboardAvoidingView, ScrollView} from 'native-base';
 
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {addProject} from 'terraso-mobile-client/model/project/projectSlice';
+import {addProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import ProjectForm, {
   ProjectFormValues,

--- a/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
@@ -21,10 +21,8 @@ import {SiteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql'
 import {Coords} from 'terraso-client-shared/types';
 
 import {ScreenCloseButton} from 'terraso-mobile-client/components/buttons/icons/appBar/ScreenCloseButton';
-import {
-  addSite,
-  fetchSitesForProject,
-} from 'terraso-mobile-client/model/site/siteSlice';
+import {addSite} from 'terraso-mobile-client/model/site/siteGlobalReducer';
+import {fetchSitesForProject} from 'terraso-mobile-client/model/site/siteSlice';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {CreateSiteView} from 'terraso-mobile-client/screens/CreateSiteScreen/components/CreateSiteView';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';

--- a/dev-client/src/screens/EditProjectInstructionsScreen.tsx
+++ b/dev-client/src/screens/EditProjectInstructionsScreen.tsx
@@ -28,7 +28,7 @@ import {
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {ScreenFormWrapper} from 'terraso-mobile-client/components/ScreenFormWrapper';
-import {updateProject} from 'terraso-mobile-client/model/project/projectSlice';
+import {updateProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteNoteForm} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteForm';
 import {useDispatch} from 'terraso-mobile-client/store';

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -36,7 +36,7 @@ import {
 import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {StaticMapView} from 'terraso-mobile-client/components/StaticMapView';
 import {renderElevation} from 'terraso-mobile-client/components/util/site';
-import {updateSite} from 'terraso-mobile-client/model/site/siteSlice';
+import {updateSite} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {useSoilIdData} from 'terraso-mobile-client/model/soilId/soilIdHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -36,7 +36,7 @@ import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {PROJECT_MANAGER_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
-import {updateProject} from 'terraso-mobile-client/model/project/projectSlice';
+import {updateProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {
   TabRoutes,
   TabStackParamList,

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -29,10 +29,8 @@ import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/RestrictByRole';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {PROJECT_MANAGER_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
-import {
-  deleteProject,
-  updateProject,
-} from 'terraso-mobile-client/model/project/projectSlice';
+import {updateProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
+import {deleteProject} from 'terraso-mobile-client/model/project/projectSlice';
 import {
   TabRoutes,
   TabStackParamList,

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -51,7 +51,7 @@ import {PROJECT_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/perm
 import {
   deleteSite,
   updateSite,
-} from 'terraso-mobile-client/model/site/siteSlice';
+} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {
   TabRoutes,
   TabStackParamList,

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -48,7 +48,6 @@ import {SiteCard} from 'terraso-mobile-client/components/SiteCard';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
 import {useProjectRoleContext} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {PROJECT_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
-import {removeSiteFromAllProjects} from 'terraso-mobile-client/model/project/projectSlice';
 import {
   deleteSite,
   updateSite,
@@ -75,7 +74,6 @@ const SiteMenu = ({site}: SiteProps) => {
 
   const deleteSiteCallback = async () => {
     await dispatch(deleteSite(site));
-    dispatch(removeSiteFromAllProjects(site.id));
   };
 
   const removeSiteFromProjectCallback = async () => {

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -31,7 +31,7 @@ import {SITE_NAME_MAX_LENGTH} from 'terraso-mobile-client/constants';
 import {
   deleteSite,
   updateSite,
-} from 'terraso-mobile-client/model/site/siteSlice';
+} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -25,7 +25,7 @@ import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useTextSearch} from 'terraso-mobile-client/hooks/useTextSearch';
-import {transferSites} from 'terraso-mobile-client/model/site/siteSlice';
+import {transferSites} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';

--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -37,7 +37,7 @@ import {ListFilterProvider} from 'terraso-mobile-client/components/ListFilter';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
 import {SitesScreenContext} from 'terraso-mobile-client/context/SitesScreenContext';
-import {fetchSoilDataForUser} from 'terraso-mobile-client/model/soilId/soilIdSlice';
+import {fetchSoilDataForUser} from 'terraso-mobile-client/model/soilId/soilIdGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import MapSearch from 'terraso-mobile-client/screens/SitesScreen/components/MapSearch';

--- a/dev-client/src/store/index.ts
+++ b/dev-client/src/store/index.ts
@@ -21,37 +21,24 @@ import {
   TypedUseSelectorHook,
 } from 'react-redux';
 
-import {configureStore, StateFromReducersMapObject} from '@reduxjs/toolkit';
+import {configureStore} from '@reduxjs/toolkit';
+import reduceReducers from 'reduce-reducers';
 
 import {
   DispatchFromStoreFactory,
   handleAbortMiddleware,
-  sharedReducers,
 } from 'terraso-client-shared/store/store';
 
-import {reducer as elevationReducer} from 'terraso-mobile-client/model/elevation/elevationSlice';
-import {reducer as mapReducer} from 'terraso-mobile-client/model/map/mapSlice';
-import {reducer as preferencesReducer} from 'terraso-mobile-client/model/preferences/preferencesSlice';
-import projectReducer from 'terraso-mobile-client/model/project/projectSlice';
-import siteReducer from 'terraso-mobile-client/model/site/siteSlice';
-import soilIdReducer from 'terraso-mobile-client/model/soilId/soilIdSlice';
 import {persistenceMiddleware} from 'terraso-mobile-client/store/persistence';
+import {AppState, rootReducer} from 'terraso-mobile-client/store/reducers';
 
-const reducers = {
-  ...sharedReducers,
-  map: mapReducer,
-  preferences: preferencesReducer,
-  elevation: elevationReducer,
-  site: siteReducer,
-  project: projectReducer,
-  soilId: soilIdReducer,
-};
-
-export type AppState = StateFromReducersMapObject<typeof reducers>;
+export type {AppState} from 'terraso-mobile-client/store/reducers';
 export type AppDispatch = DispatchFromStoreFactory<typeof createStore>;
 
 export const useSelector: TypedUseSelectorHook<AppState> = reduxUseSelector;
 export const useDispatch: () => AppDispatch = reduxUseDispatch;
+
+const globalReducers = [];
 
 export const createStore = (intialState?: Partial<AppState>) =>
   configureStore({
@@ -59,6 +46,6 @@ export const createStore = (intialState?: Partial<AppState>) =>
       getDefaultMiddleware()
         .concat(handleAbortMiddleware)
         .concat(persistenceMiddleware),
-    reducer: reducers,
+    reducer: reduceReducers(rootReducer, ...globalReducers),
     preloadedState: intialState,
   });

--- a/dev-client/src/store/index.ts
+++ b/dev-client/src/store/index.ts
@@ -29,6 +29,9 @@ import {
   handleAbortMiddleware,
 } from 'terraso-client-shared/store/store';
 
+import {projectGlobalReducer} from 'terraso-mobile-client/model/project/projectGlobalReducer';
+import {siteGlobalReducer} from 'terraso-mobile-client/model/site/siteGlobalReducer';
+import {soilIdGlobalReducer} from 'terraso-mobile-client/model/soilId/soilIdGlobalReducer';
 import {persistenceMiddleware} from 'terraso-mobile-client/store/persistence';
 import {AppState, rootReducer} from 'terraso-mobile-client/store/reducers';
 
@@ -38,7 +41,11 @@ export type AppDispatch = DispatchFromStoreFactory<typeof createStore>;
 export const useSelector: TypedUseSelectorHook<AppState> = reduxUseSelector;
 export const useDispatch: () => AppDispatch = reduxUseDispatch;
 
-const globalReducers = [];
+const globalReducers = [
+  soilIdGlobalReducer,
+  siteGlobalReducer,
+  projectGlobalReducer,
+];
 
 export const createStore = (intialState?: Partial<AppState>) =>
   configureStore({

--- a/dev-client/src/store/reducers.ts
+++ b/dev-client/src/store/reducers.ts
@@ -45,6 +45,10 @@ export type AppState = StateFromReducersMapObject<typeof sliceReducers>;
 
 export const rootReducer = combineReducers(sliceReducers);
 
+// createGlobalReducer creates a reducer which is defined separately from
+// any slice, and which doesn't define any new state, but instead acts on
+// the combined state of all of the slices. actions handlers defined in a
+// global reducer can therefore mutate state in multiple slices at once.
 export const createGlobalReducer = (
   builderCallback: (builder: ActionReducerMapBuilder<AppState>) => void,
 ) => createReducer(() => rootReducer(undefined, {type: ''}), builderCallback);

--- a/dev-client/src/store/reducers.ts
+++ b/dev-client/src/store/reducers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ActionReducerMapBuilder,
+  combineReducers,
+  createReducer,
+  StateFromReducersMapObject,
+} from '@reduxjs/toolkit';
+
+import {sharedReducers} from 'terraso-client-shared/store/store';
+
+import {reducer as elevationReducer} from 'terraso-mobile-client/model/elevation/elevationSlice';
+import {reducer as mapReducer} from 'terraso-mobile-client/model/map/mapSlice';
+import {reducer as preferencesReducer} from 'terraso-mobile-client/model/preferences/preferencesSlice';
+import projectReducer from 'terraso-mobile-client/model/project/projectSlice';
+import siteReducer from 'terraso-mobile-client/model/site/siteSlice';
+import soilIdReducer from 'terraso-mobile-client/model/soilId/soilIdSlice';
+
+const sliceReducers = {
+  ...sharedReducers,
+  map: mapReducer,
+  preferences: preferencesReducer,
+  elevation: elevationReducer,
+  site: siteReducer,
+  project: projectReducer,
+  soilId: soilIdReducer,
+};
+
+export type AppState = StateFromReducersMapObject<typeof sliceReducers>;
+
+export const rootReducer = combineReducers(sliceReducers);
+
+export const createGlobalReducer = (
+  builderCallback: (builder: ActionReducerMapBuilder<AppState>) => void,
+) => createReducer(() => rootReducer(undefined, {type: ''}), builderCallback);


### PR DESCRIPTION
## Description
**Please review one commit at a time.** git really mangled the diff, so i rewrote the commit history and it's way cleaner/more comprehensible if you go one at a time and read the descriptions.

Ready for first round of review/discussion. Explanation (will crystallize into docs in the code once consensus is reached):

The only functional difference this PR introduces is that there are no longer actions which modify the state over the course of several dispatches. In order to make that functional change, I had to do a decent chunk of refactoring. I only want to merge this PR if there's consensus that the new shape of our redux code is an improvement on the old shape.

### Changes to codebase
- creates a helper function `createGlobalReducer` which allows you to create a reducer which can act on the entire redux state at once, rather than just a slice at a time
- rewrites many redux actions which existed for the sole purpose of being called by other redux actions (i.e. were not meant as an interface to UI code) as state mutations, examples: 
```
+export const setSoilData = (
+  state: Draft<SoilState>,
+  soilData: Record<string, SoilData>,
+) => {
+  state.soilData = soilData;
+  state.matches = {};
+};
+
 const soilIdSlice = createSlice({
   name: 'soilId',
   initialState,
   reducers: {
-    setSoilData: (state, action: PayloadAction<Record<string, SoilData>>) => {
-      state.soilData = action.payload;
-      state.matches = {};
-    },
```
```
+export const addSiteToProject = (
+  state: Draft<State>,
+  args: {siteId: string; projectId: string},
+) => {
+  state.projects[args.projectId].sites[args.siteId] = true;
+};
 const projectSlice = createSlice({
     ...
-    builder.addCase(
-      addSiteToProject,
-      (state, {payload: {siteId, projectId}}) => {
-        state.projects[projectId].sites[siteId] = true;
-      },
-    );
     ...
 });
-export const addSiteToProject = createAction<SiteKey>(
-  'project/addSiteToProject',
-);
```
- rewrites UI-facing redux actions which previously dispatched actions to different slices to instead be handled by global reducers which use the new state mutations. example:
```
const soilIdSlice = createSlice({
     ...
-    builder.addCase(fetchSoilDataForUser.pending, state => {
-      state.status = 'loading';
-    });
-
-    builder.addCase(fetchSoilDataForUser.rejected, state => {
-      state.status = 'error';
-    });
-
-    builder.addCase(fetchSoilDataForUser.fulfilled, state => {
-      state.status = 'ready';
-    });
     ...
});
...
-export const fetchSoilDataForUser = createAsyncThunk(
-  'soilId/fetchSoilDataForUser',
-  dispatchByKeys(soilDataService.fetchSoilDataForUser, () => ({
-    projects: setProjects,
-    sites: setSites,
-    projectSoilSettings: setProjectSettings,
-    soilData: setSoilData,
-    users: setUsers,
-  })),
-);

+export const fetchSoilDataForUser = createAsyncThunk(
+  'soilId/fetchSoilDataForUser',
+  soilDataService.fetchSoilDataForUser,
+);
+
+export const soilIdGlobalReducer = createGlobalReducer(builder => {
+  builder.addCase(fetchSoilDataForUser.fulfilled, (state, {payload}) => {
+    setProjects(state.project, payload.projects);
+    setSites(state.site, payload.sites);
+    setUsers(state.account, payload.users);
+    setProjectSettings(state.soilId, payload.projectSoilSettings);
+    setSoilData(state.soilId, payload.soilData);
+    updateSoilIdStatus(state.soilId, 'ready');
+  });
+
+  builder.addCase(fetchSoilDataForUser.pending, state => {
+    updateSoilIdStatus(state.soilId, 'loading');
+  });
+
+  builder.addCase(fetchSoilDataForUser.rejected, state => {
+    updateSoilIdStatus(state.soilId, 'error');
+  });
+});
```

### features of the new shape of the code
- IMO this looks closer to how the code would look if we had a DB, which is a pro in my mind. i wanted to stop working before the PR got too big, but it feels like one possible extension of this refactor is to have a separation between a slice's internal code, responsible for monkeying around with the state object, and a set of slice-neutral external-facing actions which call the slices' mutations. as opposed to the previous situation where we do the monkeying and API defining and such all in one big glob
- there's always been friction in the codebase because of the way dispatched actions are not composable/reusable (you can't dispatch within code resolving an action). the mutations are more composable
- this makes heavier (or more explicit/visible use) of redux toolkit's transitive dependency [immer](https://immerjs.github.io/immer/), which allows you to record mutations against an immutable object without actually mutating the underlying object. this is another thing that makes it seem more DB like, an immer instance around the entire app state looks a lot like a transaction :thinking: 
- from what i have seen, this is the less idiomatic redux pattern
  - more idiomatic would be to have code in each slice affected by an action handling that action, but this has such poor locality of behavior that i wanted to try this alternative use (which is still mentioned as an option by the official docs)
  - carissa also pointed out that this would not even be possible without moving the account slice into the mobile client, which i'm not opposed to doing, but feels like more evidence that this approach creates spaghetti interdependencies that we would like to avoid

### Checklist
- [x] Corresponding issue has been opened
- [x] organize the code a better
- [x] post associated client-shared PR
- [ ] write documentation and PR annotations to explain changes
- [ ] create some tests

### Related Issues
Fixes #2162 

### Verification steps
Everything should work the same.
