### PR TITLE
fix: Set maxWidth for chip in UserItem

### DIFF
--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -17,6 +17,7 @@
 
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
+import {StyleSheet, View} from 'react-native';
 
 import {Button} from 'native-base';
 
@@ -88,7 +89,11 @@ export const UserItem = ({
     <MenuItem
       icon={<ProfilePic user={user} />}
       label={userLabel}
-      chip={<RoleChip membership={membership} />}
+      chip={
+        <View style={styles.chipSection}>
+          <RoleChip membership={membership} />
+        </View>
+      }
       onPress={isForCurrentUser ? undefined : memberAction}>
       {userCanLeaveProject && (
         <ConfirmModal
@@ -107,3 +112,9 @@ export const UserItem = ({
     </MenuItem>
   );
 };
+
+const styles = StyleSheet.create({
+  chipSection: {
+    maxWidth: 150,
+  },
+});


### PR DESCRIPTION
## Description
This will affect the list of users for a project. The max width will now cause the text in the chip to wrap, instead of making the chip grow arbitrarily big. This is not a big issue currently, 

### Related Issues
Add-on to #[#1877](https://github.com/techmatters/terraso-mobile-client/issues/1877)

### Images
With long chip text (increased system font size on right):
![Screenshot 2024-10-14 at 1 23 06 PM](https://github.com/user-attachments/assets/d306a2a9-d506-4405-b4a2-0cab4fafbfa1)

In Spanish with large font size:
![Screenshot 2024-10-14 at 1 33 23 PM](https://github.com/user-attachments/assets/5e5eb9b1-feab-49ba-94df-222f61f9bc3d)

This shows the maximum width a pill could be with this change (150px). Note that this is just for reference; in the actual behavior, pills will shrink to just fit the text:
![Screenshot 2024-10-14 at 1 19 27 PM](https://github.com/user-attachments/assets/09d549a3-6d4c-4b95-a402-3882e15c2d10)
