### PR TITLE
build: set LSMinimumSystemVersion to 12.0

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -118,6 +118,7 @@ const defaultConfig: ExpoConfig = {
       'aps-environment': 'development',
     },
     infoPlist: {
+      LSMinimumSystemVersion: '12.0',
       CFBundleAllowMixedLocalizations: true,
       ITSAppUsesNonExemptEncryption: false,
       NSPhotoLibraryUsageDescription:


### PR DESCRIPTION
## Description
set LSMinimumSystemVersion to 12.0. fixes ITMS-90899 warning:
>ITMS-90899: Macs with Apple silicon support issue - The app isn‘t compatible with the provided minimum macOS version of 11.0. It can run on macOS 12.0 or later. Please specify an LSMinimumSystemVersion value of 12.0 or later in a new build, or select a compatible version in App Store Connect. For details, visit: https://developer.apple.com/help/app-store-connect/manage-your-apps-availability/manage-availability-of-iphone-and-ipad-apps-on-macs-with-apple-silicon.
