### PR TITLE
fix: add tracePropogationTargets to Sentry config

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -73,6 +73,7 @@ if (APP_CONFIG.sentryEnabled) {
         maskAllText: maskReplays,
       }),
     ],
+    tracePropagationTargets: [APP_CONFIG.terrasoApiHostname],
     _experiments: {
       replaysSessionSampleRate: 0.1,
       replaysOnErrorSampleRate: 1.0,

--- a/dev-client/src/config/index.ts
+++ b/dev-client/src/config/index.ts
@@ -72,6 +72,7 @@ export const APP_CONFIG = {
   appleClientId: Constants.expoConfig!.ios?.bundleIdentifier!,
   microsoftClientId: ENV_CONFIG.MICROSOFT_OAUTH_CLIENT_ID,
   mapboxAccessToken: ENV_CONFIG.PUBLIC_MAPBOX_TOKEN,
+  terrasoApiHostname: ENV_CONFIG.TERRASO_BACKEND.replace('https://', ''),
   sentryDsn: ENV_CONFIG.SENTRY_DSN,
   sentryEnabled: sentryEnabled === 'true',
   environment: ENV_CONFIG.ENV,


### PR DESCRIPTION
## Description
Add tracePropogationTargets to Sentry config. Should enable coordination with backend traces.

Documentation:
https://docs.sentry.io/platforms/react-native/tracing/instrumentation/automatic-instrumentation/