### PR TITLE
fix: enableCaptureFailedRequests for Sentry

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -77,6 +77,7 @@ if (APP_CONFIG.sentryEnabled) {
         maskAllText: isProduction,
       }),
     ],
+    enableCaptureFailedRequests: true,
     tracePropagationTargets: [APP_CONFIG.terrasoApiHostname],
     enableUserInteractionTracing: true,
     tracesSampleRate: isProduction ? 0.1 : 1.0,


### PR DESCRIPTION
## Description
enableCaptureFailedRequests for Sentry.

Allows us to capture failed HTTP requests.