### PR TITLE
feat: soil change tracking

### DIFF
--- a/dev-client/__tests__/snapshot/SlopeScreen-test.tsx
+++ b/dev-client/__tests__/snapshot/SlopeScreen-test.tsx
@@ -39,6 +39,7 @@ test('renders correctly', () => {
             slopeSteepnessSelect: 'FLAT',
           },
         },
+        soilChanges: {},
         projectSettings: {
           '1': {
             ...fromEntries(

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -90,8 +90,10 @@ LogBox.ignoreLogs([
   'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
 ]);
 
-const persistedReduxState = loadPersistedReduxState();
-patchPersistedReduxState(persistedReduxState);
+let persistedReduxState = loadPersistedReduxState();
+if (persistedReduxState) {
+  persistedReduxState = patchPersistedReduxState(persistedReduxState);
+}
 const store = createStore(persistedReduxState);
 
 function App(): React.JSX.Element {

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -53,7 +53,10 @@ import {SitesScreenContextProvider} from 'terraso-mobile-client/context/SitesScr
 import {RootNavigator} from 'terraso-mobile-client/navigation/navigators/RootNavigator';
 import {Toasts} from 'terraso-mobile-client/screens/Toasts';
 import {createStore} from 'terraso-mobile-client/store';
-import {loadPersistedReduxState} from 'terraso-mobile-client/store/persistence';
+import {
+  loadPersistedReduxState,
+  patchPersistedReduxState,
+} from 'terraso-mobile-client/store/persistence';
 import {paperTheme, theme} from 'terraso-mobile-client/theme';
 
 enableFreeze(true);
@@ -87,7 +90,9 @@ LogBox.ignoreLogs([
   'In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.',
 ]);
 
-const store = createStore(loadPersistedReduxState());
+const persistedReduxState = loadPersistedReduxState();
+patchPersistedReduxState(persistedReduxState);
+const store = createStore(persistedReduxState);
 
 function App(): React.JSX.Element {
   const [headerHeight, setHeaderHeight] = useState(0);

--- a/dev-client/src/components/buttons/SyncButton.tsx
+++ b/dev-client/src/components/buttons/SyncButton.tsx
@@ -19,7 +19,9 @@ import {useCallback} from 'react';
 
 import {Button} from 'native-base';
 
+import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByFlag} from 'terraso-mobile-client/components/RestrictByFlag';
+import {selectUnsyncedSiteIds} from 'terraso-mobile-client/model/soilId/soilIdSelectors';
 import {fetchSoilDataForUser} from 'terraso-mobile-client/model/soilId/soilIdSlice';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 
@@ -31,6 +33,7 @@ export const SyncButton = () => {
   const currentUserID = useSelector(
     state => state.account.currentUser?.data?.id,
   );
+  const unsyncedIds = useSelector(selectUnsyncedSiteIds);
 
   const onSync = useCallback(() => {
     if (currentUserID !== undefined) {
@@ -42,6 +45,7 @@ export const SyncButton = () => {
     // TODO-offline: Create string in en.json if we actually want this button for reals
     <RestrictByFlag flag="FF_offline">
       <Button onPress={onSync}>SYNC: pull</Button>
+      <Text>({unsyncedIds.length} changed sites)</Text>
     </RestrictByFlag>
   );
 };

--- a/dev-client/src/model/soilId/soilIdSelectors.ts
+++ b/dev-client/src/model/soilId/soilIdSelectors.ts
@@ -15,12 +15,26 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {SoilIdKey} from 'terraso-client-shared/soilId/soilIdTypes';
+import {createSelector} from '@reduxjs/toolkit';
+
+import {SoilData, SoilIdKey} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {SoilIdEntry} from 'terraso-mobile-client/model/soilId/soilIdSlice';
+import {
+  ChangeRecords,
+  getUnsyncedRecords,
+} from 'terraso-mobile-client/model/sync/sync';
 import {AppState} from 'terraso-mobile-client/store';
 
 export const selectSoilIdMatches =
   (key: SoilIdKey) =>
   (state: AppState): SoilIdEntry | undefined =>
     state.soilId.matches[key];
+
+export const selectUnsyncedSites = (state: AppState): ChangeRecords<SoilData> =>
+  getUnsyncedRecords(state.soilId.soilChanges);
+
+export const selectUnsyncedSiteIds = createSelector(
+  selectUnsyncedSites,
+  changes => Object.keys(changes),
+);

--- a/dev-client/src/model/soilId/soilIdSlice.ts
+++ b/dev-client/src/model/soilId/soilIdSlice.ts
@@ -46,7 +46,6 @@ import {
 import {
   ChangeRecords,
   markAllChanged,
-  markAllSynced,
   markChanged,
 } from 'terraso-mobile-client/model/sync/sync';
 
@@ -83,9 +82,8 @@ const soilIdSlice = createSlice({
   reducers: {
     setSoilData: (state, action: PayloadAction<Record<string, SoilData>>) => {
       state.soilData = action.payload;
+      state.soilChanges = {};
       state.matches = {};
-
-      markAllSynced(state.soilChanges, action.payload, Date.now());
     },
     updateSoilData: (
       state,

--- a/dev-client/src/model/sync/sync.test.ts
+++ b/dev-client/src/model/sync/sync.test.ts
@@ -164,6 +164,10 @@ describe('sync', () => {
   });
 
   describe('isUnsynced', () => {
+    test('returns synced for empty records', () => {
+      expect(isUnsynced({})).toBeFalsy();
+    });
+
     test('returns synced for records with matching revision ids', () => {
       expect(
         isUnsynced({
@@ -180,10 +184,6 @@ describe('sync', () => {
           lastSyncedRevisionId: 9,
         }),
       ).toBeTruthy();
-    });
-
-    test('returns unsynced for empty records', () => {
-      expect(isUnsynced({})).toBeTruthy();
     });
 
     test('returns unsynced for never-synced records', () => {

--- a/dev-client/src/model/sync/sync.test.ts
+++ b/dev-client/src/model/sync/sync.test.ts
@@ -18,7 +18,6 @@
 import {
   ChangeRecords,
   getChanges,
-  getRevisionId,
   getUnsyncedRecords,
   getUpToDateResults,
   isUnsynced,
@@ -32,21 +31,11 @@ describe('sync', () => {
     jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
   });
 
-  describe('getRevisionId', () => {
-    test('zero for undefined revision', () => {
-      expect(getRevisionId(undefined)).toEqual(0);
-    });
-
-    test('zero for empty revision', () => {
-      expect(getRevisionId({})).toEqual(0);
-    });
-
-    test('value for revision', () => {
-      expect(getRevisionId({revisionId: 123})).toEqual(123);
-    });
-  });
-
   describe('nextRevisionId', () => {
+    test('assumes zero initial value', () => {
+      expect(nextRevisionId(undefined)).toEqual(1);
+    });
+
     test('increments by one', () => {
       expect(nextRevisionId(1)).toEqual(2);
     });
@@ -202,8 +191,11 @@ describe('sync', () => {
 
     test('handles results with no change records', () => {
       expect(
-        getUpToDateResults({}, {a: {revisionId: 0}, b: {revisionId: 1}}),
-      ).toEqual({a: {revisionId: 0}});
+        getUpToDateResults(
+          {},
+          {a: {revisionId: undefined}, b: {revisionId: 1}},
+        ),
+      ).toEqual({a: {revisionId: undefined}});
     });
   });
 });

--- a/dev-client/src/model/sync/sync.test.ts
+++ b/dev-client/src/model/sync/sync.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeRecords,
+  getChanges,
+  getRevisionId,
+  getUnsyncedRecords,
+  isUnsynced,
+  markChanged,
+  markSynced,
+  nextRevisionId,
+} from 'terraso-mobile-client/model/sync/sync';
+
+describe('sync', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+  });
+
+  describe('getRevisionId', () => {
+    test('zero for undefined revision', () => {
+      expect(getRevisionId(undefined)).toEqual(0);
+    });
+
+    test('zero for empty revision', () => {
+      expect(getRevisionId({})).toEqual(0);
+    });
+
+    test('value for revision', () => {
+      expect(getRevisionId({revisionId: 123})).toEqual(123);
+    });
+  });
+
+  describe('nextRevisionId', () => {
+    test('increments by one', () => {
+      expect(nextRevisionId(1)).toEqual(2);
+    });
+  });
+
+  describe('getChanges', () => {
+    test('returns changes for ids', () => {
+      const changes = {a: {revisionId: 1}, b: {revisionId: 2}};
+      expect(getChanges(changes, ['a'])).toEqual({a: {revisionId: 1}});
+    });
+
+    test('returns empty changes when missing', () => {
+      const changes = {};
+      expect(getChanges(changes, ['a'])).toEqual({a: {}});
+    });
+  });
+
+  describe('markChanged', () => {
+    let changes: ChangeRecords<unknown>;
+
+    beforeEach(() => {
+      changes = {};
+    });
+
+    test('initializes change record if not present', () => {
+      markChanged(changes, 'a', Date.now());
+      expect(changes.a).toBeDefined();
+    });
+
+    test('initializes revision id if not present', () => {
+      changes.a = {};
+      markChanged(changes, 'a', Date.now());
+      expect(changes.a.revisionId).toEqual(1);
+    });
+
+    test('increments revision id', () => {
+      changes.a = {revisionId: 122};
+      markChanged(changes, 'a', Date.now());
+      expect(changes.a.revisionId).toEqual(123);
+    });
+
+    test('records modified date', () => {
+      const at = Date.now();
+      markChanged(changes, 'a', at);
+      expect(changes.a.lastModifiedAt).toEqual(at);
+    });
+
+    test('preserves other properties', () => {
+      changes.a = {
+        lastSyncedRevisionId: 100,
+        lastSyncedData: 'data',
+        lastSyncedAt: 10000,
+      };
+      markChanged(changes, 'a', Date.now());
+      expect(changes.a.lastSyncedRevisionId).toEqual(100);
+      expect(changes.a.lastSyncedData).toEqual('data');
+      expect(changes.a.lastSyncedAt).toEqual(10000);
+    });
+  });
+
+  describe('markSynced', () => {
+    let changes: ChangeRecords<unknown>;
+
+    beforeEach(() => {
+      changes = {};
+    });
+
+    test('initializes change record if not present', () => {
+      markSynced(changes, 'a', 'data', Date.now());
+      expect(changes.a).toBeDefined();
+    });
+
+    test('initializes revision id if not present', () => {
+      markSynced(changes, 'a', 'data', Date.now());
+      expect(changes.a.revisionId).toEqual(0);
+      expect(changes.a.lastSyncedRevisionId).toEqual(0);
+    });
+
+    test('records synced revision id', () => {
+      changes.a = {revisionId: 123};
+      markSynced(changes, 'a', 'data', Date.now());
+      expect(changes.a.revisionId).toEqual(123);
+      expect(changes.a.lastSyncedRevisionId).toEqual(123);
+    });
+
+    test('records synced data', () => {
+      markSynced(changes, 'a', 'data', Date.now());
+      expect(changes.a.lastSyncedData).toEqual('data');
+    });
+
+    test('records synced date', () => {
+      const at = Date.now();
+      markSynced(changes, 'a', 'data', at);
+      expect(changes.a.lastSyncedAt).toEqual(at);
+    });
+
+    test('preserves other properties', () => {
+      changes.a = {
+        lastModifiedAt: 10000,
+      };
+      markSynced(changes, 'a', 'data', Date.now());
+      expect(changes.a.lastModifiedAt).toEqual(10000);
+    });
+  });
+
+  describe('getUnsyncedRecords', () => {
+    test('returns un-synced records', () => {
+      const changes = {
+        a: {revisionId: 1, lastSyncedRevisionId: 0},
+        b: {revisionId: 1, lastSyncedRevisionId: 1},
+      };
+      expect(getUnsyncedRecords(changes)).toEqual({
+        a: {revisionId: 1, lastSyncedRevisionId: 0},
+      });
+    });
+  });
+
+  describe('isUnsynced', () => {
+    test('returns synced for records with matching revision ids', () => {
+      expect(
+        isUnsynced({
+          revisionId: 10,
+          lastSyncedRevisionId: 10,
+        }),
+      ).toBeFalsy();
+    });
+
+    test('returns unsynced for records without matching revision ids', () => {
+      expect(
+        isUnsynced({
+          revisionId: 10,
+          lastSyncedRevisionId: 9,
+        }),
+      ).toBeTruthy();
+    });
+
+    test('returns unsynced for empty records', () => {
+      expect(isUnsynced({})).toBeTruthy();
+    });
+
+    test('returns unsynced for never-synced records', () => {
+      expect(
+        isUnsynced({
+          revisionId: 10,
+        }),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/dev-client/src/model/sync/sync.ts
+++ b/dev-client/src/model/sync/sync.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+export type ChangeRecords<T> = Record<string, ChangeRecord<T>>;
+
+export type ChangeTimestamp = number;
+
+export type ChangeRevisionId = number;
+
+export type ChangeRecord<T> = {
+  /**
+   * Unique ID for the current state since the last sync, monotonically increasing for each change.
+   * Can be used to determine whether sync responses reflect stale data.
+   * Cleared for a successful sync.
+   * Default to zero for uninitialized records.
+   */
+  revisionId?: ChangeRevisionId;
+  lastModifiedAt?: ChangeTimestamp;
+
+  lastSyncedRevisionId?: ChangeRevisionId;
+  lastSyncedData?: T;
+  lastSyncedAt?: ChangeTimestamp;
+};
+
+export const INITIAL_REVISION_ID = 0;
+
+export const getRevisionId = <T>(
+  record?: ChangeRecord<T>,
+): ChangeRevisionId => {
+  return record?.revisionId ?? INITIAL_REVISION_ID;
+};
+
+export const nextRevisionId = (
+  revisionId: ChangeRevisionId,
+): ChangeRevisionId => {
+  return revisionId + 1;
+};
+
+export const getChanges = <T>(
+  records: ChangeRecords<T>,
+  ids: string[],
+): ChangeRecords<T> => {
+  return Object.fromEntries(ids.map(id => [id, getChange(records, id)]));
+};
+
+export const getChange = <T>(
+  records: ChangeRecords<T>,
+  id: string,
+): ChangeRecord<T> => {
+  return records[id] ?? {};
+};
+
+export const markAllChanged = <T>(
+  records: ChangeRecords<T>,
+  ids: string[],
+  at: ChangeTimestamp,
+) => {
+  for (const id of ids) {
+    markChanged(records, id, at);
+  }
+};
+
+export const markChanged = <T>(
+  records: ChangeRecords<T>,
+  id: string,
+  at: ChangeTimestamp,
+) => {
+  const prevRecord = getChange(records, id);
+  const prevRevisionId = getRevisionId(prevRecord);
+  const revisionId = nextRevisionId(prevRevisionId);
+  records[id] = {
+    revisionId: revisionId,
+    lastModifiedAt: at,
+
+    lastSyncedRevisionId: prevRecord?.lastSyncedRevisionId,
+    lastSyncedData: prevRecord?.lastSyncedData,
+    lastSyncedAt: prevRecord?.lastSyncedAt,
+  };
+};
+
+export const markAllSynced = <T>(
+  records: ChangeRecords<T>,
+  synced: Record<string, T>,
+  at: ChangeTimestamp,
+) => {
+  for (const [id, data] of Object.entries(synced)) {
+    markSynced(records, id, data, at);
+  }
+};
+
+export const markSynced = <T>(
+  records: ChangeRecords<T>,
+  id: string,
+  data: T,
+  at: ChangeTimestamp,
+) => {
+  const prevRecord = getChange(records, id);
+  const prevRevisionId = getRevisionId(prevRecord);
+  records[id] = {
+    revisionId: prevRevisionId,
+    lastModifiedAt: prevRecord?.lastModifiedAt,
+    lastSyncedAt: at,
+    lastSyncedRevisionId: prevRevisionId,
+    lastSyncedData: data,
+  };
+};
+
+export const getUnsyncedRecords = <T>(
+  records: ChangeRecords<T>,
+): ChangeRecords<T> => {
+  return Object.fromEntries(
+    Object.entries(records).filter(([_, record]) => isUnsynced(record)),
+  );
+};
+
+export const isUnsynced = <T>(record: ChangeRecord<T>): boolean => {
+  if (
+    record.lastSyncedRevisionId === undefined &&
+    record.revisionId === undefined
+  ) {
+    /* Unsynced changes for empty records */
+    return true;
+  } else if (record.lastSyncedRevisionId === undefined) {
+    /* Unsynced changes if the record has changes but no last-synced id */
+    return true;
+  } else {
+    /* Unsynced changes if the record's current revision is not the last-synced one */
+    return getRevisionId(record) !== record.lastSyncedRevisionId;
+  }
+};

--- a/dev-client/src/model/sync/sync.ts
+++ b/dev-client/src/model/sync/sync.ts
@@ -132,8 +132,8 @@ export const isUnsynced = <T>(record: ChangeRecord<T>): boolean => {
     record.lastSyncedRevisionId === undefined &&
     record.revisionId === undefined
   ) {
-    /* Unsynced changes for empty records */
-    return true;
+    /* Never-synced never-changed records have no need for syncing */
+    return false;
   } else if (record.lastSyncedRevisionId === undefined) {
     /* Unsynced changes if the record has changes but no last-synced id */
     return true;

--- a/dev-client/src/store/persistence.test.ts
+++ b/dev-client/src/store/persistence.test.ts
@@ -118,13 +118,13 @@ describe('persistence middleware', () => {
 describe('patchPersistedReduxState', () => {
   test('adds changes if absent', () => {
     const state: any = {soilId: {soilChanges: undefined}};
-    patchPersistedReduxState(state);
-    expect(state.soilId.soilChanges).toEqual({});
+    const result = patchPersistedReduxState(state);
+    expect(result.soilId!.soilChanges).toEqual({});
   });
 
   test('retains changes if present', () => {
     const state: any = {soilId: {soilChanges: {a: {}}}};
-    patchPersistedReduxState(state);
-    expect(state.soilId.soilChanges).toEqual({a: {}});
+    const result = patchPersistedReduxState(state);
+    expect(result.soilId!.soilChanges).toEqual({a: {}});
   });
 });

--- a/dev-client/src/store/persistence.ts
+++ b/dev-client/src/store/persistence.ts
@@ -16,6 +16,7 @@
  */
 
 import {Middleware} from '@reduxjs/toolkit';
+import {merge} from 'lodash';
 
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
@@ -36,5 +37,11 @@ export const loadPersistedReduxState = () => {
     return (
       kvStorage.getMap<Partial<AppState>>(PERSISTED_STATE_KEY) ?? undefined
     );
+  }
+};
+
+export const patchPersistedReduxState = (state?: Partial<AppState>) => {
+  if (state) {
+    merge(state, {soilId: {soilChanges: {}}});
   }
 };

--- a/dev-client/src/store/persistence.ts
+++ b/dev-client/src/store/persistence.ts
@@ -16,7 +16,7 @@
  */
 
 import {Middleware} from '@reduxjs/toolkit';
-import {merge} from 'lodash';
+import {merge} from 'lodash/fp';
 
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {kvStorage} from 'terraso-mobile-client/persistence/kvStorage';
@@ -40,8 +40,8 @@ export const loadPersistedReduxState = () => {
   }
 };
 
-export const patchPersistedReduxState = (state?: Partial<AppState>) => {
-  if (state) {
-    merge(state, {soilId: {soilChanges: {}}});
-  }
+export const patchPersistedReduxState = (
+  state: Partial<AppState>,
+): Partial<AppState> => {
+  return merge(state, {soilId: {soilChanges: {}}});
 };


### PR DESCRIPTION
## Description

Add a data model to track changes relevant to the sync system. Entities have change records containing a revision ID and information about the last change and last successful sync. The Soil ID slice tracks changes for soil data by updating the change records when mutations occur and marking them as synced when user data is loaded from the server. The number of un-synced sites is exposed through the sync button component for diagnostic purposes.

Also adds a basic system for patching data loaded from disk during startup -- ultimately we will want this to work by merging the slices' default initial states with the states saved to mmkv, however circular app dependencies prevented this and so we should revisit it as follow-on work once the main offline feature is done.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #2278

### Verification steps

Make changes to soil data and observe that the number of unsynced sites changes appropriately. Reload the user's data and observe that changes are marked as synced.
