### PR TITLE
feat: sync diff

### DIFF
--- a/dev-client/src/model/soilId/actions/remoteSoilDataActions.ts
+++ b/dev-client/src/model/soilId/actions/remoteSoilDataActions.ts
@@ -24,7 +24,12 @@ import {
 import * as remoteSoilData from 'terraso-client-shared/soilId/soilDataService';
 import {SoilData} from 'terraso-client-shared/soilId/soilIdTypes';
 
-import {getDeletedDepthIntervals} from 'terraso-mobile-client/model/soilId/actions/soilDataDiff';
+import {
+  getChangedDepthDependentData,
+  getChangedDepthIntervals,
+  getChangedSoilDataFields,
+  getDeletedDepthIntervals,
+} from 'terraso-mobile-client/model/soilId/actions/soilDataDiff';
 import {
   getEntityRecord,
   SyncRecord,
@@ -69,13 +74,23 @@ export const unsyncedDataToMutationInputEntry = (
   return {
     siteId,
     soilData: {
-      ...soilData,
-      depthIntervals: soilData.depthIntervals,
-      depthDependentData: soilData.depthDependentData,
+      ...getChangedSoilDataFields(soilData, record.lastSyncedData),
+      depthIntervals: getChangedDepthIntervals(
+        soilData,
+        record.lastSyncedData,
+      ).map(changes => {
+        return {depthInterval: changes.depthInterval, ...changes.changedFields};
+      }),
       deletedDepthIntervals: getDeletedDepthIntervals(
         soilData,
         record.lastSyncedData,
       ),
+      depthDependentData: getChangedDepthDependentData(
+        soilData,
+        record.lastSyncedData,
+      ).map(changes => {
+        return {depthInterval: changes.depthInterval, ...changes.changedFields};
+      }),
     },
   };
 };

--- a/dev-client/src/model/soilId/actions/soilDataActionFields.ts
+++ b/dev-client/src/model/soilId/actions/soilDataActionFields.ts
@@ -51,7 +51,7 @@ export const SOIL_DATA_UPDATE_FIELDS = [
   'waterTableDepthSelect',
 ] as const satisfies (keyof SoilData)[] & (keyof SoilDataUpdateMutationInput)[];
 
-export type UpdateField = (typeof SOIL_DATA_UPDATE_FIELDS)[number];
+export type SoilDataUpdateField = (typeof SOIL_DATA_UPDATE_FIELDS)[number];
 
 /**
  * The soil data depth interval fields which are covered by the depth interval update action.

--- a/dev-client/src/model/soilId/actions/soilDataDiff.test.ts
+++ b/dev-client/src/model/soilId/actions/soilDataDiff.test.ts
@@ -204,6 +204,7 @@ describe('soil data diff', () => {
       prev.depthIntervals = [
         {label: '', depthInterval: {start: 1, end: 2}},
         {label: 'old', depthInterval: {start: 2, end: 3}},
+        {label: 'deleted', depthInterval: {start: 4, end: 5}},
       ];
 
       const changed = getChangedDepthIntervals(curr, prev);

--- a/dev-client/src/model/soilId/actions/soilDataDiff.test.ts
+++ b/dev-client/src/model/soilId/actions/soilDataDiff.test.ts
@@ -15,71 +15,388 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {getDeletedDepthIntervals} from 'terraso-mobile-client/model/soilId/actions/soilDataDiff';
-import {SoilData} from 'terraso-mobile-client/model/soilId/soilIdSlice';
+import {
+  DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS,
+  DEPTH_INTERVAL_UPDATE_FIELDS,
+  SOIL_DATA_UPDATE_FIELDS,
+} from 'terraso-mobile-client/model/soilId/actions/soilDataActionFields';
+import {
+  getChangedDepthDependentData,
+  getChangedDepthDependentFields,
+  getChangedDepthIntervalFields,
+  getChangedDepthIntervals,
+  getChangedSoilDataFields,
+  getDeletedDepthIntervals,
+} from 'terraso-mobile-client/model/soilId/actions/soilDataDiff';
+import {
+  DepthDependentSoilData,
+  SoilData,
+  SoilDataDepthInterval,
+} from 'terraso-mobile-client/model/soilId/soilIdSlice';
 
-describe('getDeletedDepthIntervals', () => {
-  let curr: SoilData;
-  let prev: SoilData;
+describe('soil data diff', () => {
+  describe('getChangedSoilDataFields', () => {
+    const someSoilData = (more?: Partial<SoilData>): SoilData => {
+      return {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
 
-  beforeEach(() => {
-    curr = {
-      depthIntervalPreset: 'CUSTOM',
-      depthIntervals: [],
-      depthDependentData: [],
+        bedrock: 1,
+        crossSlope: 'CONCAVE',
+        downSlope: 'CONCAVE',
+        floodingSelect: 'FREQUENT',
+        grazingSelect: 'CAMEL',
+        landCoverSelect: 'BARREN',
+        limeRequirementsSelect: 'HIGH',
+        slopeAspect: 1,
+        slopeLandscapePosition: 'ALLUVIAL_FAN',
+        slopeSteepnessDegree: 1,
+        slopeSteepnessPercent: 1,
+        slopeSteepnessSelect: 'FLAT',
+        soilDepthSelect: 'BETWEEN_50_AND_70_CM',
+        surfaceCracksSelect: 'DEEP_VERTICAL_CRACKS',
+        surfaceSaltSelect: 'MOST_OF_SURFACE',
+        surfaceStoninessSelect: 'BETWEEN_01_AND_3',
+        waterTableDepthSelect: 'BETWEEN_30_AND_45_CM',
+
+        ...more,
+      };
     };
-    prev = {
-      depthIntervalPreset: 'CUSTOM',
-      depthIntervals: [],
-      depthDependentData: [],
+
+    test('returns all fields when no previous record', () => {
+      let curr = someSoilData();
+
+      const changed = getChangedSoilDataFields(curr, undefined);
+      for (const field of SOIL_DATA_UPDATE_FIELDS) {
+        expect(Object.keys(changed)).toContain(field);
+        expect(changed[field]).toEqual(curr[field]);
+      }
+    });
+
+    test('returns all changed fields', () => {
+      let curr = someSoilData();
+      let prev: SoilData = {
+        depthIntervalPreset: 'BLM',
+        depthDependentData: [],
+        depthIntervals: [],
+      };
+
+      const changed = getChangedSoilDataFields(curr, prev);
+      for (const field of SOIL_DATA_UPDATE_FIELDS) {
+        expect(Object.keys(changed)).toContain(field);
+        expect(changed[field]).toEqual(curr[field]);
+      }
+    });
+
+    test('returns only changed fields', () => {
+      let curr = someSoilData({soilDepthSelect: 'BETWEEN_50_AND_70_CM'});
+      let prev = someSoilData({
+        soilDepthSelect: 'GREATER_THAN_20_LESS_THAN_50_CM',
+      });
+
+      const changed = getChangedSoilDataFields(curr, prev);
+      expect(changed).toEqual({soilDepthSelect: 'BETWEEN_50_AND_70_CM'});
+    });
+  });
+
+  describe('getDeletedDepthIntervals', () => {
+    let curr: SoilData;
+    let prev: SoilData;
+
+    beforeEach(() => {
+      curr = {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
+      };
+      prev = {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
+      };
+    });
+
+    test('returns empty when no previous record', () => {
+      curr.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: '', depthInterval: {start: 2, end: 3}},
+      ];
+
+      const deleted = getDeletedDepthIntervals(curr, undefined);
+      expect(deleted).toEqual([]);
+    });
+
+    test('returns empty when no deleted records', () => {
+      curr.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: '', depthInterval: {start: 2, end: 3}},
+      ];
+      prev.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: '', depthInterval: {start: 2, end: 3}},
+      ];
+
+      const deleted = getDeletedDepthIntervals(curr, undefined);
+      expect(deleted).toEqual([]);
+    });
+
+    test('returns prev depth intervals when deleted', () => {
+      prev.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: '', depthInterval: {start: 2, end: 3}},
+      ];
+
+      const deleted = getDeletedDepthIntervals(curr, prev);
+      expect(deleted).toEqual([
+        {start: 1, end: 2},
+        {start: 2, end: 3},
+      ]);
+    });
+
+    test('returns only deleted prev intervals', () => {
+      curr.depthIntervals = [{label: '', depthInterval: {start: 2, end: 3}}];
+      prev.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: '', depthInterval: {start: 2, end: 3}},
+      ];
+
+      const deleted = getDeletedDepthIntervals(curr, prev);
+      expect(deleted).toEqual([{start: 1, end: 2}]);
+    });
+  });
+
+  describe('getChangedDepthIntervals', () => {
+    let curr: SoilData;
+    let prev: SoilData;
+
+    beforeEach(() => {
+      curr = {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
+      };
+      prev = {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
+      };
+    });
+
+    test('returns all depth intervals when no previous record', () => {
+      curr.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: '', depthInterval: {start: 2, end: 3}},
+      ];
+
+      const changed = getChangedDepthIntervals(curr, undefined);
+      expect(changed).toHaveLength(2);
+      expect(changed[0].depthInterval).toEqual({start: 1, end: 2});
+      expect(changed[1].depthInterval).toEqual({start: 2, end: 3});
+    });
+
+    test('returns only changed intervals', () => {
+      curr.depthIntervals = [
+        {label: 'changed', depthInterval: {start: 1, end: 2}},
+        {label: 'old', depthInterval: {start: 2, end: 3}},
+        {label: 'added', depthInterval: {start: 3, end: 4}},
+      ];
+      prev.depthIntervals = [
+        {label: '', depthInterval: {start: 1, end: 2}},
+        {label: 'old', depthInterval: {start: 2, end: 3}},
+      ];
+
+      const changed = getChangedDepthIntervals(curr, prev);
+      expect(changed).toHaveLength(2);
+      expect(changed[0].depthInterval).toEqual({start: 1, end: 2});
+      expect(changed[1].depthInterval).toEqual({start: 3, end: 4});
+    });
+
+    test('returns changed interval fields', () => {
+      curr.depthIntervals = [
+        {label: 'changed', depthInterval: {start: 1, end: 2}},
+      ];
+      prev.depthIntervals = [{label: '', depthInterval: {start: 1, end: 2}}];
+
+      const changed = getChangedDepthIntervals(curr, prev);
+      expect(changed).toHaveLength(1);
+      expect(changed[0].changedFields).toEqual({label: 'changed'});
+    });
+  });
+
+  describe('getChangedDepthIntervalFields', () => {
+    const someSoilDataDi = (
+      more?: Partial<SoilDataDepthInterval>,
+    ): SoilDataDepthInterval => {
+      return {
+        depthInterval: {start: 1, end: 2},
+        label: 'test',
+
+        carbonatesEnabled: false,
+        electricalConductivityEnabled: false,
+        phEnabled: false,
+        sodiumAdsorptionRatioEnabled: false,
+        soilColorEnabled: false,
+        soilOrganicCarbonMatterEnabled: false,
+        soilStructureEnabled: false,
+        soilTextureEnabled: false,
+
+        ...more,
+      };
     };
+
+    test('returns all fields when no previous record', () => {
+      let curr = someSoilDataDi();
+
+      const changed = getChangedDepthIntervalFields(curr, undefined);
+      for (const field of DEPTH_INTERVAL_UPDATE_FIELDS) {
+        expect(Object.keys(changed)).toContain(field);
+        expect(changed[field]).toEqual(curr[field]);
+      }
+    });
+
+    test('returns all changed fields', () => {
+      let curr = someSoilDataDi();
+      let prev: SoilDataDepthInterval = {
+        depthInterval: {start: 1, end: 2},
+        label: '',
+      };
+
+      const changed = getChangedDepthIntervalFields(curr, prev);
+      for (const field of DEPTH_INTERVAL_UPDATE_FIELDS) {
+        expect(Object.keys(changed)).toContain(field);
+        expect(changed[field]).toEqual(curr[field]);
+      }
+    });
+
+    test('returns only changed fields', () => {
+      let curr = someSoilDataDi({label: 'a'});
+      let prev = someSoilDataDi({label: 'b'});
+
+      const changed = getChangedDepthIntervalFields(curr, prev);
+      expect(changed).toEqual({label: 'a'});
+    });
   });
 
-  test('returns empty when no previous record', () => {
-    curr.depthIntervals = [
-      {label: '', depthInterval: {start: 1, end: 2}},
-      {label: '', depthInterval: {start: 2, end: 3}},
-    ];
+  describe('getChangedDepthDependentData', () => {
+    let curr: SoilData;
+    let prev: SoilData;
 
-    const deleted = getDeletedDepthIntervals(curr, undefined);
-    expect(deleted).toEqual([]);
+    beforeEach(() => {
+      curr = {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
+      };
+      prev = {
+        depthIntervalPreset: 'CUSTOM',
+        depthIntervals: [],
+        depthDependentData: [],
+      };
+    });
+
+    test('returns all data when no previous record', () => {
+      curr.depthDependentData = [
+        {depthInterval: {start: 1, end: 2}},
+        {depthInterval: {start: 2, end: 3}},
+      ];
+
+      const changed = getChangedDepthDependentData(curr, undefined);
+      expect(changed).toHaveLength(2);
+      expect(changed[0].depthInterval).toEqual({start: 1, end: 2});
+      expect(changed[1].depthInterval).toEqual({start: 2, end: 3});
+    });
+
+    test('returns only changed data', () => {
+      curr.depthDependentData = [
+        {ph: 1, depthInterval: {start: 1, end: 2}},
+        {ph: 2, depthInterval: {start: 2, end: 3}},
+        {ph: 3, depthInterval: {start: 3, end: 4}},
+      ];
+      prev.depthDependentData = [
+        {ph: 0, depthInterval: {start: 1, end: 2}},
+        {ph: 2, depthInterval: {start: 2, end: 3}},
+      ];
+
+      const changed = getChangedDepthDependentData(curr, prev);
+      expect(changed).toHaveLength(2);
+      expect(changed[0].depthInterval).toEqual({start: 1, end: 2});
+      expect(changed[1].depthInterval).toEqual({start: 3, end: 4});
+    });
+
+    test('returns changed data fields', () => {
+      curr.depthDependentData = [{ph: 1, depthInterval: {start: 1, end: 2}}];
+      prev.depthDependentData = [{ph: 0, depthInterval: {start: 1, end: 2}}];
+
+      const changed = getChangedDepthDependentData(curr, prev);
+      expect(changed).toHaveLength(1);
+      expect(changed[0].changedFields).toEqual({ph: 1});
+    });
   });
 
-  test('returns empty when no deleted records', () => {
-    curr.depthIntervals = [
-      {label: '', depthInterval: {start: 1, end: 2}},
-      {label: '', depthInterval: {start: 2, end: 3}},
-    ];
-    prev.depthIntervals = [
-      {label: '', depthInterval: {start: 1, end: 2}},
-      {label: '', depthInterval: {start: 2, end: 3}},
-    ];
+  describe('getChangedDepthDependentFields', () => {
+    const someSoilDataDi = (
+      more?: Partial<DepthDependentSoilData>,
+    ): DepthDependentSoilData => {
+      return {
+        depthInterval: {start: 1, end: 2},
 
-    const deleted = getDeletedDepthIntervals(curr, undefined);
-    expect(deleted).toEqual([]);
-  });
+        carbonates: 'NONEFFERVESCENT',
+        clayPercent: 1,
+        colorChroma: 0.1,
+        colorHue: 0.1,
+        colorPhotoLightingCondition: 'EVEN',
+        colorPhotoSoilCondition: 'DRY',
+        colorPhotoUsed: false,
+        colorValue: 0.1,
+        conductivity: 0.1,
+        conductivityTest: 'OTHER',
+        conductivityUnit: 'DECISIEMENS_METER',
+        ph: 0.1,
+        phTestingMethod: 'INDICATOR_SOLUTION',
+        phTestingSolution: 'OTHER',
+        rockFragmentVolume: 'VOLUME_0_1',
+        sodiumAbsorptionRatio: 0.1,
+        soilOrganicCarbon: 0.1,
+        soilOrganicCarbonTesting: 'DRY_COMBUSTION',
+        soilOrganicMatter: 0.1,
+        soilOrganicMatterTesting: 'DRY_COMBUSTION',
+        structure: 'ANGULAR_BLOCKY',
+        texture: 'CLAY',
 
-  test('returns prev depth intervals when deleted', () => {
-    prev.depthIntervals = [
-      {label: '', depthInterval: {start: 1, end: 2}},
-      {label: '', depthInterval: {start: 2, end: 3}},
-    ];
+        ...more,
+      };
+    };
 
-    const deleted = getDeletedDepthIntervals(curr, prev);
-    expect(deleted).toEqual([
-      {start: 1, end: 2},
-      {start: 2, end: 3},
-    ]);
-  });
+    test('returns all fields when no previous record', () => {
+      let curr = someSoilDataDi();
 
-  test('returns only deleted prev intervals', () => {
-    curr.depthIntervals = [{label: '', depthInterval: {start: 2, end: 3}}];
-    prev.depthIntervals = [
-      {label: '', depthInterval: {start: 1, end: 2}},
-      {label: '', depthInterval: {start: 2, end: 3}},
-    ];
+      const changed = getChangedDepthDependentFields(curr, undefined);
+      for (const field of DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS) {
+        expect(Object.keys(changed)).toContain(field);
+        expect(changed[field]).toEqual(curr[field]);
+      }
+    });
 
-    const deleted = getDeletedDepthIntervals(curr, prev);
-    expect(deleted).toEqual([{start: 1, end: 2}]);
+    test('returns all changed fields', () => {
+      let curr = someSoilDataDi();
+      let prev: DepthDependentSoilData = {
+        depthInterval: {start: 1, end: 2},
+      };
+
+      const changed = getChangedDepthDependentFields(curr, prev);
+      for (const field of DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS) {
+        expect(Object.keys(changed)).toContain(field);
+        expect(changed[field]).toEqual(curr[field]);
+      }
+    });
+
+    test('returns only changed fields', () => {
+      let curr = someSoilDataDi({texture: 'CLAY'});
+      let prev = someSoilDataDi({texture: 'CLAY_LOAM'});
+
+      const changed = getChangedDepthDependentFields(curr, prev);
+      expect(changed).toEqual({texture: 'CLAY'});
+    });
   });
 });

--- a/dev-client/src/model/soilId/actions/soilDataDiff.ts
+++ b/dev-client/src/model/soilId/actions/soilDataDiff.ts
@@ -16,11 +16,33 @@
  */
 
 import {
+  DepthDependentSoilData,
   DepthInterval,
   SoilData,
+  SoilDataDepthInterval,
 } from 'terraso-client-shared/soilId/soilIdTypes';
 
+import {
+  DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS,
+  DEPTH_INTERVAL_UPDATE_FIELDS,
+  DepthDependentUpdateField,
+  DepthIntervalUpdateField,
+  SOIL_DATA_UPDATE_FIELDS,
+  SoilDataUpdateField,
+} from 'terraso-mobile-client/model/soilId/actions/soilDataActionFields';
 import {depthIntervalKey} from 'terraso-mobile-client/model/soilId/soilIdFunctions';
+
+export const getChangedSoilDataFields = (
+  curr: SoilData,
+  prev?: SoilData,
+): Record<SoilDataUpdateField, any> => {
+  return diffFields(SOIL_DATA_UPDATE_FIELDS, curr, prev);
+};
+
+export type DepthIntervalChanges<F extends string> = {
+  depthInterval: DepthInterval;
+  changedFields: Record<F, any>;
+};
 
 export const getDeletedDepthIntervals = (
   curr: SoilData,
@@ -37,3 +59,76 @@ export const getDeletedDepthIntervals = (
     .filter(di => !currIntervals.has(depthIntervalKey(di.depthInterval)))
     .map(di => di.depthInterval);
 };
+
+export const getChangedDepthIntervals = (
+  curr: SoilData,
+  prev?: SoilData,
+): DepthIntervalChanges<DepthIntervalUpdateField>[] => {
+  const prevIntervals = indexDepthIntervals(prev?.depthIntervals ?? []);
+  const diffs = curr.depthIntervals.map(di => {
+    return {
+      depthInterval: di.depthInterval,
+      changedFields: getChangedDepthIntervalFields(
+        di,
+        prevIntervals[depthIntervalKey(di.depthInterval)],
+      ),
+    };
+  });
+
+  return diffs.filter(di => Object.keys(di.changedFields).length > 0);
+};
+
+export const getChangedDepthIntervalFields = (
+  curr: SoilDataDepthInterval,
+  prev?: SoilDataDepthInterval,
+): Record<DepthIntervalUpdateField, any> => {
+  return diffFields(DEPTH_INTERVAL_UPDATE_FIELDS, curr, prev);
+};
+
+export const getChangedDepthDependentData = (
+  curr: SoilData,
+  prev?: SoilData,
+): DepthIntervalChanges<DepthDependentUpdateField>[] => {
+  const prevData = indexDepthIntervals(prev?.depthDependentData ?? []);
+  const diffs = curr.depthDependentData.map(dd => {
+    return {
+      depthInterval: dd.depthInterval,
+      changedFields: getChangedDepthDependentFields(
+        dd,
+        prevData[depthIntervalKey(dd.depthInterval)],
+      ),
+    };
+  });
+  return diffs.filter(di => Object.keys(di.changedFields).length > 0);
+};
+
+export const getChangedDepthDependentFields = (
+  curr: DepthDependentSoilData,
+  prev?: DepthDependentSoilData,
+): Record<DepthDependentUpdateField, any> => {
+  return diffFields(DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS, curr, prev);
+};
+
+export const diffFields = <F extends keyof T, T>(
+  fields: F[],
+  curr: T,
+  prev?: T,
+): Record<F, any> => {
+  let changedFields: (keyof T)[];
+  if (!prev) {
+    changedFields = fields;
+  } else {
+    changedFields = fields.filter(field => curr[field] !== prev[field]);
+  }
+
+  return Object.fromEntries(
+    changedFields.map(field => [field, curr[field]]),
+  ) as Record<F, any>;
+};
+
+export const indexDepthIntervals = <T>(
+  items: (T & {depthInterval: DepthInterval})[],
+): Record<string, T> =>
+  Object.fromEntries(
+    items.map(item => [depthIntervalKey(item.depthInterval), item]),
+  );

--- a/dev-client/src/model/soilId/actions/soilDataDiff.ts
+++ b/dev-client/src/model/soilId/actions/soilDataDiff.ts
@@ -25,23 +25,20 @@ import {
 import {
   DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS,
   DEPTH_INTERVAL_UPDATE_FIELDS,
-  DepthDependentUpdateField,
-  DepthIntervalUpdateField,
   SOIL_DATA_UPDATE_FIELDS,
-  SoilDataUpdateField,
 } from 'terraso-mobile-client/model/soilId/actions/soilDataActionFields';
 import {depthIntervalKey} from 'terraso-mobile-client/model/soilId/soilIdFunctions';
 
 export const getChangedSoilDataFields = (
   curr: SoilData,
   prev?: SoilData,
-): Record<SoilDataUpdateField, any> => {
+): Partial<SoilData> => {
   return diffFields(SOIL_DATA_UPDATE_FIELDS, curr, prev);
 };
 
-export type DepthIntervalChanges<F extends string> = {
+export type DepthIntervalChanges<T> = {
   depthInterval: DepthInterval;
-  changedFields: Record<F, any>;
+  changedFields: Partial<T>;
 };
 
 export const getDeletedDepthIntervals = (
@@ -63,7 +60,7 @@ export const getDeletedDepthIntervals = (
 export const getChangedDepthIntervals = (
   curr: SoilData,
   prev?: SoilData,
-): DepthIntervalChanges<DepthIntervalUpdateField>[] => {
+): DepthIntervalChanges<SoilDataDepthInterval>[] => {
   const prevIntervals = indexDepthIntervals(prev?.depthIntervals ?? []);
   const diffs = curr.depthIntervals.map(di => {
     return {
@@ -81,14 +78,14 @@ export const getChangedDepthIntervals = (
 export const getChangedDepthIntervalFields = (
   curr: SoilDataDepthInterval,
   prev?: SoilDataDepthInterval,
-): Record<DepthIntervalUpdateField, any> => {
+): Partial<SoilDataDepthInterval> => {
   return diffFields(DEPTH_INTERVAL_UPDATE_FIELDS, curr, prev);
 };
 
 export const getChangedDepthDependentData = (
   curr: SoilData,
   prev?: SoilData,
-): DepthIntervalChanges<DepthDependentUpdateField>[] => {
+): DepthIntervalChanges<DepthDependentSoilData>[] => {
   const prevData = indexDepthIntervals(prev?.depthDependentData ?? []);
   const diffs = curr.depthDependentData.map(dd => {
     return {
@@ -105,7 +102,7 @@ export const getChangedDepthDependentData = (
 export const getChangedDepthDependentFields = (
   curr: DepthDependentSoilData,
   prev?: DepthDependentSoilData,
-): Record<DepthDependentUpdateField, any> => {
+): Partial<DepthDependentSoilData> => {
   return diffFields(DEPTH_DEPENDENT_SOIL_DATA_UPDATE_FIELDS, curr, prev);
 };
 
@@ -113,7 +110,7 @@ export const diffFields = <F extends keyof T, T>(
   fields: F[],
   curr: T,
   prev?: T,
-): Record<F, any> => {
+): Partial<T> => {
   let changedFields: (keyof T)[];
   if (!prev) {
     changedFields = fields;
@@ -123,7 +120,7 @@ export const diffFields = <F extends keyof T, T>(
 
   return Object.fromEntries(
     changedFields.map(field => [field, curr[field]]),
-  ) as Record<F, any>;
+  ) as Partial<T>;
 };
 
 export const indexDepthIntervals = <T>(


### PR DESCRIPTION
## Description

Enhance the basic `soilDataDiff` system introduced in #2279 to support tracking changes to all fields. The new methods plug into the `remoteSoilDataActions` methods for generating push input and populate the push input with the diff of the last-synced data from the server.

Note: this PR must be reviewed after https://github.com/techmatters/terraso-mobile-client/pull/2413, as it builds on that changeset.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
#2283

### Verification steps

Make changes to individual fields on soil data and verify that the server only receives push input for those fields / depth intervals etc.
