### PR TITLE
fix: Use userLocation from redux state instead of mapbox UserLocation.

### DIFF
--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -78,6 +78,8 @@ export const BottomTabsScreen = memo(() => {
       locationManager.addListener(listener);
 
       return () => locationManager.removeListener(listener);
+    } else {
+      dispatch(updateLocation({coords: null, accuracyM: null}));
     }
   }, [dispatch, locationPermissions?.granted]);
 

--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -98,7 +98,9 @@ export const SitesScreen = memo(() => {
     }
   }, [dispatch, currentUserID]);
 
-  const currentUserCoords = useSelector(state => state.map.userLocation.coords);
+  const currentUserCoords = useSelector(
+    state => state.map.userLocation?.coords,
+  );
 
   const [finishedLoading, setFinishedLoading] = useState(false);
   const [finishedInitialCameraMove, setFinishedInitialCameraMove] =

--- a/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
+++ b/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
@@ -55,6 +55,7 @@ export const CustomUserLocation = ({
   const userLocation = useSelector(state => state.map.userLocation);
 
   const feature = useMemo(() => {
+    // Coords should be null when permissions are not granted
     if (userLocation.coords === null) {
       return null;
     }

--- a/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
@@ -25,7 +25,7 @@ import {
 } from 'react';
 import {Keyboard, PixelRatio, StyleSheet} from 'react-native';
 
-import Mapbox, {Camera, Location} from '@rnmapbox/maps';
+import Mapbox, {Camera} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/src/types/OnPressEvent';
 import {useTheme} from 'native-base';
 
@@ -56,7 +56,6 @@ const MAX_EXPANSION_ZOOM = 15;
 const STARTING_ZOOM_LEVEL = 12;
 
 type Props = {
-  updateUserLocation?: (location: Location) => void;
   calloutState: CalloutState;
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
@@ -70,13 +69,7 @@ export type MapRef = {
 export const SiteMap = memo(
   forwardRef<MapRef, Props>(
     (
-      {
-        updateUserLocation,
-        setCalloutState,
-        calloutState,
-        styleURL,
-        onMapFinishedLoading,
-      },
+      {setCalloutState, calloutState, styleURL, onMapFinishedLoading},
       forwardedRef,
     ): React.JSX.Element => {
       const mapRef = useRef<Mapbox.MapView>(null);
@@ -331,10 +324,7 @@ export const SiteMap = memo(
               style={mapStyles.temporarySiteLayer}
             />
           </Mapbox.ShapeSource>
-          <CustomUserLocation
-            onUserLocationPress={onUserLocationPress}
-            updateUserLocation={updateUserLocation}
-          />
+          <CustomUserLocation onUserLocationPress={onUserLocationPress} />
           <SiteMapCallout
             sites={sites}
             state={calloutState}


### PR DESCRIPTION
## Description
My hand-wavey hypothesis was that maybe the usage of the Mapbox.UserLocation component was doing something different than how we handle userLocation in the rest of the app, or that the component was not re-rendering itself when permissions were granted.

I'm hoping this will cause the component to re-render once location permissions are granted, which makes the user location in redux get updated. But the bug only repros in a real build so will try to test but 🤷 not sure if I will succeed.

Also remove unused prop.

### Related Issues
Hopefully addresses #2227
I suspect it also addresses #1893

