### PR TITLE
build: update react-native-gesture-handler to 2.20.2

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -50,7 +50,7 @@
         "react-i18next": "^15.1.1",
         "react-native": "^0.75.4",
         "react-native-autocomplete-input": "^5.4.0",
-        "react-native-gesture-handler": "^2.20.0",
+        "react-native-gesture-handler": "^2.20.2",
         "react-native-get-random-values": "^1.11.0",
         "react-native-gradle-plugin": "^0.71.19",
         "react-native-mmkv-storage": "^0.10.3",
@@ -72,7 +72,7 @@
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-typescript": "^7.26.0",
         "@babel/runtime": "^7.26.0",
-        "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
+        "@ianvs/prettier-plugin-sort-imports": "^4.4.0",
         "@react-native-community/cli-doctor": "^15.0.1",
         "@react-native/babel-preset": "^0.75.4",
         "@react-native/eslint-config": "^0.75.4",
@@ -21717,9 +21717,10 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.0.tgz",
-      "integrity": "sha512-rFKqgHRfxQ7uSAivk8vxCiW4SB3G0U7jnv7kZD4Y90K5kp6YrU8Q3tWhxe3Rx55BIvSd3mBe9ZWbWVJ0FsSHPA==",
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.2.tgz",
+      "integrity": "sha512-HqzFpFczV4qCnwKlvSAvpzEXisL+Z9fsR08YV5LfJDkzuArMhBu2sOoSPUF/K62PCoAb+ObGlTC83TKHfUd0vg==",
+      "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -68,7 +68,7 @@
     "react-i18next": "^15.1.1",
     "react-native": "^0.75.4",
     "react-native-autocomplete-input": "^5.4.0",
-    "react-native-gesture-handler": "^2.20.0",
+    "react-native-gesture-handler": "^2.20.2",
     "react-native-get-random-values": "^1.11.0",
     "react-native-gradle-plugin": "^0.71.19",
     "react-native-mmkv-storage": "^0.10.3",


### PR DESCRIPTION
## Description
update react-native-gesture-handler to 2.20.2.