### PR TITLE
fix: correct strings for texture class/soil texture

### DIFF
--- a/dev-client/__tests__/snapshot/__snapshots__/SoilScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/SoilScreen-test.tsx.snap
@@ -383,7 +383,7 @@ exports[`renders correctly 1`] = `
                             }
                           }
                         >
-                          Soil Texture
+                          Texture Class
                         </Text>
                         <View
                           style={
@@ -676,7 +676,7 @@ exports[`renders correctly 1`] = `
                             }
                           }
                         >
-                          Soil Texture
+                          Texture Class
                         </Text>
                         <View
                           style={
@@ -969,7 +969,7 @@ exports[`renders correctly 1`] = `
                             }
                           }
                         >
-                          Soil Texture
+                          Texture Class
                         </Text>
                         <View
                           style={
@@ -1262,7 +1262,7 @@ exports[`renders correctly 1`] = `
                             }
                           }
                         >
-                          Soil Texture
+                          Texture Class
                         </Text>
                         <View
                           style={
@@ -1555,7 +1555,7 @@ exports[`renders correctly 1`] = `
                             }
                           }
                         >
-                          Soil Texture
+                          Texture Class
                         </Text>
                         <View
                           style={
@@ -1848,7 +1848,7 @@ exports[`renders correctly 1`] = `
                             }
                           }
                         >
-                          Soil Texture
+                          Texture Class
                         </Text>
                         <View
                           style={

--- a/dev-client/src/screens/SoilScreen/components/SoilDepthSummary.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilDepthSummary.tsx
@@ -42,7 +42,7 @@ type Props = {
 
 export const SoilDepthSummary = ({siteId, interval, requiredInputs}: Props) => {
   const {interval: depthInterval} = interval;
-  const {t} = useTranslation();
+  const {t, i18n} = useTranslation();
 
   const navigation = useNavigation();
 
@@ -84,6 +84,7 @@ export const SoilDepthSummary = ({siteId, interval, requiredInputs}: Props) => {
       }));
   }, [t, navigation, siteId, soilData, depthInterval, project]);
 
+  // Texture Class needs a different label on the Soil tab.
   return (
     <Column space="1px">
       <DepthEditor
@@ -91,14 +92,23 @@ export const SoilDepthSummary = ({siteId, interval, requiredInputs}: Props) => {
         aggregatedInterval={interval}
         requiredInputs={requiredInputs}
       />
-      {methods.map(({method, summary, ...props}) => (
-        <DataInputSummary
-          key={method}
-          label={t(`soil.collection_method.${method}`)}
-          value={summary}
-          {...props}
-        />
-      ))}
+      {methods.map(({method, summary, ...props}) => {
+        const summaryDescriptionExists = i18n.exists(
+          `soil.collection_method_summary.${method}`,
+        );
+        const description = summaryDescriptionExists
+          ? `soil.collection_method_summary.${method}`
+          : `soil.collection_method.${method}`;
+
+        return (
+          <DataInputSummary
+            key={method}
+            label={t(description)}
+            value={summary}
+            {...props}
+          />
+        );
+      })}
       {methods.length === 0 && <Box height="2px" />}
     </Column>
   );

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -664,7 +664,7 @@
                 "ribbon_length_help": "How long is the ribbon?",
                 "grittyness_help": "How does the soil feel?",
                 "result": "Soil Texture: {{result}}",
-                "use_label": "Use This Texture",
+                "use_label": "Use This Texture Class",
                 "ribbon_length": {
                     "SM": "<2.5cm",
                     "MD": "2.5–5cm",

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -563,6 +563,9 @@
             "required_data_title": "Data Collection Requirements"
         },
         "required_method": "{{method}} (required)",
+        "collection_method_summary": {
+            "soilTexture": "Texture Class"
+        },
         "collection_method": {
             "slope": "Slope and Landscape",
             "soilTexture": "Soil Texture",
@@ -644,9 +647,9 @@
             "title": "Soil Texture",
             "label": "Texture Class",
             "info": {
-                "title": "Soil Texture",
-                "description": "Soil is made up of particles of different sizes. Once you remove all large particles (anything over $t(soil.texture.info.description_diameter,{\"context\":\"{{units}}\"}) in diameter), what is left is a mixture of sand, silt, and clay.\n\n<bold>Soil texture</bold> is determined by the percent of sand, silt, and clay in the soil. Changes in this ratio can have large impacts on the potential of the soil.\n\nSoil texture determines many important characteristics of your land, including:",
-                "description_end": "Knowing the soil texture also helps you more accurately identify your soil.",
+                "title": "Texture Class",
+                "description": "Soil is made up of particles of different sizes. Once you remove all rock fragments (anything over $t(soil.texture.info.description_diameter,{\"context\":\"{{units}}\"}) in diameter), what is left is a mixture of sand, silt, and clay.\n\n<bold>Texture class</bold> is determined by the percent of sand, silt, and clay in the soil. Changes in this ratio can have large impacts on the potential of the soil.\n\nSoil texture determines many important characteristics of your land, including:",
+                "description_end": "Knowing the soil texture helps you more accurately identify your soil.",
                 "description_diameter_METRIC": "2mm",
                 "description_diameter_ENGLISH": "1/16”",
                 "point1": "How much water the soil can hold",
@@ -696,7 +699,7 @@
                 "grittyness_details_2": "<0>Smooth</0> means that the wetted soil is slippery or soapy in feel.",
                 "grittyness_details_3": "<0>Not gritty or smooth</0> means that neither of those two textures dominates. You may still feel some sand grains or some soapiness, but the feel of the soil is not predominantly one or the other."
             },
-            "guide_intro": "Don’t know your soil texture? Use the step-by-step guide.",
+            "guide_intro": "Don’t know the texture class? Use the step-by-step guide.",
             "use_guide_label": "Use Guide",
             "clay_title": "Percent Clay",
             "clay_label": "Percent clay",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -715,9 +715,12 @@
             "required_data_title": "Requisitos para la recogida de datos"
         },
         "required_method": "{{method}} (obligatorio)",
+        "collection_method_summary": {
+            "soilTexture": "Clase de textura"
+        },
         "collection_method": {
             "slope": "Incluye la inclinación, forma, aspecto y posición del pendiente del suelo.",
-            "soilTexture": "Incluye clase de textura, porcentaje de arcilla y fragmentos de roca",
+            "soilTexture": "Textura del suelo",
             "rockFragmentVolume": "Fragmento de roca",
             "soilColor": "Color de suelo",
             "verticalCracking": "Grietas del suelo",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -552,7 +552,7 @@
                 "ribbon_help": "¿Se puede formar una cinta con el suelo?",
                 "ribbon_length_help": "¿Cuánto mide la cinta de largo?",
                 "grittyness_help": "¿Cómo se siente el suelo?",
-                "use_label": "Usar esta textura",
+                "use_label": "Usar esta clase de textura",
                 "ribbon_length": {
                     "SM": "<2.5cm",
                     "MD": "2.5–5cm",


### PR DESCRIPTION
## Description
Correct strings for texture class/soil texture. Courtney and I went over the screens and text together. What's in the build is now correct (and supersedes any discrepencies in #2225 or Figma).

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/2225.