### PR TITLE
feat: change site depth preset button from `IconButton` to `TextButton`

### DIFF
--- a/dev-client/src/components/buttons/TextButton.tsx
+++ b/dev-client/src/components/buttons/TextButton.tsx
@@ -28,7 +28,7 @@ export type TextButtonType = 'default' | 'error';
 export type TextButtonProps = {
   label: string;
   type?: TextButtonType;
-  role: AccessibilityProps['role'];
+  role?: AccessibilityProps['role'];
   leftIcon?: IconName;
   rightIcon?: IconName;
   disabled?: boolean;
@@ -38,7 +38,7 @@ export type TextButtonProps = {
 export const TextButton = ({
   label,
   type = 'default',
-  role,
+  role = 'button',
   leftIcon,
   rightIcon,
   disabled,

--- a/dev-client/src/screens/SoilScreen/SoilScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SoilScreen.tsx
@@ -23,7 +23,7 @@ import {Button, ScrollView} from 'native-base';
 import {SoilIdSoilDataDepthIntervalPresetChoices} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {AddDepthModalBody} from 'terraso-mobile-client/components/AddDepthModal';
-import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
+import {TextButton} from 'terraso-mobile-client/components/buttons/TextButton';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Modal} from 'terraso-mobile-client/components/modals/Modal';
@@ -98,7 +98,11 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
           <InfoSheet
             heading={<TranslatedHeading i18nKey="soil.soil_preset.header" />}
             trigger={onOpen => (
-              <IconButton type="md" name="tune" onPress={onOpen} />
+              <TextButton
+                label={t('soil.soil_preset.label')}
+                rightIcon="expand-more"
+                onPress={onOpen}
+              />
             )}>
             <EditSiteSoilDepthPreset
               selected={soilData.depthIntervalPreset}


### PR DESCRIPTION
## Description
Changes the `SoilScreen`'s depth interval preset modal trigger from an `IconButton` to `TextButton`.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Related to #2069

### Verification steps
Button should no longer be icon button.