### PR TITLE
feat: disable user settings buttons when offline

### DIFF
--- a/dev-client/src/hooks/connectivityHooks.ts
+++ b/dev-client/src/hooks/connectivityHooks.ts
@@ -22,5 +22,9 @@ import {ConnectivityContext} from 'terraso-mobile-client/context/connectivity/Co
 export const useIsOffline = () => {
   const context = useContext(ConnectivityContext);
 
+  // if we aren't sure yet whether we are on or offline, conservatively assume we are offline
+  if (context.isOffline === null) {
+    return true;
+  }
   return context.isOffline;
 };

--- a/dev-client/src/screens/UserSettingsScreen/components/menu/DeleteAccountItem.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/menu/DeleteAccountItem.tsx
@@ -32,7 +32,7 @@ export function DeleteAccountItem() {
     [navigation],
   );
 
-  const isDisabled = useIsOffline() === true || isPending;
+  const isDisabled = useIsOffline() || isPending;
 
   return (
     <MenuItem

--- a/dev-client/src/screens/UserSettingsScreen/components/menu/DeleteAccountItem.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/menu/DeleteAccountItem.tsx
@@ -19,6 +19,7 @@ import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {MenuItem} from 'terraso-mobile-client/components/menus/MenuItem';
+import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 import {useUserDeletionRequests} from 'terraso-mobile-client/hooks/userDeletionRequest';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 
@@ -31,13 +32,15 @@ export function DeleteAccountItem() {
     [navigation],
   );
 
+  const isDisabled = useIsOffline() === true || isPending;
+
   return (
     <MenuItem
       variant="destructive"
       uppercase
       icon="delete"
       label={t('settings.delete_account')}
-      disabled={isPending}
+      disabled={isDisabled}
       subLabel={isPending ? t('settings.delete_account_pending') : undefined}
       onPress={onDeleteAccount}
     />

--- a/dev-client/src/screens/UserSettingsScreen/components/menu/SignOutItem.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/menu/SignOutItem.tsx
@@ -24,7 +24,7 @@ import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 export function SignOutItem() {
   const {t} = useTranslation();
 
-  const isDisabled = useIsOffline() === true;
+  const isDisabled = useIsOffline();
 
   return (
     <SignOutModal

--- a/dev-client/src/screens/UserSettingsScreen/components/menu/SignOutItem.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/menu/SignOutItem.tsx
@@ -19,9 +19,12 @@ import {useTranslation} from 'react-i18next';
 
 import {MenuItem} from 'terraso-mobile-client/components/menus/MenuItem';
 import {SignOutModal} from 'terraso-mobile-client/components/modals/SignOutModal';
+import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 
 export function SignOutItem() {
   const {t} = useTranslation();
+
+  const isDisabled = useIsOffline() === true;
 
   return (
     <SignOutModal
@@ -31,6 +34,7 @@ export function SignOutItem() {
           uppercase
           icon="logout"
           label={t('settings.sign_out')}
+          disabled={isDisabled}
           onPress={onOpen}
         />
       )}


### PR DESCRIPTION
## Description
Disables the sign out and delete account buttons on the user settings screen when offline.

@knipec `useIsOffline` returns `boolean | null`, should it just return `boolean`? or is the intention for `null` to mean "unknown" and different components might want to handle that case differently?

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Related to #2376 

### Verification steps
Buttons should be disabled when offline.