### PR TITLE
build: revert react-native-screens to 4.1.0

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -58,7 +58,7 @@
         "react-native-paper": "^5.12.5",
         "react-native-reanimated": "^3.16.2",
         "react-native-safe-area-context": "^4.14.0",
-        "react-native-screens": "^4.2.0",
+        "react-native-screens": "^4.1.0",
         "react-native-svg": "^15.9.0",
         "react-native-tab-view": "^4.0.2",
         "reduce-reducers": "^1.0.4",
@@ -22091,9 +22091,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.2.0.tgz",
-      "integrity": "sha512-FqQSWjDNsLuoLHx28PQBKJKQFn6kVB3+hmuEQl6NtBZXYVn3c3I/UVc7kyWv7vndJTBqS4a7Xshz4CJqjnZNFg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.1.0.tgz",
+      "integrity": "sha512-tCBwe7fRMpoi/nIgZxE86N8b2SH8d5PlfGaQO8lgqlXqIyvwqm3u1HJCaA0tsacPyzhW7vVtRfQyq9e1j0S2gA==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -76,7 +76,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "^3.16.2",
     "react-native-safe-area-context": "^4.14.0",
-    "react-native-screens": "^4.2.0",
+    "react-native-screens": "^4.1.0",
     "react-native-svg": "^15.9.0",
     "react-native-tab-view": "^4.0.2",
     "reduce-reducers": "^1.0.4",


### PR DESCRIPTION
## Description
Revert react-native-screens to 4.1.0.

### Related Issues
Addresses #2510.