### PR TITLE
fix: wrap EmptySiteMessage in BottomSheetScrollView

### DIFF
--- a/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
@@ -20,7 +20,10 @@ import {useTranslation} from 'react-i18next';
 import {ActivityIndicator} from 'react-native-paper';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
-import BottomSheet, {BottomSheetFlatList} from '@gorhom/bottom-sheet';
+import BottomSheet, {
+  BottomSheetFlatList,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet';
 import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 import {useTheme} from 'native-base';
 
@@ -112,7 +115,9 @@ export const SiteListBottomSheet = memo(
           {isLoadingData ? (
             <ActivityIndicator size="large" />
           ) : sites.length === 0 ? (
-            <EmptySiteMessage />
+            <BottomSheetScrollView>
+              <EmptySiteMessage />
+            </BottomSheetScrollView>
           ) : (
             <BottomSheetFlatList
               style={listStyle}


### PR DESCRIPTION
## Description
Wrap EmptySiteMessage in BottomSheetScrollView

Thanks to @tm-ruxandra for the fix.

### Related Issues
Addresses #2512.