### PR TITLE
fix: temporary site popover: disable when offline

### DIFF
--- a/dev-client/locales/po/en.po
+++ b/dev-client/locales/po/en.po
@@ -127,6 +127,9 @@ msgstr "{{value}} {{units}}"
 msgid "site##elevation_unknown"
 msgstr "unknown"
 
+msgid "site##not_available_offine"
+msgstr "Not available offline"
+
 msgid "site##empty##info"
 msgstr ""
 "You don’t have any sites yet. A site lets you collect and save data, learn more about your land and its potential, and share with others.\n"

--- a/dev-client/locales/po/es.po
+++ b/dev-client/locales/po/es.po
@@ -278,6 +278,12 @@ msgstr "{{value}} {{units}}"
 msgid "site##elevation_unknown"
 msgstr "desconocido"
 
+<<<<<<< HEAD
+=======
+msgid "site##not_available_offine"
+msgstr "TK Not available offline"
+
+>>>>>>> e1c86dcf (chore: update PO files)
 msgid "site##form##name_min_length_error"
 msgstr "El nombre del sitio debe tener un mínimo de {{min}} caracteres"
 

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -196,6 +196,13 @@ export const theme = extendTheme({
             },
           },
         },
+        outline: {
+          _disabled: {
+            _text: {
+              color: 'action.disabled',
+            },
+          },
+        },
         fullWidth: {
           borderRadius: '0px',
           width: 'full',

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -48,6 +48,7 @@
         "elevation_label": "Elevation",
         "elevation_value": "{{value}} {{units}}",
         "elevation_unknown": "unknown",
+        "not_available_offine": "Not available offline",
         "empty": {
             "info": "You don’t have any sites yet. A site lets you collect and save data, learn more about your land and its potential, and share with others.\n\n<bold>Use the map to create a site.</bold> There are three ways to use the map to find a location for a site:\n",
             "bullet_1": "Tap the map to drop a pin and get more information about that location.",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -113,6 +113,7 @@
         "elevation_label": "Elevación",
         "elevation_value": "{{value}} {{units}}",
         "elevation_unknown": "desconocido",
+        "not_available_offine": "TK Not available offline",
         "form": {
             "name_min_length_error": "El nombre del sitio debe tener un mínimo de {{min}} caracteres",
             "name_max_length_error": "El nombre del sitio debe tener un máximo de {{max}} caracteres",


### PR DESCRIPTION
## Description
On the temporary site popover, disable data fetching and site creation when offline.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/2560