### PR TITLE
feat: list/rank soil inconsistency workaround

### DIFF
--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
@@ -37,7 +37,9 @@ export const fetchLocationBasedSoilMatchesThunk = async (
 ) => fetchLocationBasedSoilMatches(coords);
 
 export const fetchLocationBasedSoilMatches = async (coords: Coords) => {
-  const result = await soilIdService.fetchLocationBasedSoilMatches(coords);
+  const result = await soilIdService.fetchDataBasedSoilMatches(coords, {
+    depthDependentData: [],
+  });
 
   if (result.__typename === 'SoilIdFailure') {
     return locationEntryForStatus(coords, result.reason);

--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
@@ -37,6 +37,10 @@ export const fetchLocationBasedSoilMatchesThunk = async (
 ) => fetchLocationBasedSoilMatches(coords);
 
 export const fetchLocationBasedSoilMatches = async (coords: Coords) => {
+  // NOTE: we call the dataBasedSoilMatches endpoint here as a temporary workaround
+  //       to make the pre and post site creation soil lists consistent. The ideal
+  //       upstream fix would be to actually make the results of these endpoints
+  //       consistent for a fresh site
   const result = await soilIdService.fetchDataBasedSoilMatches(coords, {
     depthDependentData: [],
   });

--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
@@ -40,7 +40,8 @@ export const fetchLocationBasedSoilMatches = async (coords: Coords) => {
   // NOTE: we call the dataBasedSoilMatches endpoint here as a temporary workaround
   //       to make the pre and post site creation soil lists consistent. The ideal
   //       upstream fix would be to actually make the results of these endpoints
-  //       consistent for a fresh site
+  //       consistent for a fresh site.
+  //       Upstream bug: https://github.com/techmatters/soil-id-algorithm/issues/126
   const result = await soilIdService.fetchDataBasedSoilMatches(coords, {
     depthDependentData: [],
   });

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+
 import {
   coordsKey,
   dataEntryForMatches,
@@ -64,12 +66,17 @@ describe('locationEntryForStatus', () => {
 
 describe('locationEntryForMatches', () => {
   test('produces an entry with ready status and the given matches', () => {
+    const match = {rank: 1, score: 1};
+    const inputMatches = [{combinedMatch: match, dataSource: 'SSURGO'}];
     expect(
-      locationEntryForMatches({latitude: 1, longitude: 2}, ['match'] as any),
+      locationEntryForMatches(
+        {latitude: 1, longitude: 2},
+        inputMatches as DataBasedSoilMatch[],
+      ),
     ).toEqual({
       input: {latitude: 1, longitude: 2},
       status: 'ready',
-      matches: ['match'],
+      matches: [{match, dataSource: 'SSURGO'}],
     });
   });
 });

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.ts
@@ -65,12 +65,17 @@ export const locationEntryForStatus = (
 
 export const locationEntryForMatches = (
   input: Coords,
-  matches: LocationBasedSoilMatch[],
+  matches: DataBasedSoilMatch[],
 ): SoilIdLocationEntry => {
   return {
     input,
     status: 'ready',
-    matches: matches,
+    matches: matches.map(
+      ({dataMatch: _, locationMatch: __, combinedMatch, ...rest}) => ({
+        ...rest,
+        match: combinedMatch,
+      }),
+    ),
   };
 };
 


### PR DESCRIPTION
## Description
Changes the `fetchLocationBasedSoilMatches` redux action to secretly call the `fetchDataBasedSoilMatches` endpoint with an empty set of data. See discussion on https://github.com/techmatters/soil-id-algorithm/issues/126 for why this is desirable behaviorally. This is in draft because it puts the codebase in a kinda hacky state where the method names aren't really honest anymore, but I wanted to record my progress before I take time off.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Related to https://github.com/techmatters/soil-id-algorithm/issues/126. Depends on https://github.com/techmatters/terraso-client-shared/pull/1112.

### Verification steps
There should be no difference in the soil ID results now before or after creating a site.