### PR TITLE
Feat: sync conflict notification

### DIFF
--- a/dev-client/locales/po/en.po
+++ b/dev-client/locales/po/en.po
@@ -898,6 +898,9 @@ msgstr "Save"
 msgid "general##save_fab"
 msgstr "Save"
 
+msgid "general##dismiss"
+msgstr "Dismiss"
+
 msgid "general##use"
 msgstr "Use"
 
@@ -1024,6 +1027,12 @@ msgstr "Next"
 msgid "general##proceed"
 msgstr "Proceed"
 
+msgid "general##support##label"
+msgstr "Support"
+
+msgid "general##support##url"
+msgstr "https://landpks.terraso.org/"
+
 msgid "permissions##camera_title"
 msgstr "LandPKS Soil ID needs to access your camera"
 
@@ -1044,6 +1053,12 @@ msgstr "For the best map experience, grant LandPKS Soil ID access to your locati
 
 msgid "errors##generic"
 msgstr "Error saving soil ID information."
+
+msgid "errors##sync_conflict##headline"
+msgstr "Project conflict"
+
+msgid "errors##sync_conflict##body"
+msgstr "This project has changed. Learn more and get support at the LandPKS website."
 
 msgid "screens##SITES"
 msgstr "LandPKS Soil ID"

--- a/dev-client/locales/po/es.po
+++ b/dev-client/locales/po/es.po
@@ -995,8 +995,20 @@ msgstr "{{current}} / {{limit}} caracteres"
 msgid "general##open_settings"
 msgstr "Ir a configuraciones"
 
+msgid "general##support##label"
+msgstr "Support TK"
+
+msgid "general##support##url"
+msgstr "https://landpks.terraso.org/"
+
 msgid "errors##generic"
 msgstr "Error al guardar la informacion de la identificación del suelo."
+
+msgid "errors##sync_conflict##headline"
+msgstr "Project conflict TK"
+
+msgid "errors##sync_conflict##body"
+msgstr "This project has changed. Learn more and get support at the LandPKS website. TK"
 
 msgid "screens##LOGIN"
 msgstr "Iniciar sesión"

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -51,6 +51,7 @@ import {ConnectivityContextProvider} from 'terraso-mobile-client/context/connect
 import {GeospatialProvider} from 'terraso-mobile-client/context/GeospatialContext';
 import {HeaderHeightContext} from 'terraso-mobile-client/context/HeaderHeightContext';
 import {SitesScreenContextProvider} from 'terraso-mobile-client/context/SitesScreenContext';
+import {SyncNotificationContextProvider} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {RootNavigator} from 'terraso-mobile-client/navigation/navigators/RootNavigator';
 import {Toasts} from 'terraso-mobile-client/screens/Toasts';
 import {createStore} from 'terraso-mobile-client/store';
@@ -136,12 +137,14 @@ function App(): React.JSX.Element {
                         <SitesScreenContextProvider>
                           <ConnectivityContextProvider>
                             <ForegroundPermissionsProvider>
-                              <RestrictByFlag flag="FF_offline">
-                                <PushDispatcher />
-                                <PullRequester />
-                                <PullDispatcher />
-                              </RestrictByFlag>
-                              <RootNavigator />
+                              <SyncNotificationContextProvider>
+                                <RestrictByFlag flag="FF_offline">
+                                  <PushDispatcher />
+                                  <PullRequester />
+                                  <PullDispatcher />
+                                </RestrictByFlag>
+                                <RootNavigator />
+                              </SyncNotificationContextProvider>
                             </ForegroundPermissionsProvider>
                           </ConnectivityContextProvider>
                         </SitesScreenContextProvider>

--- a/dev-client/src/components/NativeBaseAdapters.tsx
+++ b/dev-client/src/components/NativeBaseAdapters.tsx
@@ -109,18 +109,28 @@ type HeadingProps = NativeBaseTextProps &
     variant?: keyof (typeof theme.components)['Heading']['variants'];
   };
 
-export const Heading = (props: React.PropsWithChildren<HeadingProps>) => (
-  <RN.Text
-    {...convertNBStyles(
-      {
-        variant: 'h6',
-        color: 'text.primary',
-        ...props,
-      },
-      'Heading',
-    )}
-  />
-);
+export const Heading = (props: React.PropsWithChildren<HeadingProps>) => {
+  const hasTextAncestor = useContext(TextAncestorContext);
+  return (
+    <TextAncestorContext.Provider value={true}>
+      <RN.Text
+        {...convertNBStyles(
+          {
+            ...(hasTextAncestor
+              ? {variant: 'h6'}
+              : {
+                  variant: 'h6',
+                  color: 'text.primary',
+                  ...props,
+                }),
+            ...props,
+          },
+          'Heading',
+        )}
+      />
+    </TextAncestorContext.Provider>
+  );
+};
 
 type BadgeProps = NativeBaseProps &
   RN.ViewProps & {

--- a/dev-client/src/components/buttons/DismissButton.tsx
+++ b/dev-client/src/components/buttons/DismissButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Technology Matters
+ * Copyright © 2024 Technology Matters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/dev-client/src/components/buttons/DismissButton.tsx
+++ b/dev-client/src/components/buttons/DismissButton.tsx
@@ -29,7 +29,7 @@ export type DismissButtonProps = {
 export const DismissButton = ({onPress}: DismissButtonProps) => {
   return (
     <Button
-      borderColor="alert.errorContent"
+      borderColor="error.content"
       _pressed={{backgroundColor: 'transparent'}}
       onPress={onPress}
       variant="outline">
@@ -42,7 +42,7 @@ export const DismissButton = ({onPress}: DismissButtonProps) => {
 
 const styles = StyleSheet.create({
   text: {
-    color: convertColorProp('alert.errorContent'),
+    color: convertColorProp('error.content'),
     fontSize: 14,
     lineHeight: 24,
     fontWeight: '500',

--- a/dev-client/src/components/buttons/DismissButton.tsx
+++ b/dev-client/src/components/buttons/DismissButton.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {StyleSheet, Text} from 'react-native';
+
+import {Button} from 'native-base';
+
+import {TranslatedContent} from 'terraso-mobile-client/components/content/typography/TranslatedContent';
+import {convertColorProp} from 'terraso-mobile-client/components/util/nativeBaseAdapters';
+
+export default function DismissButton() {
+  return (
+    <Button
+      borderColor="alert.errorContent"
+      _pressed={{backgroundColor: 'transparent'}} // TODO: get actual color
+      variant="outline">
+      <Text style={styles.text}>
+        <TranslatedContent i18nKey="general.dismiss" />
+      </Text>
+    </Button>
+  );
+}
+
+const styles = StyleSheet.create({
+  text: {
+    color: convertColorProp('alert.errorContent'),
+    fontSize: 14,
+    lineHeight: 24,
+    fontWeight: '500',
+  },
+});

--- a/dev-client/src/components/buttons/DismissButton.tsx
+++ b/dev-client/src/components/buttons/DismissButton.tsx
@@ -26,7 +26,7 @@ export default function DismissButton() {
   return (
     <Button
       borderColor="alert.errorContent"
-      _pressed={{backgroundColor: 'transparent'}} // TODO: get actual color
+      _pressed={{backgroundColor: 'transparent'}}
       variant="outline">
       <Text style={styles.text}>
         <TranslatedContent i18nKey="general.dismiss" />

--- a/dev-client/src/components/buttons/DismissButton.tsx
+++ b/dev-client/src/components/buttons/DismissButton.tsx
@@ -15,25 +15,30 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {StyleSheet, Text} from 'react-native';
+import {PressableProps, StyleSheet, Text} from 'react-native';
 
 import {Button} from 'native-base';
 
 import {TranslatedContent} from 'terraso-mobile-client/components/content/typography/TranslatedContent';
 import {convertColorProp} from 'terraso-mobile-client/components/util/nativeBaseAdapters';
 
-export default function DismissButton() {
+export type DismissButtonProps = {
+  onPress?: PressableProps['onPress'];
+};
+
+export const DismissButton = ({onPress}: DismissButtonProps) => {
   return (
     <Button
       borderColor="alert.errorContent"
       _pressed={{backgroundColor: 'transparent'}}
+      onPress={onPress}
       variant="outline">
       <Text style={styles.text}>
         <TranslatedContent i18nKey="general.dismiss" />
       </Text>
     </Button>
   );
-}
+};
 
 const styles = StyleSheet.create({
   text: {

--- a/dev-client/src/components/buttons/TextButton.tsx
+++ b/dev-client/src/components/buttons/TextButton.tsx
@@ -98,7 +98,7 @@ export const COLORS = {
   },
   alertError: {
     default: 'alert.errorContent',
-    pressed: 'text.primary', // TODO: get real color from design team
+    pressed: 'alert.errorContent',
   },
   disabled: {
     default: 'text.disabled',

--- a/dev-client/src/components/buttons/TextButton.tsx
+++ b/dev-client/src/components/buttons/TextButton.tsx
@@ -23,7 +23,7 @@ import {Button} from 'native-base';
 
 import {Icon, IconName} from 'terraso-mobile-client/components/icons/Icon';
 
-export type TextButtonType = 'default' | 'error';
+export type TextButtonType = 'default' | 'error' | 'alertError';
 
 export type TextButtonProps = {
   label: string;
@@ -95,6 +95,10 @@ export const COLORS = {
   error: {
     default: 'error.main',
     pressed: 'error.content',
+  },
+  alertError: {
+    default: 'alert.errorContent',
+    pressed: 'text.primary', // TODO: get real color from design team
   },
   disabled: {
     default: 'text.disabled',

--- a/dev-client/src/components/buttons/TextButton.tsx
+++ b/dev-client/src/components/buttons/TextButton.tsx
@@ -97,8 +97,8 @@ export const COLORS = {
     pressed: 'error.content',
   },
   alertError: {
-    default: 'alert.errorContent',
-    pressed: 'alert.errorContent',
+    default: 'error.content',
+    pressed: 'error.content',
   },
   disabled: {
     default: 'text.disabled',

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -16,19 +16,19 @@
  */
 
 import {useCallback} from 'react';
-import {ToastAndroid} from 'react-native';
 
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
+import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 
 export const useHandleMissingSite = () => {
   const navigation = useNavigation();
+  const syncNotifications = useSyncNotificationContext();
 
   return useCallback(() => {
     navigation.navigate('BOTTOM_TABS');
-    // TODO: Decide design / how to show toasts / use en.json string
     if (isFlagEnabled('FF_offline')) {
-      ToastAndroid.show('Sorry, someone deleted that!', ToastAndroid.SHORT);
+      syncNotifications.showError();
     }
-  }, [navigation]);
+  }, [navigation, syncNotifications]);
 };

--- a/dev-client/src/components/dialogs/ErrorDialog.tsx
+++ b/dev-client/src/components/dialogs/ErrorDialog.tsx
@@ -60,11 +60,11 @@ export const ErrorDialog = forwardRef<
           </View>
           {headline && (
             <View style={styles.headline}>
-              <Text color="alert.errorContent">{headline}</Text>
+              <Text color="error.content">{headline}</Text>
             </View>
           )}
           <View>
-            <Text color="alert.errorContent">{children}</Text>
+            <Text color="error.content">{children}</Text>
           </View>
           <View style={styles.actions}>
             <ExternalLink
@@ -82,7 +82,7 @@ export const ErrorDialog = forwardRef<
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: convertColorProp('alert.errorFill'),
+    backgroundColor: convertColorProp('error.background'),
     borderRadius: 28,
     padding: 24,
     width: 312,

--- a/dev-client/src/components/dialogs/ErrorDialog.tsx
+++ b/dev-client/src/components/dialogs/ErrorDialog.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from 'react';
+import {useTranslation} from 'react-i18next';
+import {StyleSheet} from 'react-native';
+import {Modal, Portal} from 'react-native-paper';
+
+import DismissButton from 'terraso-mobile-client/components/buttons/DismissButton';
+import {Icon} from 'terraso-mobile-client/components/icons/Icon';
+import {ExternalLink} from 'terraso-mobile-client/components/links/ExternalLink';
+import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
+import {Text, View} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {convertColorProp} from 'terraso-mobile-client/components/util/nativeBaseAdapters';
+
+export type ErrorDialogProps = React.PropsWithChildren<{
+  headline?: React.ReactNode;
+}>;
+
+/**
+ * Dialog presented to a user when a technical error occurs.
+ */
+export const ErrorDialog = forwardRef<
+  ModalHandle,
+  React.PropsWithChildren<ErrorDialogProps>
+>(({headline, children}, forwardedRef) => {
+  const {t} = useTranslation();
+  const [isOpen, setIsOpen] = useState(true);
+  const onOpen = useCallback(() => setIsOpen(true), [setIsOpen]);
+  const onClose = useCallback(() => setIsOpen(false), [setIsOpen]);
+  const modalHandle = useMemo(() => ({onClose, onOpen}), [onOpen, onClose]);
+  useImperativeHandle(forwardedRef, () => modalHandle, [modalHandle]);
+
+  return (
+    <Portal>
+      <Modal visible={isOpen} onDismiss={onClose}>
+        <View style={styles.container}>
+          <View style={styles.icon}>
+            <Icon name="error" color="error.main" size="md" />
+          </View>
+          {headline && (
+            <View style={styles.headline}>
+              <Text color="alert.errorContent">{headline}</Text>
+            </View>
+          )}
+          <View>
+            <Text color="alert.errorContent">{children}</Text>
+          </View>
+          <View style={styles.actions}>
+            <ExternalLink
+              type="alertError"
+              label={t('general.support.label')}
+              url={t('general.support.url')}
+            />
+            <DismissButton />
+          </View>
+        </View>
+      </Modal>
+    </Portal>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: convertColorProp('alert.errorFill'),
+    borderRadius: 28,
+    padding: 24,
+    width: 312,
+    alignSelf: 'center',
+  },
+  icon: {
+    alignItems: 'center',
+  },
+  headline: {
+    marginTop: 16,
+    marginBottom: 16,
+    alignItems: 'center',
+  },
+  actions: {
+    marginTop: 24,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  dismissText: {},
+});

--- a/dev-client/src/components/dialogs/ErrorDialog.tsx
+++ b/dev-client/src/components/dialogs/ErrorDialog.tsx
@@ -26,7 +26,7 @@ import {useTranslation} from 'react-i18next';
 import {StyleSheet} from 'react-native';
 import {Modal, Portal} from 'react-native-paper';
 
-import DismissButton from 'terraso-mobile-client/components/buttons/DismissButton';
+import {DismissButton} from 'terraso-mobile-client/components/buttons/DismissButton';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ExternalLink} from 'terraso-mobile-client/components/links/ExternalLink';
 import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
@@ -72,7 +72,7 @@ export const ErrorDialog = forwardRef<
               label={t('general.support.label')}
               url={t('general.support.url')}
             />
-            <DismissButton />
+            <DismissButton onPress={onClose} />
           </View>
         </View>
       </Modal>

--- a/dev-client/src/components/links/ExternalLink.tsx
+++ b/dev-client/src/components/links/ExternalLink.tsx
@@ -21,18 +21,26 @@ import {Linking} from 'react-native';
 import {TextButton} from 'terraso-mobile-client/components/buttons/TextButton';
 import {validateUrl} from 'terraso-mobile-client/util';
 
+export type ExternalLinkType = 'default' | 'alertError';
+
 export type ExternalLinkProps = {
+  type?: ExternalLinkType;
   label: string;
   url: string;
 };
 
-export const ExternalLink = ({label, url}: ExternalLinkProps) => {
+export const ExternalLink = ({
+  type = 'default',
+  label,
+  url,
+}: ExternalLinkProps) => {
   const isValidUrl = useMemo(() => validateUrl(url), [url]);
   const openUrl = useCallback(() => Linking.openURL(url), [url]);
 
   return (
     isValidUrl && (
       <TextButton
+        type={type}
         role="link"
         label={label}
         rightIcon="open-in-new"

--- a/dev-client/src/context/SyncNotificationContext.tsx
+++ b/dev-client/src/context/SyncNotificationContext.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {createContext, useContext, useMemo, useRef} from 'react';
+
+import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
+import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
+import {ErrorDialog} from 'terraso-mobile-client/components/dialogs/ErrorDialog';
+import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
+
+export type SyncNotificationHandle = {
+  showError: () => void;
+};
+
+const SyncNotificationContext = createContext<SyncNotificationHandle>({
+  showError: () => {},
+});
+
+export const useSyncNotificationContext = () => {
+  return useContext(SyncNotificationContext);
+};
+
+export const SyncNotificationContextProvider = ({
+  children,
+}: React.PropsWithChildren) => {
+  const errorDialogRef = useRef<ModalHandle>(null);
+  const syncNotificationHandle = useMemo(() => {
+    return {
+      showError: () => errorDialogRef.current?.onOpen(),
+    };
+  }, [errorDialogRef]);
+
+  return (
+    <SyncNotificationContext.Provider value={syncNotificationHandle}>
+      <ErrorDialog
+        ref={errorDialogRef}
+        headline={
+          <TranslatedHeading i18nKey="errors.sync_conflict.headline" />
+        }>
+        <TranslatedParagraph i18nKey="errors.sync_conflict.body" />
+      </ErrorDialog>
+      {children}
+    </SyncNotificationContext.Provider>
+  );
+};

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -62,6 +62,10 @@ export const theme = extendTheme({
       main: '#ED6C02',
       content: '#663C00',
     },
+    alert: {
+      errorContent: '#5F2120',
+      errorFill: '#FDEDED',
+    },
     grey: {
       200: '#EEEEEE',
       300: '#E0E0E0',

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -62,10 +62,6 @@ export const theme = extendTheme({
       main: '#ED6C02',
       content: '#663C00',
     },
-    alert: {
-      errorContent: '#5F2120',
-      errorFill: '#FDEDED',
-    },
     grey: {
       200: '#EEEEEE',
       300: '#E0E0E0',

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -76,6 +76,7 @@ export const theme = extendTheme({
     action: {
       active: '#1A202C',
       active_subtle: '#1A202CB2',
+      selected: '#00192314',
       disabled: '#8B9498',
       disabledBackground: '#E0E0E0',
     },

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -401,6 +401,7 @@
         "users": "users",
         "save": "Save",
         "save_fab": "Save",
+        "dismiss": "Dismiss",
         "use": "Use",
         "last_modified_by": "last modified {{user}}, {{date}}",
         "select_all": "Select All",
@@ -450,7 +451,11 @@
         "yes": "Yes",
         "no": "No",
         "next": "Next",
-        "proceed": "Proceed"
+        "proceed": "Proceed",
+        "support": {
+            "label": "Support",
+            "url": "https://landpks.terraso.org/"
+        }
     },
     "permissions": {
         "camera_title": "LandPKS Soil ID needs to access your camera",
@@ -461,7 +466,11 @@
         "location_body": "For the best map experience, grant LandPKS Soil ID access to your location in device settings."
     },
     "errors": {
-        "generic": "Error saving soil ID information."
+        "generic": "Error saving soil ID information.",
+        "sync_conflict": {
+            "headline": "Project conflict",
+            "body": "This project has changed. Learn more and get support at the LandPKS website."
+        }
     },
     "screens": {
         "SITES": "LandPKS Soil ID",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -409,6 +409,7 @@
         "proceed": "Proceder",
         "last_modified": "Última modificación",
         "save_fab": "Guardar",
+        "dismiss": "Dismiss TK",
         "last_modified_by": "última modificación {{user}}, {{date}}",
         "select_all": "Seleccionar todo",
         "you_name": "{{name}} (tú)",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -440,10 +440,18 @@
             "privacy_policy_link_text": "Lee más acerca de nuestras políticas de privacidad de datos."
         },
         "character_limit": "{{current}} / {{limit}} caracteres",
-        "open_settings": "Ir a configuraciones"
+        "open_settings": "Ir a configuraciones",
+        "support": {
+            "label": "Support TK",
+            "url": "https://landpks.terraso.org/"
+        }
     },
     "errors": {
-        "generic": "Error al guardar la informacion de la identificación del suelo."
+        "generic": "Error al guardar la informacion de la identificación del suelo.",
+        "sync_conflict": {
+            "headline": "Project conflict TK",
+            "body": "This project has changed. Learn more and get support at the LandPKS website. TK"
+        }
     },
     "screens": {
         "LOGIN": "Iniciar sesión",


### PR DESCRIPTION
## Description

Add a new dialog which implements the sync error notification requirements. The dialog is exposed to the application through a new "sync notification context", which the missing site pull handler now uses instead of the generic Android toast. This context can also be reused for handling push errors.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#2324 

### Verification steps

Trigger a sync error condition (for example, navigate to a site and then delete that site). Trigger a pull and observe the error dialog.
