### PR TITLE
feat: push error notification

### DIFF
--- a/dev-client/__tests__/integration/store/sync/PushDispatcher.test.tsx
+++ b/dev-client/__tests__/integration/store/sync/PushDispatcher.test.tsx
@@ -140,7 +140,7 @@ describe('PushDispatcher', () => {
     await waitFor(() => expect(showError).toHaveBeenCalledTimes(1));
   });
 
-  test('shoes not show error notification when push has no sync errors', async () => {
+  test('does not show error notification when push has no sync errors', async () => {
     useIsLoggedIn.mockReturnValue(true);
     useDebouncedIsOffline.mockReturnValue(false);
     useDebouncedUnsyncedSiteIds.mockReturnValue(['abcd']);

--- a/dev-client/src/store/sync/PushDispatcher.tsx
+++ b/dev-client/src/store/sync/PushDispatcher.tsx
@@ -93,7 +93,7 @@ export const PushDispatcher = () => {
 
     /* Cancel any pending retries when push input changes or component unmounts */
     return endRetry;
-  }, [needsPush, dispatchPush, beginRetry, endRetry, syncNotifications]);
+  }, [needsPush, dispatchPush, beginRetry, endRetry]);
 
   return <></>;
 };


### PR DESCRIPTION
## Description

(Depends on https://github.com/techmatters/terraso-mobile-client/pull/2572)

Show a sync error notification when a push completes with sync errors.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #2293

### Verification steps

Push with an error condition (e.g., to a deleted site). Observe the error notification.
