### PR TITLE
feat: disable soil id match selector when offline

### DIFF
--- a/dev-client/src/components/content/typography/DisableableText.tsx
+++ b/dev-client/src/components/content/typography/DisableableText.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+
+type DisableableTextProps = {
+  disabled?: boolean;
+} & React.PropsWithChildren;
+
+export const DisableableText = ({
+  disabled = false,
+  children,
+}: DisableableTextProps) => {
+  return <Text color={disabled ? 'text.disabled' : undefined}>{children}</Text>;
+};

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilIdMatchSelector.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilIdMatchSelector.tsx
@@ -21,8 +21,10 @@ import CheckBox from '@react-native-community/checkbox';
 
 import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
+import {DisableableText} from 'terraso-mobile-client/components/content/typography/DisableableText';
 import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
 import {RestrictBySiteRole} from 'terraso-mobile-client/components/RestrictByRole';
+import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 import {SITE_EDITOR_ROLES} from 'terraso-mobile-client/model/permissions/permissions';
 import {getMatchSelectionId} from 'terraso-mobile-client/model/soilId/soilMetadataFunctions';
 import {useSoilIdSelection} from 'terraso-mobile-client/model/soilId/soilMetadataHooks';
@@ -32,7 +34,11 @@ type SoilIdMatchSelectorProps = {
   siteId: string;
 };
 
-export function SoilIdMatchSelector({siteId, match}: SoilIdMatchSelectorProps) {
+export const SoilIdMatchSelector = ({
+  siteId,
+  match,
+}: SoilIdMatchSelectorProps) => {
+  const isOffline = useIsOffline();
   const {selectedSoilId, selectSoilId} = useSoilIdSelection(siteId);
   const matchId = getMatchSelectionId(match);
 
@@ -41,16 +47,20 @@ export function SoilIdMatchSelector({siteId, match}: SoilIdMatchSelectorProps) {
       <View style={styles.container}>
         <CheckBox
           accessibilityRole="checkbox"
+          accessibilityState={{disabled: isOffline}}
           value={selectedSoilId === matchId}
+          disabled={isOffline}
           onValueChange={value => {
             selectSoilId(value ? matchId : null);
           }}
         />
-        <TranslatedParagraph i18nKey="site.soil_id.matches.selector" />
+        <DisableableText disabled={isOffline}>
+          <TranslatedParagraph i18nKey="site.soil_id.matches.selector" />
+        </DisableableText>
       </View>
     </RestrictBySiteRole>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
## Description

Disable soil ID match selector when offline. Add a new `DisableableText` typography component to help implement this type of feature in the future.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#2516

### Verification steps

Enter offline mode and navigate to a soil ID match for a site. Observe that the selection checkbox is still visible but it and its text appear disabled. Interacting with it does not change the user's selection.