### PR TITLE
fix: make private/public radio blocks horizontal instead of vertical

### DIFF
--- a/dev-client/__tests__/snapshot/__snapshots__/ProjectViewScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/ProjectViewScreen-test.tsx.snap
@@ -1530,6 +1530,7 @@ exports[`renders correctly 1`] = `
                                         style={
                                           {
                                             "alignItems": "flex-start",
+                                            "flexDirection": "row",
                                             "marginLeft": 0,
                                           }
                                         }
@@ -1807,7 +1808,11 @@ exports[`renders correctly 1`] = `
                                         </View>
                                         <View
                                           dataSet={{}}
-                                          style={{}}
+                                          style={
+                                            {
+                                              "width": 26,
+                                            }
+                                          }
                                         />
                                         <View
                                           accessibilityRole="radio"

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -157,6 +157,7 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
                 onChange: onSitePrivacyChanged,
                 value: site.privacy,
                 ml: '0',
+                variant: 'oneLine',
               }}
             />
           </Row>

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -103,6 +103,7 @@ export const ProjectInputScreen = ({
                 onChange: onProjectPrivacyChanged,
                 value: project?.privacy,
                 ml: '0',
+                variant: 'oneLine',
               }}
               allDisabled={!allowEditing}
             />


### PR DESCRIPTION
## Description
Make public/private radio buttons horizontal instead of vertically stacked.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/2568