### PR TITLE
fix: error dialog should not be open by default

### DIFF
--- a/dev-client/src/components/dialogs/ErrorDialog.tsx
+++ b/dev-client/src/components/dialogs/ErrorDialog.tsx
@@ -45,7 +45,7 @@ export const ErrorDialog = forwardRef<
   React.PropsWithChildren<ErrorDialogProps>
 >(({headline, children}, forwardedRef) => {
   const {t} = useTranslation();
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const onOpen = useCallback(() => setIsOpen(true), [setIsOpen]);
   const onClose = useCallback(() => setIsOpen(false), [setIsOpen]);
   const modalHandle = useMemo(() => ({onClose, onOpen}), [onOpen, onClose]);


### PR DESCRIPTION
## Description

The error dialog was unintentionally checked in with its `isOpen` state set to `true` by default. Fix this oversight.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#2293

### Verification steps

Open application and verify that dialog does not show initially.
