### PR TITLE
fix: Don't show user location dot when permissions aren't granted + re-render when permissions change.

### DIFF
--- a/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
+++ b/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {CircleLayer, Location, UserLocation} from '@rnmapbox/maps';
+import {CircleLayer, UserLocation} from '@rnmapbox/maps';
 
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
 import {useUpdatedForegroundPermissions} from 'terraso-mobile-client/hooks/appPermissionsHooks';
@@ -42,12 +42,10 @@ const layerStyles = {
 
 type CustomUserLocationProps = {
   onUserLocationPress: (event?: GeoJSON.GeoJsonProperties) => void;
-  updateUserLocation?: (location: Location) => void;
 };
 
 export const CustomUserLocation = ({
   onUserLocationPress,
-  updateUserLocation,
 }: CustomUserLocationProps) => {
   const {permissions} = useUpdatedForegroundPermissions();
   console.log('Permissions: ', permissions?.granted);
@@ -58,7 +56,6 @@ export const CustomUserLocation = ({
 
   return permissions?.granted ? (
     <UserLocation
-      onUpdate={updateUserLocation}
       onPress={handleUserLocationPress}
       minDisplacement={USER_DISPLACEMENT_MIN_DISTANCE_M}>
       <CircleLayer

--- a/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
+++ b/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
@@ -17,6 +17,7 @@
 import {CircleLayer, Location, UserLocation} from '@rnmapbox/maps';
 
 import {USER_DISPLACEMENT_MIN_DISTANCE_M} from 'terraso-mobile-client/constants';
+import {useUpdatedForegroundPermissions} from 'terraso-mobile-client/hooks/appPermissionsHooks';
 
 const mapboxBlue = 'rgba(51, 181, 229, 100)';
 
@@ -48,11 +49,14 @@ export const CustomUserLocation = ({
   onUserLocationPress,
   updateUserLocation,
 }: CustomUserLocationProps) => {
+  const {permissions} = useUpdatedForegroundPermissions();
+  console.log('Permissions: ', permissions?.granted);
+
   const handleUserLocationPress = (event?: GeoJSON.GeoJsonProperties) => {
     onUserLocationPress(event);
   };
 
-  return (
+  return permissions?.granted ? (
     <UserLocation
       onUpdate={updateUserLocation}
       onPress={handleUserLocationPress}
@@ -76,5 +80,7 @@ export const CustomUserLocation = ({
         style={layerStyles.foreground}
       />
     </UserLocation>
+  ) : (
+    <></>
   );
 };

--- a/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
+++ b/dev-client/src/screens/SitesScreen/components/CustomUserLocation.tsx
@@ -48,7 +48,6 @@ export const CustomUserLocation = ({
   onUserLocationPress,
 }: CustomUserLocationProps) => {
   const {permissions} = useUpdatedForegroundPermissions();
-  console.log('Permissions: ', permissions?.granted);
 
   const handleUserLocationPress = (event?: GeoJSON.GeoJsonProperties) => {
     onUserLocationPress(event);

--- a/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
@@ -25,7 +25,7 @@ import {
 } from 'react';
 import {Keyboard, PixelRatio, StyleSheet} from 'react-native';
 
-import Mapbox, {Camera, Location} from '@rnmapbox/maps';
+import Mapbox, {Camera} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/src/types/OnPressEvent';
 import {useTheme} from 'native-base';
 
@@ -56,7 +56,6 @@ const MAX_EXPANSION_ZOOM = 15;
 const STARTING_ZOOM_LEVEL = 12;
 
 type Props = {
-  updateUserLocation?: (location: Location) => void;
   calloutState: CalloutState;
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
@@ -70,13 +69,7 @@ export type MapRef = {
 export const SiteMap = memo(
   forwardRef<MapRef, Props>(
     (
-      {
-        updateUserLocation,
-        setCalloutState,
-        calloutState,
-        styleURL,
-        onMapFinishedLoading,
-      },
+      {setCalloutState, calloutState, styleURL, onMapFinishedLoading},
       forwardedRef,
     ): React.JSX.Element => {
       const mapRef = useRef<Mapbox.MapView>(null);
@@ -331,10 +324,7 @@ export const SiteMap = memo(
               style={mapStyles.temporarySiteLayer}
             />
           </Mapbox.ShapeSource>
-          <CustomUserLocation
-            onUserLocationPress={onUserLocationPress}
-            updateUserLocation={updateUserLocation}
-          />
+          <CustomUserLocation onUserLocationPress={onUserLocationPress} />
           <SiteMapCallout
             sites={sites}
             state={calloutState}


### PR DESCRIPTION
### Description 
- I expect re-rendering when permissions change should allow the user to see the blue location marker on the map when they first use the app. 
- However, the issue only reproes on a physical Android device, and tbh I don't want to go through the hassle of making a tagged release just to test it for myself. I suspect this change is at least not bad, and I will test it in the next beta release unless someone thinks I shouldn't do this. 😅 
- Also, I think we shouldn't show the location marker when they have revoked location permissions. (Side note: The map will still zoom, as that's determined by the userLocation in redux, which does not get cleared when permissions are revoked).
- I think it's also not ideal that we don't just use the userLocation in redux to determine where to draw the location marker. But when I tried that, I was having issues where two dots were rendering and I didn't understand why, and this bug doesn't seem high enough priority to take more time on it.

Also remove an unused prop

### Related Issues
Hopefully addresses #2227
Also #1893 