### PR TITLE
fix: make alert/error icon sizes 18px

### DIFF
--- a/dev-client/src/components/messages/AlertMessageBox.tsx
+++ b/dev-client/src/components/messages/AlertMessageBox.tsx
@@ -36,7 +36,7 @@ export const AlertMessageBox = ({title, children}: MessageBoxProps) => {
       borderRadius="4px"
       padding="md">
       <Row>
-        <Icon name="warning-amber" color="warning.main" mr="md" />
+        <Icon name="warning-amber" color="warning.main" mr="md" size="xs" />
         <Column flex={1}>
           <Text variant="body1-strong" color="warning.content" mb="sm">
             {title}

--- a/dev-client/src/components/messages/ErrorMessageBox.tsx
+++ b/dev-client/src/components/messages/ErrorMessageBox.tsx
@@ -36,7 +36,7 @@ export const ErrorMessageBox = ({title, children}: MessageBoxProps) => {
       borderRadius="4px"
       padding="md">
       <Row>
-        <Icon name="error-outline" color="error.main" mr="md" />
+        <Icon name="error-outline" color="error.main" mr="md" size="xs" />
         <Column flex={1}>
           <Text variant="body1-strong" color="error.content" mb="sm">
             {title}

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -290,6 +290,7 @@ export const theme = extendTheme({
     },
     Icon: {
       sizes: {
+        xs: 18,
         sm: 20,
         md: 24,
         lg: 35,


### PR DESCRIPTION
## Description
Make alert/error icon sizes 18px instead of 24px.