### PR TITLE
fix: use correct support url for sync conflict notifications

### DIFF
--- a/dev-client/src/components/dialogs/ErrorDialog.tsx
+++ b/dev-client/src/components/dialogs/ErrorDialog.tsx
@@ -35,6 +35,7 @@ import {convertColorProp} from 'terraso-mobile-client/components/util/nativeBase
 
 export type ErrorDialogProps = React.PropsWithChildren<{
   headline?: React.ReactNode;
+  supportUrl?: string;
 }>;
 
 /**
@@ -43,7 +44,7 @@ export type ErrorDialogProps = React.PropsWithChildren<{
 export const ErrorDialog = forwardRef<
   ModalHandle,
   React.PropsWithChildren<ErrorDialogProps>
->(({headline, children}, forwardedRef) => {
+>(({headline, supportUrl, children}, forwardedRef) => {
   const {t} = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const onOpen = useCallback(() => setIsOpen(true), [setIsOpen]);
@@ -70,7 +71,7 @@ export const ErrorDialog = forwardRef<
             <ExternalLink
               type="alertError"
               label={t('general.support.label')}
-              url={t('general.support.url')}
+              url={supportUrl ?? t('general.support.label')}
             />
             <DismissButton onPress={onClose} />
           </View>

--- a/dev-client/src/context/SyncNotificationContext.tsx
+++ b/dev-client/src/context/SyncNotificationContext.tsx
@@ -16,6 +16,7 @@
  */
 
 import {createContext, useContext, useMemo, useRef} from 'react';
+import {useTranslation} from 'react-i18next';
 
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
@@ -37,6 +38,7 @@ export const useSyncNotificationContext = () => {
 export const SyncNotificationContextProvider = ({
   children,
 }: React.PropsWithChildren) => {
+  const {t} = useTranslation();
   const errorDialogRef = useRef<ModalHandle>(null);
   const syncNotificationHandle = useMemo(() => {
     return {
@@ -48,6 +50,7 @@ export const SyncNotificationContextProvider = ({
     <SyncNotificationContext.Provider value={syncNotificationHandle}>
       <ErrorDialog
         ref={errorDialogRef}
+        supportUrl={t('errors.sync_conflict.support_url')}
         headline={
           <TranslatedHeading i18nKey="errors.sync_conflict.headline" />
         }>

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -478,7 +478,8 @@
         "generic": "Error saving soil ID information.",
         "sync_conflict": {
             "headline": "Project conflict",
-            "body": "This project has changed. Learn more and get support at the LandPKS website."
+            "body": "This project has changed. Learn more and get support at the LandPKS website.",
+            "support_url": "https://landpks.terraso.org/help/synchronization-conflict/"
         }
     },
     "screens": {

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -460,7 +460,8 @@
         "generic": "Error al guardar la informacion de la identificación del suelo.",
         "sync_conflict": {
             "headline": "Project conflict TK",
-            "body": "This project has changed. Learn more and get support at the LandPKS website. TK"
+            "body": "This project has changed. Learn more and get support at the LandPKS website. TK",
+            "support_url": "https://landpks.terraso.org/help/synchronization-conflict/"
         }
     },
     "screens": {


### PR DESCRIPTION
## Description

Use correct support url for sync conflict notifications. `ErrorDialog` clients can now pass in an optional custom URL which takes precedence over the main Terraso site.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#2324

### Verification steps

 Verify sync error dialog URL.