### PR TITLE
refactor: rename instructions to pinned note

### DIFF
--- a/dev-client/src/navigation/screenDefinitions.tsx
+++ b/dev-client/src/navigation/screenDefinitions.tsx
@@ -27,7 +27,7 @@ import {ColorAnalysisScreen} from 'terraso-mobile-client/screens/ColorAnalysisSc
 import {CreateProjectScreen} from 'terraso-mobile-client/screens/CreateProjectScreen/CreateProjectScreen';
 import {CreateSiteScreen} from 'terraso-mobile-client/screens/CreateSiteScreen/CreateSiteScreen';
 import {DeleteAccountScreen} from 'terraso-mobile-client/screens/DeleteAccountScreen/DeleteAccountScreen';
-import {EditProjectInstructionsScreen} from 'terraso-mobile-client/screens/EditProjectInstructionsScreen';
+import {EditPinnedNoteScreen} from 'terraso-mobile-client/screens/EditPinnedNoteScreen';
 import {LocationSoilIdScreen} from 'terraso-mobile-client/screens/LocationScreens/LocationSoilIdScreen';
 import {SiteTabsScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteTabsScreen';
 import {TemporaryLocationScreen} from 'terraso-mobile-client/screens/LocationScreens/TemporaryLocationScreen';
@@ -102,7 +102,7 @@ export const screenDefinitions = {
 export const modalScreenDefinitions = {
   ADD_SITE_NOTE: AddSiteNoteScreen,
   EDIT_SITE_NOTE: EditSiteNoteScreen,
-  EDIT_PROJECT_INSTRUCTIONS: EditProjectInstructionsScreen,
+  EDIT_PINNED_NOTE: EditPinnedNoteScreen,
   READ_PINNED_NOTE: ReadPinnedNoteScreen,
 } satisfies ScreenDefinitions;
 

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -37,7 +37,7 @@ type Props = {
   projectId: string;
 };
 
-export const EditProjectInstructionsScreen = ({projectId}: Props) => {
+export const EditPinnedNoteScreen = ({projectId}: Props) => {
   const formWrapperRef = useRef<{handleSubmit: () => void}>(null);
   const {t} = useTranslation();
   const navigation = useNavigation();

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -42,7 +42,7 @@ import {useSoilIdData} from 'terraso-mobile-client/model/soilId/soilIdHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {LocationSoilIdCard} from 'terraso-mobile-client/screens/LocationScreens/components/LocationSoilIdCard';
-import {ProjectInstructionsButton} from 'terraso-mobile-client/screens/LocationScreens/components/ProjectInstructionsButton';
+import {PinnedNoteButton} from 'terraso-mobile-client/screens/LocationScreens/components/PinnedNoteButton';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {formatCoordinate} from 'terraso-mobile-client/util';
 
@@ -166,7 +166,7 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
           <Row space={4} alignItems="baseline">
             <PeopleChip count={Object.keys(project.memberships).length} />
             {project?.siteInstructions && (
-              <ProjectInstructionsButton project={project} />
+              <PinnedNoteButton project={project} />
             )}
           </Row>
         )}

--- a/dev-client/src/screens/LocationScreens/components/PinnedNoteButton.tsx
+++ b/dev-client/src/screens/LocationScreens/components/PinnedNoteButton.tsx
@@ -34,7 +34,7 @@ type Props = {
   project: Project;
 };
 
-export const ProjectInstructionsButton = ({project}: Props) => {
+export const PinnedNoteButton = ({project}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
 

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -58,7 +58,7 @@ export const ProjectInputScreen = ({
   const project = useSelector(state => state.project.projects[projectId]);
   const dispatch = useDispatch();
 
-  const onEditInstructions = useCallback(() => {
+  const onEditPinnedNote = useCallback(() => {
     return navigation.navigate('EDIT_PINNED_NOTE', {
       projectId: project.id,
     });
@@ -117,7 +117,7 @@ export const ProjectInputScreen = ({
               pr={4}
               size="lg"
               shadow={5}
-              onPress={onEditInstructions}
+              onPress={onEditPinnedNote}
               leftIcon={<Icon name="push-pin" />}>
               {t('projects.inputs.instructions.add_label')}
             </Button>

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -59,7 +59,7 @@ export const ProjectInputScreen = ({
   const dispatch = useDispatch();
 
   const onEditInstructions = useCallback(() => {
-    return navigation.navigate('EDIT_PROJECT_INSTRUCTIONS', {
+    return navigation.navigate('EDIT_PINNED_NOTE', {
       projectId: project.id,
     });
   }, [navigation, project]);

--- a/dev-client/src/screens/SiteNotesScreen/components/PinnedNoteCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/PinnedNoteCard.tsx
@@ -50,7 +50,7 @@ export const PinnedNoteCard = ({project}: Props) => {
       <Row>
         <Icon name="push-pin" color="primary.dark" size="sm" mr={1} />
         <Text bold fontSize="md">
-          {t('site.notes.project_instructions')}
+          {t('site.notes.pinned_note')}
         </Text>
       </Row>
       <Text pt={1} fontSize="md" numberOfLines={3} ellipsizeMode="tail">

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -195,7 +195,7 @@
             "confirm_removal_body": "This action cannot be undone.",
             "min_length_error": "Must be at least {{min}} characters",
             "placeholder_text": "Start typing your note…",
-            "project_instructions": "Pinned Note",
+            "pinned_note": "Pinned Note",
             "offline": "Creating and editing notes is only available online."
         },
         "search": {

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -80,7 +80,7 @@
             "confirm_removal_body": "Esta acción no se puede deshacer.",
             "min_length_error": "Debe tener al menos {{min}} caracteres",
             "placeholder_text": "Empieza a escribir tu nota…",
-            "project_instructions": "Nota destacada",
+            "pinned_note": "Nota destacada",
             "offline": "TK Creating and editing notes is only available online."
         },
         "search": {


### PR DESCRIPTION
## Description
Renames "project instructions" to "pinned note" in the code, to match what this is called in the app.

I did not changed Project.siteInstructions yet, as that requires a shared client update.

### Related Issues
Partially addresses #2625.