### PR TITLE
feat: offline soil id errors

### DIFF
--- a/dev-client/src/context/SoilIdMatchContext.tsx
+++ b/dev-client/src/context/SoilIdMatchContext.tsx
@@ -43,6 +43,7 @@ import {
 import {
   fetchLocationBasedSoilMatches,
   fetchSiteDataBasedSoilMatches,
+  flushDataCacheErrors,
   flushLocationCache,
 } from 'terraso-mobile-client/model/soilIdMatch/soilIdMatchSlice';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
@@ -82,7 +83,7 @@ export const SoilIdMatchContextProvider = ({
   const activeSites = useValueSet<string>();
 
   /* One-time cache flush for when the user first comes online */
-  useLocationCacheFlushing();
+  useCacheFlushing();
 
   /* Dispatch fetches as needed for the active inputs */
   useCoordFetching(useCoordsToFetch(activeCoords.values));
@@ -102,7 +103,7 @@ export const SoilIdMatchContextProvider = ({
   );
 };
 
-const useLocationCacheFlushing = () => {
+const useCacheFlushing = () => {
   const dispatch = useDispatch();
   const isOffline = useIsOffline();
   const [isFlushed, setIsFlushed] = useState(false);
@@ -114,6 +115,7 @@ const useLocationCacheFlushing = () => {
   useEffect(() => {
     if (!isOffline && !isFlushed) {
       dispatch(flushLocationCache());
+      dispatch(flushDataCacheErrors());
       setIsFlushed(true);
     }
   }, [dispatch, isOffline, isFlushed, setIsFlushed]);

--- a/dev-client/src/model/soilIdMatch/soilIdMatchSlice.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatchSlice.ts
@@ -24,6 +24,7 @@ import {
   CoordsKey,
   coordsKey,
   dataEntryForStatus,
+  flushErrorEntries,
   locationEntryForStatus,
   SoilIdDataEntry,
   SoilIdLocationEntry,
@@ -54,6 +55,9 @@ const soilIdMatchSlice = createSlice({
   reducers: {
     flushLocationCache: state => {
       state.locationBasedMatches = {};
+    },
+    flushDataCacheErrors: state => {
+      flushErrorEntries(state.siteDataBasedMatches);
     },
   },
   extraReducers: builder => {
@@ -102,7 +106,8 @@ const soilIdMatchSlice = createSlice({
   },
 });
 
-export const {flushLocationCache} = soilIdMatchSlice.actions;
+export const {flushLocationCache, flushDataCacheErrors} =
+  soilIdMatchSlice.actions;
 
 export const fetchLocationBasedSoilMatches = createAsyncThunk(
   'soilId/fetchLocationBasedSoilMatches',

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
@@ -19,9 +19,24 @@ import {
   coordsKey,
   dataEntryForMatches,
   dataEntryForStatus,
+  flushErrorEntries,
+  isErrorStatus,
   locationEntryForMatches,
   locationEntryForStatus,
 } from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
+
+describe('isErrorStatus', () => {
+  test('identifies errors', () => {
+    expect(isErrorStatus('error')).toBeTruthy();
+    expect(isErrorStatus('ALGORITHM_FAILURE')).toBeTruthy();
+    expect(isErrorStatus('DATA_UNAVAILABLE')).toBeTruthy();
+  });
+
+  test('identifies non-errors', () => {
+    expect(isErrorStatus('loading')).toBeFalsy();
+    expect(isErrorStatus('ready')).toBeFalsy();
+  });
+});
 
 describe('coordsKey', () => {
   test('produces keys for coords', () => {
@@ -70,5 +85,22 @@ describe('dataEntryForMatches', () => {
       input: 'input',
       matches: ['match'],
     });
+  });
+});
+
+describe('flushErrorEntries', () => {
+  test('removes entries with error statuses', () => {
+    const coords = {latitude: 1, longitude: 2};
+    const entries = {
+      a: locationEntryForStatus(coords, 'loading'),
+      b: locationEntryForStatus(coords, 'ready'),
+      c: locationEntryForStatus(coords, 'error'),
+      d: locationEntryForStatus(coords, 'ALGORITHM_FAILURE'),
+      e: locationEntryForStatus(coords, 'DATA_UNAVAILABLE'),
+    };
+
+    flushErrorEntries(entries);
+
+    expect(Object.keys(entries).sort()).toEqual(['a', 'b']);
   });
 });

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.ts
@@ -42,6 +42,10 @@ export type SoilIdResults = {
   dataBasedMatches: DataBasedSoilMatch[];
 };
 
+export const isErrorStatus = (status: SoilIdStatus): boolean => {
+  return status !== 'loading' && status !== 'ready';
+};
+
 export const coordsKey = (coords: Coords): CoordsKey => {
   return `(${coords.longitude}, ${coords.latitude})`;
 };
@@ -88,4 +92,16 @@ export const dataEntryForMatches = (
     status: 'ready',
     matches: matches,
   };
+};
+
+export const flushErrorEntries = (
+  entries:
+    | Record<string, SoilIdLocationEntry>
+    | Record<string, SoilIdDataEntry>,
+) => {
+  for (const id of Object.keys(entries)) {
+    if (isErrorStatus(entries[id].status)) {
+      delete entries[id];
+    }
+  }
 };


### PR DESCRIPTION
## Description

Flush any data-based matches which have error statuses when the app first enters online mode.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
[#1179](https://github.com/techmatters/terraso-product/issues/1179)

### Verification steps

Simulate a soil ID error when loading data-based matches (a site at a coordinate with no soilweb data, for example). Restart the application and verify that it attempts to reload the data when the user views that site again.