### PR TITLE
feat: Make site/project/note data required for relevant screens

### DIFF
--- a/dev-client/__tests__/integration/RestrictByRequirements.test.tsx
+++ b/dev-client/__tests__/integration/RestrictByRequirements.test.tsx
@@ -99,4 +99,23 @@ describe('RestrictByRequrements', () => {
     expect(queryByText('Hello world')).toBeNull();
     expect(thingsDone).toEqual('null');
   });
+
+  test('renders children and triggers no action when required data exists, even if it is a boolean equal to false', () => {
+    let thingsDone = '';
+    const requirements = [
+      {
+        data: false,
+        doIfMissing: () => (thingsDone += 'false'),
+      },
+    ];
+
+    const {queryByText} = render(
+      <RestrictByRequirements requirements={requirements}>
+        {() => <Text>Hello world</Text>}
+      </RestrictByRequirements>,
+    );
+
+    expect(queryByText('Hello world')).toBeTruthy();
+    expect(thingsDone).toEqual('');
+  });
 });

--- a/dev-client/__tests__/integration/ScreenDataRequirements.test.tsx
+++ b/dev-client/__tests__/integration/ScreenDataRequirements.test.tsx
@@ -19,9 +19,9 @@ import {Text} from 'react-native';
 
 import {render} from '@testing/integration/utils';
 
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 
-describe('RestrictByRequrements', () => {
+describe('ScreenDataRequirements', () => {
   test('renders children and triggers no actions when required data exists', () => {
     let thingsDone = '';
     const requirements = [
@@ -37,9 +37,9 @@ describe('RestrictByRequrements', () => {
     ];
 
     const {queryByText} = render(
-      <RestrictByRequirements requirements={requirements}>
+      <ScreenDataRequirements requirements={requirements}>
         {() => <Text>Hello world</Text>}
-      </RestrictByRequirements>,
+      </ScreenDataRequirements>,
     );
 
     expect(queryByText('Hello world')).toBeTruthy();
@@ -64,9 +64,9 @@ describe('RestrictByRequrements', () => {
     ];
 
     const {queryByText} = render(
-      <RestrictByRequirements requirements={requirements}>
+      <ScreenDataRequirements requirements={requirements}>
         {() => <Text>Hello world</Text>}
-      </RestrictByRequirements>,
+      </ScreenDataRequirements>,
     );
 
     expect(queryByText('Hello world')).toBeNull();
@@ -91,9 +91,9 @@ describe('RestrictByRequrements', () => {
     ];
 
     const {queryByText} = render(
-      <RestrictByRequirements requirements={requirements}>
+      <ScreenDataRequirements requirements={requirements}>
         {() => <Text>Hello world</Text>}
-      </RestrictByRequirements>,
+      </ScreenDataRequirements>,
     );
 
     expect(queryByText('Hello world')).toBeNull();
@@ -110,9 +110,9 @@ describe('RestrictByRequrements', () => {
     ];
 
     const {queryByText} = render(
-      <RestrictByRequirements requirements={requirements}>
+      <ScreenDataRequirements requirements={requirements}>
         {() => <Text>Hello world</Text>}
-      </RestrictByRequirements>,
+      </ScreenDataRequirements>,
     );
 
     expect(queryByText('Hello world')).toBeTruthy();

--- a/dev-client/src/components/dataRequirements/RestrictByRequirements.tsx
+++ b/dev-client/src/components/dataRequirements/RestrictByRequirements.tsx
@@ -49,6 +49,11 @@ type Props = {
   children: () => React.ReactNode;
 };
 
+/*
+ * This is intended to wrap components (mostly screens as of 2024-12) so they only render
+ * if required data is truthy. This prevents screens from breaking if, for example, a pull
+ * happens that deletes data that is required to view the screen.
+ */
 export const RestrictByRequirements = ({requirements, children}: Props) => {
   const requiredDataExists = useRequiredData(requirements);
 

--- a/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
+++ b/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useEffect} from 'react';
+import {useEffect, useMemo} from 'react';
 
 type Requirement = {
   data: any;
@@ -56,9 +56,24 @@ type Props = {
  */
 export const ScreenDataRequirements = ({requirements, children}: Props) => {
   const requiredDataExists = useRequiredData(requirements);
-
   if (!requiredDataExists) {
     return null;
   }
   return <>{children()}</>;
+};
+
+/*
+ * I believe this is not strictly necessary; if a screen is re-rendering, the ScreenDataRequirements component
+ * will re-render regardless of if its props change (unless memoized)
+ */
+export const useMemoizedRequirements = (
+  requirementsAsNewObj: Requirement[],
+) => {
+  const deps = requirementsAsNewObj.flatMap(r => [r.data, r.doIfMissing]);
+  return useMemo(() => {
+    return requirementsAsNewObj;
+    // The linter doesn't like the dynamic dependency list, but the useMemo should only depend on the values of the required data
+    // and missing data handlers. If it depends on the list object, it's re-created every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
 };

--- a/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
+++ b/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
@@ -54,7 +54,7 @@ type Props = {
  * if required data is truthy. This prevents screens from breaking if, for example, a pull
  * happens that deletes data that is required to view the screen.
  */
-export const RestrictByRequirements = ({requirements, children}: Props) => {
+export const ScreenDataRequirements = ({requirements, children}: Props) => {
   const requiredDataExists = useRequiredData(requirements);
 
   if (!requiredDataExists) {

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -21,7 +21,7 @@ import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 
-export const useHandleMissingSite = () => {
+export const useHandleMissingSiteOrProject = () => {
   const navigation = useNavigation();
   const syncNotifications = useSyncNotificationContext();
 

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -21,7 +21,7 @@ import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 
-export const useHandleMissingSiteOrProject = () => {
+export const useNavToBottomTabsAndShowSyncError = () => {
   const navigation = useNavigation();
   const syncNotifications = useSyncNotificationContext();
 
@@ -33,7 +33,7 @@ export const useHandleMissingSiteOrProject = () => {
   }, [navigation, syncNotifications]);
 };
 
-export const usePopNavigationAndSyncError = () => {
+export const usePopNavigationAndShowSyncError = () => {
   const navigation = useNavigation();
   const syncNotifications = useSyncNotificationContext();
 

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -32,3 +32,15 @@ export const useHandleMissingSiteOrProject = () => {
     }
   }, [navigation, syncNotifications]);
 };
+
+export const usePopNavigationAndSyncError = () => {
+  const navigation = useNavigation();
+  const syncNotifications = useSyncNotificationContext();
+
+  return useCallback(() => {
+    navigation.pop();
+    if (isFlagEnabled('FF_offline')) {
+      syncNotifications.showError();
+    }
+  }, [navigation, syncNotifications]);
+};

--- a/dev-client/src/navigation/screenDefinitions.tsx
+++ b/dev-client/src/navigation/screenDefinitions.tsx
@@ -28,9 +28,10 @@ import {CreateProjectScreen} from 'terraso-mobile-client/screens/CreateProjectSc
 import {CreateSiteScreen} from 'terraso-mobile-client/screens/CreateSiteScreen/CreateSiteScreen';
 import {DeleteAccountScreen} from 'terraso-mobile-client/screens/DeleteAccountScreen/DeleteAccountScreen';
 import {EditPinnedNoteScreen} from 'terraso-mobile-client/screens/EditPinnedNoteScreen';
-import {LocationSoilIdScreen} from 'terraso-mobile-client/screens/LocationScreens/LocationSoilIdScreen';
+import {SiteLocationSoilIdScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteLocationSoilIdScreen';
 import {SiteTabsScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteTabsScreen';
 import {TemporaryLocationScreen} from 'terraso-mobile-client/screens/LocationScreens/TemporaryLocationScreen';
+import {TemporaryLocationSoilIdScreen} from 'terraso-mobile-client/screens/LocationScreens/TemporaryLocationSoilIdScreen';
 import {LoginScreen} from 'terraso-mobile-client/screens/LoginScreen';
 import {ManageTeamMemberScreen} from 'terraso-mobile-client/screens/ManageTeamMemberScreen';
 import {ProjectListScreen} from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
@@ -59,6 +60,8 @@ import {TextureScreen} from 'terraso-mobile-client/screens/SoilScreen/TextureScr
 import {UserSettingsScreen} from 'terraso-mobile-client/screens/UserSettingsScreen/UserSettingsScreen';
 import {WelcomeScreen} from 'terraso-mobile-client/screens/WelcomeScreen';
 
+SiteLocationSoilIdScreen;
+
 export const bottomTabScreensDefinitions = {
   PROJECT_LIST: ProjectListScreen,
   SITES: SitesScreen,
@@ -75,7 +78,8 @@ export const screenDefinitions = {
   CREATE_SITE: CreateSiteScreen,
   TEMP_LOCATION: TemporaryLocationScreen,
   SITE_TABS: SiteTabsScreen,
-  LOCATION_SOIL_ID: LocationSoilIdScreen,
+  SITE_LOCATION_SOIL_ID: SiteLocationSoilIdScreen,
+  TEMPORARY_LOCATION_SOIL_ID: TemporaryLocationSoilIdScreen,
   SITE_SETTINGS: SiteSettingsScreen,
   SITE_TEAM_SETTINGS: SiteTeamSettingsScreen,
   ADD_USER_PROJECT: AddUserToProjectScreen,

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -24,15 +24,16 @@ import {Button} from 'native-base';
 import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useHandleMissingSiteOrProject,
+  usePopNavigationAndSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
-import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {addUserToProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {TabRoutes} from 'terraso-mobile-client/navigation/constants';
@@ -51,7 +52,6 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigation = useNavigation();
-  const syncNotifications = useSyncNotificationContext();
 
   const project = useSelector(state => state.project.projects[projectId]);
   const user = useSelector(state => state.account.users[userId]);
@@ -75,12 +75,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
   const handleMissingProject = useHandleMissingSiteOrProject();
-  const handleMissingUser = useCallback(() => {
-    navigation.pop();
-    if (isFlagEnabled('FF_offline')) {
-      syncNotifications.showError();
-    }
-  }, [navigation, syncNotifications]);
+  const handleMissingUser = usePopNavigationAndSyncError();
   const requirements = [
     {data: project, doIfMissing: handleMissingProject},
     {data: user, doIfMissing: handleMissingUser},

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -28,7 +28,10 @@ import {
   useNavToBottomTabsAndShowSyncError,
   usePopNavigationAndShowSyncError,
 } from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -76,10 +79,10 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();
-  const requirements = [
+  const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
     {data: user, doIfMissing: handleMissingUser},
-  ];
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -25,8 +25,8 @@ import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {
-  useHandleMissingSiteOrProject,
-  usePopNavigationAndSyncError,
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
 } from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
@@ -74,8 +74,8 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
-  const handleMissingUser = usePopNavigationAndSyncError();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
+  const handleMissingUser = usePopNavigationAndShowSyncError();
   const requirements = [
     {data: project, doIfMissing: handleMissingProject},
     {data: user, doIfMissing: handleMissingUser},

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -24,11 +24,15 @@ import {Button} from 'native-base';
 import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   Box,
   Column,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
+import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {addUserToProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {TabRoutes} from 'terraso-mobile-client/navigation/constants';
@@ -47,6 +51,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigation = useNavigation();
+  const syncNotifications = useSyncNotificationContext();
 
   const project = useSelector(state => state.project.projects[projectId]);
   const user = useSelector(state => state.account.users[userId]);
@@ -69,48 +74,64 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
+  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingUser = useCallback(() => {
+    navigation.pop();
+    if (isFlagEnabled('FF_offline')) {
+      syncNotifications.showError();
+    }
+  }, [navigation, syncNotifications]);
+  const requirements = [
+    {data: project, doIfMissing: handleMissingProject},
+    {data: user, doIfMissing: handleMissingUser},
+  ];
+
   return (
-    <ScreenScaffold AppBar={<AppBar title={project?.name} />}>
-      <ScreenContentSection title={t('projects.add_user.heading')}>
-        <Column>
-          <Box ml="md" my="lg">
-            <MinimalUserDisplay user={user} />
-          </Box>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold AppBar={<AppBar title={project?.name} />}>
+          <ScreenContentSection title={t('projects.add_user.heading')}>
+            <Column>
+              <Box ml="md" my="lg">
+                <MinimalUserDisplay user={user} />
+              </Box>
 
-          <ProjectRoleRadioBlock
-            onChange={setSelectedRole}
-            selectedRole={selectedRole}
-          />
+              <ProjectRoleRadioBlock
+                onChange={setSelectedRole}
+                selectedRole={selectedRole}
+              />
 
-          <Row
-            flex={0}
-            justifyContent="flex-end"
-            alignItems="center"
-            space="12px"
-            pt="md">
-            <Button
-              onPress={onCancel}
-              size="lg"
-              variant="outline"
-              borderColor="action.active"
-              _text={{textTransform: 'uppercase', color: 'action.active'}}>
-              {t('general.cancel')}
-            </Button>
-            {/* FYI: The 1px border is to visually match the size of the outline
+              <Row
+                flex={0}
+                justifyContent="flex-end"
+                alignItems="center"
+                space="12px"
+                pt="md">
+                <Button
+                  onPress={onCancel}
+                  size="lg"
+                  variant="outline"
+                  borderColor="action.active"
+                  _text={{textTransform: 'uppercase', color: 'action.active'}}>
+                  {t('general.cancel')}
+                </Button>
+                {/* FYI: The 1px border is to visually match the size of the outline
             variant, which appears to be 1px bigger than the solid variant due
             to its border. */}
-            <Button
-              borderWidth="1px"
-              borderColor="primary.main"
-              onPress={addUser}
-              size="lg"
-              variant="solid"
-              _text={{textTransform: 'uppercase'}}>
-              {t('general.add')}
-            </Button>
-          </Row>
-        </Column>
-      </ScreenContentSection>
-    </ScreenScaffold>
+                <Button
+                  borderWidth="1px"
+                  borderColor="primary.main"
+                  onPress={addUser}
+                  size="lg"
+                  variant="solid"
+                  _text={{textTransform: 'uppercase'}}>
+                  {t('general.add')}
+                </Button>
+              </Row>
+            </Column>
+          </ScreenContentSection>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -25,7 +25,7 @@ import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -87,7 +87,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
   ];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold AppBar={<AppBar title={project?.name} />}>
           <ScreenContentSection title={t('projects.add_user.heading')}>
@@ -132,6 +132,6 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
           </ScreenContentSection>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -18,7 +18,7 @@
 import {useTranslation} from 'react-i18next';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -40,7 +40,7 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
   // wanting to add multiple users at the same time.
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -19,7 +19,7 @@ import {useTranslation} from 'react-i18next';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AddTeamMemberForm} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/AddTeamMemberForm';
@@ -44,7 +44,7 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold AppBar={<AppBar title={project.name} />}>
           <ScreenContentSection title={t('projects.add_user.heading')}>
@@ -55,6 +55,6 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
           </ScreenContentSection>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -18,11 +18,14 @@
 import {useTranslation} from 'react-i18next';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AddTeamMemberForm} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/AddTeamMemberForm';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
+import {selectProject} from 'terraso-mobile-client/store/selectors';
 
 type Props = {
   projectId: string;
@@ -31,22 +34,27 @@ type Props = {
 export const AddUserToProjectScreen = ({projectId}: Props) => {
   const {t} = useTranslation();
 
-  const projectName = useSelector(
-    state => state.project.projects[projectId]?.name,
-  );
+  const project = useSelector(selectProject(projectId));
 
   // FYI: There was previously a mechanism to enter emails individually, but set roles at the same time.
   // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
   // wanting to add multiple users at the same time.
 
+  const handleMissingProject = useHandleMissingSiteOrProject();
+  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+
   return (
-    <ScreenScaffold AppBar={<AppBar title={projectName} />}>
-      <ScreenContentSection title={t('projects.add_user.heading')}>
-        <Text variant="body1">{t('projects.add_user.help_text')}</Text>
-        <Box mt="md">
-          <AddTeamMemberForm projectId={projectId} />
-        </Box>
-      </ScreenContentSection>
-    </ScreenScaffold>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold AppBar={<AppBar title={project.name} />}>
+          <ScreenContentSection title={t('projects.add_user.heading')}>
+            <Text variant="body1">{t('projects.add_user.help_text')}</Text>
+            <Box mt="md">
+              <AddTeamMemberForm projectId={projectId} />
+            </Box>
+          </ScreenContentSection>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -19,7 +19,10 @@ import {useTranslation} from 'react-i18next';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AddTeamMemberForm} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/AddTeamMemberForm';
@@ -41,7 +44,9 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   // wanting to add multiple users at the same time.
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/CreateSiteScreen.tsx
@@ -22,7 +22,6 @@ import {Coords} from 'terraso-client-shared/types';
 
 import {ScreenCloseButton} from 'terraso-mobile-client/components/buttons/icons/appBar/ScreenCloseButton';
 import {addSite} from 'terraso-mobile-client/model/site/siteGlobalReducer';
-import {fetchSitesForProject} from 'terraso-mobile-client/model/site/siteSlice';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {CreateSiteView} from 'terraso-mobile-client/screens/CreateSiteScreen/components/CreateSiteView';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -31,9 +30,6 @@ import {useDispatch} from 'terraso-mobile-client/store';
 type Props =
   | {
       coords: Coords;
-    }
-  | {
-      projectId: string;
     }
   | {
       elevation: number;
@@ -52,9 +48,6 @@ export const CreateSiteScreen = (props: Props = {}) => {
         console.error(result.payload.parsedErrors);
         return;
       }
-      if (input.projectId) {
-        dispatch(fetchSitesForProject(input.projectId));
-      }
       return result.payload;
     },
     [dispatch],
@@ -66,7 +59,6 @@ export const CreateSiteScreen = (props: Props = {}) => {
       AppBar={<AppBar LeftButton={<ScreenCloseButton />} />}>
       <CreateSiteView
         createSiteCallback={createSiteCallback}
-        defaultProjectId={'projectId' in props ? props.projectId : undefined}
         sitePin={'coords' in props ? props.coords : undefined}
         elevation={'elevation' in props ? props.elevation : undefined}
       />

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -21,6 +21,8 @@ import {Keyboard} from 'react-native';
 
 import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   Box,
   Column,
@@ -67,23 +69,30 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
     await handleUpdateProject({content: ''});
   };
 
+  const handleMissingProject = useHandleMissingSiteOrProject();
+  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+
   return (
-    <ScreenFormWrapper
-      ref={formWrapperRef}
-      initialValues={{content: project.siteInstructions || ''}}
-      onSubmit={handleUpdateProject}
-      onDelete={handleDelete}
-      isSubmitting={isSubmitting}>
-      {formikProps => (
-        <Column pt={10} pl={5} pr={5} pb={10} flex={1}>
-          <Heading variant="h6" pb={7}>
-            {t('projects.inputs.instructions.title')}
-          </Heading>
-          <Box flexGrow={1}>
-            <SiteNoteForm content={formikProps.values.content || ''} />
-          </Box>
-        </Column>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenFormWrapper
+          ref={formWrapperRef}
+          initialValues={{content: project.siteInstructions || ''}}
+          onSubmit={handleUpdateProject}
+          onDelete={handleDelete}
+          isSubmitting={isSubmitting}>
+          {formikProps => (
+            <Column pt={10} pl={5} pr={5} pb={10} flex={1}>
+              <Heading variant="h6" pb={7}>
+                {t('projects.inputs.instructions.title')}
+              </Heading>
+              <Box flexGrow={1}>
+                <SiteNoteForm content={formikProps.values.content || ''} />
+              </Box>
+            </Column>
+          )}
+        </ScreenFormWrapper>
       )}
-    </ScreenFormWrapper>
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -22,7 +22,10 @@ import {Keyboard} from 'react-native';
 import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -70,7 +73,9 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
   };
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -22,7 +22,7 @@ import {Keyboard} from 'react-native';
 import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -73,7 +73,7 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenFormWrapper
           ref={formWrapperRef}
@@ -93,6 +93,6 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
           )}
         </ScreenFormWrapper>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -51,6 +51,7 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
     try {
       const projectInput: ProjectUpdateMutationInput = {
         id: project.id,
+        // FYI: "pinned notes" historically have been called "site instructions" or "project instructions"
         siteInstructions: content,
       };
       await dispatch(updateProject(projectInput));

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -21,7 +21,7 @@ import {Keyboard} from 'react-native';
 
 import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
@@ -69,7 +69,7 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
     await handleUpdateProject({content: ''});
   };
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -79,7 +79,11 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
   );
 
   const onExploreDataPress = useCallback(() => {
-    navigation.navigate('LOCATION_SOIL_ID', {siteId: site?.id, coords});
+    if (site?.id) {
+      navigation.navigate('SITE_LOCATION_SOIL_ID', {siteId: site.id, coords});
+    } else {
+      navigation.navigate('TEMPORARY_LOCATION_SOIL_ID', {coords});
+    }
   }, [navigation, site, coords]);
 
   const onSitePrivacyChanged = useCallback(

--- a/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
@@ -20,6 +20,8 @@ import {ScrollView} from 'react-native-gesture-handler';
 
 import {Coords} from 'terraso-client-shared/types';
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -45,29 +47,42 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
     isSite ? selectSite(siteId)(state) : undefined,
   );
 
+  const siteIsRequiredButMissing = isSite && !site;
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [
+    {
+      data: siteIsRequiredButMissing ? undefined : true,
+      doIfMissing: handleMissingSite,
+    },
+  ];
+
   return (
-    <ScreenScaffold
-      AppBar={
-        <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
-      }>
-      <ScrollView>
-        {isSite ? (
-          <SoilIdSelectionSection siteId={siteId} coords={coords} />
-        ) : (
-          <></>
-        )}
-        <SoilIdDescriptionSection siteId={siteId} coords={coords} />
-        <SoilIdMatchesSection siteId={siteId} coords={coords} />
-        {isSite ? (
-          <SiteRoleContextProvider siteId={siteId}>
-            <SiteDataSection siteId={siteId} />
-          </SiteRoleContextProvider>
-        ) : (
-          <Box paddingVertical="md">
-            <CreateSiteButton coords={coords} />
-          </Box>
-        )}
-      </ScrollView>
-    </ScreenScaffold>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold
+          AppBar={
+            <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
+          }>
+          <ScrollView>
+            {isSite ? (
+              <SoilIdSelectionSection siteId={siteId} coords={coords} />
+            ) : (
+              <></>
+            )}
+            <SoilIdDescriptionSection siteId={siteId} coords={coords} />
+            <SoilIdMatchesSection siteId={siteId} coords={coords} />
+            {isSite ? (
+              <SiteRoleContextProvider siteId={siteId}>
+                <SiteDataSection siteId={siteId} />
+              </SiteRoleContextProvider>
+            ) : (
+              <Box paddingVertical="md">
+                <CreateSiteButton coords={coords} />
+              </Box>
+            )}
+          </ScrollView>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationSoilIdScreen.tsx
@@ -21,7 +21,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Coords} from 'terraso-client-shared/types';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -57,7 +57,7 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
   ];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           AppBar={
@@ -83,6 +83,6 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
           </ScrollView>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
@@ -18,7 +18,7 @@
 import {Coords} from 'terraso-client-shared/types';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
 import {useSelector} from 'terraso-mobile-client/store';
 import {selectSite} from 'terraso-mobile-client/store/selectors';
@@ -33,7 +33,7 @@ export const SiteDashboardScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <LocationDashboardContent
           site={site}
@@ -41,6 +41,6 @@ export const SiteDashboardScreen = ({siteId}: Props) => {
           elevation={site?.elevation ?? undefined}
         />
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
@@ -17,20 +17,30 @@
 
 import {Coords} from 'terraso-client-shared/types';
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
 import {useSelector} from 'terraso-mobile-client/store';
+import {selectSite} from 'terraso-mobile-client/store/selectors';
 
 type Props = {
   siteId: string;
 };
 export const SiteDashboardScreen = ({siteId}: Props) => {
-  const site = useSelector(state => state.site.sites[siteId]);
+  const site = useSelector(selectSite(siteId));
+
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <LocationDashboardContent
-      site={site}
-      coords={site as Coords}
-      elevation={site?.elevation ?? undefined}
-    />
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <LocationDashboardContent
+          site={site}
+          coords={site as Coords}
+          elevation={site?.elevation ?? undefined}
+        />
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
@@ -17,7 +17,7 @@
 
 import {Coords} from 'terraso-client-shared/types';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
 import {useSelector} from 'terraso-mobile-client/store';
@@ -29,7 +29,7 @@ type Props = {
 export const SiteDashboardScreen = ({siteId}: Props) => {
   const site = useSelector(selectSite(siteId));
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteDashboardScreen.tsx
@@ -18,7 +18,10 @@
 import {Coords} from 'terraso-client-shared/types';
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {LocationDashboardContent} from 'terraso-mobile-client/screens/LocationScreens/LocationDashboardContent';
 import {useSelector} from 'terraso-mobile-client/store';
 import {selectSite} from 'terraso-mobile-client/store/selectors';
@@ -30,7 +33,9 @@ export const SiteDashboardScreen = ({siteId}: Props) => {
   const site = useSelector(selectSite(siteId));
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/LocationScreens/SiteLocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteLocationSoilIdScreen.tsx
@@ -21,7 +21,10 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Coords} from 'terraso-client-shared/types';
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {SiteDataSection} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SiteDataSection';
@@ -43,7 +46,9 @@ export const SiteLocationSoilIdScreen = ({siteId, coords}: SiteProps) => {
   const site = useSelector(state => selectSite(siteId)(state));
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/LocationScreens/SiteLocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteLocationSoilIdScreen.tsx
@@ -22,10 +22,8 @@ import {Coords} from 'terraso-client-shared/types';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
-import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
-import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
 import {SiteDataSection} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SiteDataSection';
 import {SoilIdDescriptionSection} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilIdDescriptionSection';
 import {SoilIdMatchesSection} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilIdMatchesSection';
@@ -34,27 +32,18 @@ import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
 import {selectSite} from 'terraso-mobile-client/store/selectors';
 
-type Props = {
-  siteId?: string;
+type SiteProps = {
+  siteId: string;
   coords: Coords;
 };
 
-export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
+export const SiteLocationSoilIdScreen = ({siteId, coords}: SiteProps) => {
   const {t} = useTranslation();
 
-  const isSite = !!siteId;
-  const site = useSelector(state =>
-    isSite ? selectSite(siteId)(state) : undefined,
-  );
+  const site = useSelector(state => selectSite(siteId)(state));
 
-  const siteIsRequiredButMissing = isSite && !site;
   const handleMissingSite = useHandleMissingSiteOrProject();
-  const requirements = [
-    {
-      data: siteIsRequiredButMissing ? undefined : true,
-      doIfMissing: handleMissingSite,
-    },
-  ];
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
     <ScreenDataRequirements requirements={requirements}>
@@ -64,22 +53,13 @@ export const LocationSoilIdScreen = ({siteId, coords}: Props) => {
             <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
           }>
           <ScrollView>
-            {isSite ? (
-              <SoilIdSelectionSection siteId={siteId} coords={coords} />
-            ) : (
-              <></>
-            )}
+            <SoilIdSelectionSection siteId={siteId} coords={coords} />
+
             <SoilIdDescriptionSection siteId={siteId} coords={coords} />
             <SoilIdMatchesSection siteId={siteId} coords={coords} />
-            {isSite ? (
-              <SiteRoleContextProvider siteId={siteId}>
-                <SiteDataSection siteId={siteId} />
-              </SiteRoleContextProvider>
-            ) : (
-              <Box paddingVertical="md">
-                <CreateSiteButton coords={coords} />
-              </Box>
-            )}
+            <SiteRoleContextProvider siteId={siteId}>
+              <SiteDataSection siteId={siteId} />
+            </SiteRoleContextProvider>
           </ScrollView>
         </ScreenScaffold>
       )}

--- a/dev-client/src/screens/LocationScreens/SiteLocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteLocationSoilIdScreen.tsx
@@ -20,7 +20,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 
 import {Coords} from 'terraso-client-shared/types';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -42,7 +42,7 @@ export const SiteLocationSoilIdScreen = ({siteId, coords}: SiteProps) => {
 
   const site = useSelector(state => selectSite(siteId)(state));
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
@@ -20,7 +20,7 @@ import {useTranslation} from 'react-i18next';
 
 import {AppBarIconButton} from 'terraso-mobile-client/components/buttons/icons/appBar/AppBarIconButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {isSiteManager} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -70,7 +70,7 @@ export const SiteTabsScreen = (props: Props) => {
   }, [siteId, navigation, userRole]);
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           AppBar={
@@ -84,6 +84,6 @@ export const SiteTabsScreen = (props: Props) => {
           </SiteRoleContextProvider>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
@@ -19,7 +19,7 @@ import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {AppBarIconButton} from 'terraso-mobile-client/components/buttons/icons/appBar/AppBarIconButton';
-import {useHandleMissingSite} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {isSiteManager} from 'terraso-mobile-client/model/permissions/permissions';
@@ -51,7 +51,7 @@ export const SiteTabsScreen = (props: Props) => {
   const site = useSelector(state => selectSite(siteId)(state));
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
 
-  const handleMissingSite = useHandleMissingSite();
+  const handleMissingSite = useHandleMissingSiteOrProject();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   const appBarRightButton = useMemo(() => {

--- a/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
@@ -19,7 +19,7 @@ import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {AppBarIconButton} from 'terraso-mobile-client/components/buttons/icons/appBar/AppBarIconButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {isSiteManager} from 'terraso-mobile-client/model/permissions/permissions';
@@ -51,7 +51,7 @@ export const SiteTabsScreen = (props: Props) => {
   const site = useSelector(state => selectSite(siteId)(state));
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   const appBarRightButton = useMemo(() => {

--- a/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/SiteTabsScreen.tsx
@@ -20,7 +20,10 @@ import {useTranslation} from 'react-i18next';
 
 import {AppBarIconButton} from 'terraso-mobile-client/components/buttons/icons/appBar/AppBarIconButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {isSiteManager} from 'terraso-mobile-client/model/permissions/permissions';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -52,7 +55,9 @@ export const SiteTabsScreen = (props: Props) => {
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   const appBarRightButton = useMemo(() => {
     // display nothing if user does not own the site / is not manager

--- a/dev-client/src/screens/LocationScreens/TemporaryLocationSoilIdScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/TemporaryLocationSoilIdScreen.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {ScrollView} from 'react-native-gesture-handler';
+
+import {Coords} from 'terraso-client-shared/types';
+
+import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
+import {CreateSiteButton} from 'terraso-mobile-client/screens/LocationScreens/components/CreateSiteButton';
+import {SoilIdDescriptionSection} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilIdDescriptionSection';
+import {SoilIdMatchesSection} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilIdMatchesSection';
+import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
+
+type TempLocationProps = {
+  coords: Coords;
+};
+
+export const TemporaryLocationSoilIdScreen = ({coords}: TempLocationProps) => {
+  const {t} = useTranslation();
+
+  return (
+    <ScreenScaffold
+      AppBar={<AppBar title={t('site.dashboard.default_title')} />}>
+      <ScrollView>
+        <SoilIdDescriptionSection coords={coords} />
+        <SoilIdMatchesSection coords={coords} />
+        <Box paddingVertical="md">
+          <CreateSiteButton coords={coords} />
+        </Box>
+      </ScrollView>
+    </ScreenScaffold>
+  );
+};

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -25,7 +25,10 @@ import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 
 import {ScreenCloseButton} from 'terraso-mobile-client/components/buttons/icons/appBar/ScreenCloseButton';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useHandleMissingSiteOrProject,
+  usePopNavigationAndSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
@@ -34,8 +37,6 @@ import {
   Column,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
-import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {
   deleteUserFromProject,
   updateUserRole,
@@ -61,7 +62,6 @@ export const ManageTeamMemberScreen = ({
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigation = useNavigation();
-  const syncNotifications = useSyncNotificationContext();
 
   const project = useSelector(state => state.project.projects[projectId]);
   const user = useSelector(state => state.account.users[userId]);
@@ -87,12 +87,7 @@ export const ManageTeamMemberScreen = ({
   }, [dispatch, projectId, userId, selectedRole, navigation]);
 
   const handleMissingProject = useHandleMissingSiteOrProject();
-  const handleMissingUser = useCallback(() => {
-    navigation.pop();
-    if (isFlagEnabled('FF_offline')) {
-      syncNotifications.showError();
-    }
-  }, [navigation, syncNotifications]);
+  const handleMissingUser = usePopNavigationAndSyncError();
   const requirements = [
     {data: project, doIfMissing: handleMissingProject},
     {data: user, doIfMissing: handleMissingUser},

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -26,7 +26,7 @@ import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 import {ScreenCloseButton} from 'terraso-mobile-client/components/buttons/icons/appBar/ScreenCloseButton';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {
@@ -99,7 +99,7 @@ export const ManageTeamMemberScreen = ({
   ];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           AppBar={
@@ -148,7 +148,7 @@ export const ManageTeamMemberScreen = ({
           </ScreenContentSection>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };
 

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -29,7 +29,10 @@ import {
   useNavToBottomTabsAndShowSyncError,
   usePopNavigationAndShowSyncError,
 } from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {
@@ -88,10 +91,10 @@ export const ManageTeamMemberScreen = ({
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();
-  const requirements = [
+  const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
     {data: user, doIfMissing: handleMissingUser},
-  ];
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -26,8 +26,8 @@ import {ProjectRole} from 'terraso-client-shared/project/projectTypes';
 import {ScreenCloseButton} from 'terraso-mobile-client/components/buttons/icons/appBar/ScreenCloseButton';
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {
-  useHandleMissingSiteOrProject,
-  usePopNavigationAndSyncError,
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
 } from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
@@ -86,8 +86,8 @@ export const ManageTeamMemberScreen = ({
     navigation.pop();
   }, [dispatch, projectId, userId, selectedRole, navigation]);
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
-  const handleMissingUser = usePopNavigationAndSyncError();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
+  const handleMissingUser = usePopNavigationAndShowSyncError();
   const requirements = [
     {data: project, doIfMissing: handleMissingProject},
     {data: user, doIfMissing: handleMissingUser},

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -26,7 +26,7 @@ import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {DataPrivacyInfoButton} from 'terraso-mobile-client/components/content/info/privacy/DataPrivacyInfoButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   Box,
@@ -86,7 +86,7 @@ export const ProjectInputScreen = ({
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <Column height="full" backgroundColor="background.default">
           <ScrollView>
@@ -164,6 +164,6 @@ export const ProjectInputScreen = ({
           </RestrictByProjectRole>
         </Column>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -26,7 +26,10 @@ import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {DataPrivacyInfoButton} from 'terraso-mobile-client/components/content/info/privacy/DataPrivacyInfoButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   Box,
@@ -83,7 +86,9 @@ export const ProjectInputScreen = ({
   const allowEditing = useMemo(() => userRole === 'MANAGER', [userRole]);
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/ProjectInputScreen.tsx
@@ -25,7 +25,7 @@ import {Button, Fab} from 'native-base';
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {DataPrivacyInfoButton} from 'terraso-mobile-client/components/content/info/privacy/DataPrivacyInfoButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
@@ -82,7 +82,7 @@ export const ProjectInputScreen = ({
 
   const allowEditing = useMemo(() => userRole === 'MANAGER', [userRole]);
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
+++ b/dev-client/src/screens/ProjectListScreen/ProjectListScreen.tsx
@@ -41,20 +41,21 @@ import {OfflineMessageBox} from 'terraso-mobile-client/screens/LocationScreens/c
 import {ProjectList} from 'terraso-mobile-client/screens/ProjectListScreen/components/ProjectList';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
-import {selectProjectUserRolesMap} from 'terraso-mobile-client/store/selectors';
+import {
+  selectProjects,
+  selectProjectUserRolesMap,
+} from 'terraso-mobile-client/store/selectors';
 import {equals, searchText} from 'terraso-mobile-client/util';
 
 const SORT_OPTIONS = ['nameAsc', 'nameDesc', 'lastModAsc', 'lastModDesc'];
 
 export const ProjectListScreen = () => {
-  const allProjects = useSelector(state => state.project.projects);
+  const allProjects = useSelector(selectProjects);
   const activeProjects = useMemo(
     () => Object.values(allProjects).filter(project => !project.archived),
     [allProjects],
   );
-  const projectRoleLookup = useSelector(state =>
-    selectProjectUserRolesMap(state),
-  );
+  const projectRoleLookup = useSelector(selectProjectUserRolesMap);
 
   const {t} = useTranslation();
   const navigation = useNavigation();

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -25,7 +25,10 @@ import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/gr
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/restrictions/RestrictByRole';
@@ -69,7 +72,9 @@ export function ProjectSettingsScreen({
   const userRole = useProjectRoleContext();
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -25,7 +25,7 @@ import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/gr
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByProjectRole} from 'terraso-mobile-client/components/restrictions/RestrictByRole';
@@ -72,7 +72,7 @@ export function ProjectSettingsScreen({
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScrollView
           backgroundColor={theme.colors.primary.contrast}
@@ -106,7 +106,7 @@ export function ProjectSettingsScreen({
           </Column>
         </ScrollView>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 }
 

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -24,7 +24,7 @@ import {ScrollView} from 'native-base';
 import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Column} from 'terraso-mobile-client/components/NativeBaseAdapters';
@@ -68,7 +68,7 @@ export function ProjectSettingsScreen({
 
   const userRole = useProjectRoleContext();
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -30,7 +30,7 @@ import {normalizeText} from 'terraso-client-shared/utils';
 
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ListFilterModal,
   ListFilterProvider,
@@ -267,7 +267,7 @@ export function ProjectSitesScreen({
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <Column
           p={3}
@@ -294,7 +294,7 @@ export function ProjectSitesScreen({
           {!isEmpty && full}
         </Column>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 }
 

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -29,7 +29,7 @@ import {Site} from 'terraso-client-shared/site/siteTypes';
 import {normalizeText} from 'terraso-client-shared/utils';
 
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ListFilterModal,
@@ -263,7 +263,7 @@ export function ProjectSitesScreen({
   );
 
   const project = useSelector(selectProject(projectId));
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -30,7 +30,10 @@ import {normalizeText} from 'terraso-client-shared/utils';
 
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ListFilterModal,
   ListFilterProvider,
@@ -264,7 +267,9 @@ export function ProjectSitesScreen({
 
   const project = useSelector(selectProject(projectId));
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -29,6 +29,8 @@ import {Site} from 'terraso-client-shared/site/siteTypes';
 import {normalizeText} from 'terraso-client-shared/utils';
 
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   ListFilterModal,
   ListFilterProvider,
@@ -58,6 +60,7 @@ import {
 } from 'terraso-mobile-client/navigation/constants';
 import {RootStackScreenProps} from 'terraso-mobile-client/navigation/types';
 import {AppState, useDispatch, useSelector} from 'terraso-mobile-client/store';
+import {selectProject} from 'terraso-mobile-client/store/selectors';
 import {theme} from 'terraso-mobile-client/theme';
 import {searchText} from 'terraso-mobile-client/util';
 
@@ -259,31 +262,39 @@ export function ProjectSitesScreen({
     </ListFilterProvider>
   );
 
+  const project = useSelector(selectProject(projectId));
+  const handleMissingProject = useHandleMissingSiteOrProject();
+  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+
   return (
-    <Column
-      p={3}
-      pb={5}
-      space={3}
-      h="100%"
-      backgroundColor="background.tertiary">
-      {isEmpty && (
-        <>
-          <Text>{t('projects.sites.empty_viewer')}</Text>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <Column
+          p={3}
+          pb={5}
+          space={3}
+          h="100%"
+          backgroundColor="background.tertiary">
+          {isEmpty && (
+            <>
+              <Text>{t('projects.sites.empty_viewer')}</Text>
+              <RestrictByProjectRole role={PROJECT_EDITOR_ROLES}>
+                <Text>{t('projects.sites.empty_contributor')}</Text>
+              </RestrictByProjectRole>
+            </>
+          )}
           <RestrictByProjectRole role={PROJECT_EDITOR_ROLES}>
-            <Text>{t('projects.sites.empty_contributor')}</Text>
+            <Button
+              onPress={transferCallback}
+              alignSelf="flex-start"
+              _text={{textTransform: 'uppercase'}}>
+              {t('projects.sites.transfer')}
+            </Button>
           </RestrictByProjectRole>
-        </>
+          {!isEmpty && full}
+        </Column>
       )}
-      <RestrictByProjectRole role={PROJECT_EDITOR_ROLES}>
-        <Button
-          onPress={transferCallback}
-          alignSelf="flex-start"
-          _text={{textTransform: 'uppercase'}}>
-          {t('projects.sites.transfer')}
-        </Button>
-      </RestrictByProjectRole>
-      {!isEmpty && full}
-    </Column>
+    </RestrictByRequirements>
   );
 }
 

--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -24,7 +24,10 @@ import {ProjectMembership} from 'terraso-client-shared/project/projectTypes';
 
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -96,7 +99,9 @@ export const ProjectTeamScreen = ({route}: Props) => {
 
   const project = useSelector(selectProject(route.params.projectId));
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -23,6 +23,8 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {ProjectMembership} from 'terraso-client-shared/project/projectTypes';
 
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   Box,
   Column,
@@ -39,7 +41,10 @@ import {
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {UserList} from 'terraso-mobile-client/screens/ProjectTeamScreen/components/UserList';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
-import {selectProjectMembershipsWithUsers} from 'terraso-mobile-client/store/selectors';
+import {
+  selectProject,
+  selectProjectMembershipsWithUsers,
+} from 'terraso-mobile-client/store/selectors';
 
 type Props = NativeStackScreenProps<TabStackParamList, TabRoutes.TEAM>;
 
@@ -89,33 +94,45 @@ export const ProjectTeamScreen = ({route}: Props) => {
     [navigation, route.params.projectId, userRole],
   );
 
+  const project = useSelector(selectProject(route.params.projectId));
+  const handleMissingProject = useHandleMissingSiteOrProject();
+  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+
   return (
-    <Column height="full" p={4} space={3} backgroundColor="background.default">
-      <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
-        <Box alignSelf="flex-start">
-          <AddButton
-            text={t('projects.team.add')}
-            buttonProps={{
-              onPress: () =>
-                navigation.navigate('ADD_USER_PROJECT', {
-                  projectId: route.params.projectId,
-                }),
-            }}
-          />
-        </Box>
-      </RestrictByProjectRole>
-      <Heading variant="h6" py="20px">
-        {t('projects.team.manage_team')}
-      </Heading>
-      <ScrollView>
-        <UserList
-          memberships={members}
-          currentUserId={currentUser.data?.id}
-          removeUser={removeMembership}
-          memberAction={manageMember}
-          currentUserRole={currentUserRole}
-        />
-      </ScrollView>
-    </Column>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <Column
+          height="full"
+          p={4}
+          space={3}
+          backgroundColor="background.default">
+          <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
+            <Box alignSelf="flex-start">
+              <AddButton
+                text={t('projects.team.add')}
+                buttonProps={{
+                  onPress: () =>
+                    navigation.navigate('ADD_USER_PROJECT', {
+                      projectId: route.params.projectId,
+                    }),
+                }}
+              />
+            </Box>
+          </RestrictByProjectRole>
+          <Heading variant="h6" py="20px">
+            {t('projects.team.manage_team')}
+          </Heading>
+          <ScrollView>
+            <UserList
+              memberships={members}
+              currentUserId={currentUser.data?.id}
+              removeUser={removeMembership}
+              memberAction={manageMember}
+              currentUserRole={currentUserRole}
+            />
+          </ScrollView>
+        </Column>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -24,7 +24,7 @@ import {ProjectMembership} from 'terraso-client-shared/project/projectTypes';
 
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -99,7 +99,7 @@ export const ProjectTeamScreen = ({route}: Props) => {
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <Column
           height="full"
@@ -133,6 +133,6 @@ export const ProjectTeamScreen = ({route}: Props) => {
           </ScrollView>
         </Column>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/ProjectTeamScreen.tsx
@@ -23,7 +23,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {ProjectMembership} from 'terraso-client-shared/project/projectTypes';
 
 import {AddButton} from 'terraso-mobile-client/components/AddButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
@@ -95,7 +95,7 @@ export const ProjectTeamScreen = ({route}: Props) => {
   );
 
   const project = useSelector(selectProject(route.params.projectId));
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ProjectRoleContextProvider} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -27,7 +27,7 @@ type Props = {projectId: string};
 
 export const ProjectViewScreen = ({projectId}: Props) => {
   const project = useSelector(state => state.project.projects[projectId]);
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
 
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -16,7 +16,7 @@
  */
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ProjectRoleContextProvider} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ProjectTabNavigator} from 'terraso-mobile-client/navigation/navigators/ProjectTabNavigator';
@@ -32,7 +32,7 @@ export const ProjectViewScreen = ({projectId}: Props) => {
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ProjectRoleContextProvider projectId={projectId}>
           <ScreenScaffold
@@ -42,6 +42,6 @@ export const ProjectViewScreen = ({projectId}: Props) => {
           </ScreenScaffold>
         </ProjectRoleContextProvider>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {ProjectRoleContextProvider} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ProjectTabNavigator} from 'terraso-mobile-client/navigation/navigators/ProjectTabNavigator';
@@ -25,14 +27,21 @@ type Props = {projectId: string};
 
 export const ProjectViewScreen = ({projectId}: Props) => {
   const project = useSelector(state => state.project.projects[projectId]);
+  const handleMissingProject = useHandleMissingSiteOrProject();
+
+  const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <ProjectRoleContextProvider projectId={projectId}>
-      <ScreenScaffold
-        AppBar={<AppBar title={project?.name} />}
-        BottomNavigation={null}>
-        <ProjectTabNavigator projectId={projectId} />
-      </ScreenScaffold>
-    </ProjectRoleContextProvider>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ProjectRoleContextProvider projectId={projectId}>
+          <ScreenScaffold
+            AppBar={<AppBar title={project?.name} />}
+            BottomNavigation={null}>
+            <ProjectTabNavigator projectId={projectId} />
+          </ScreenScaffold>
+        </ProjectRoleContextProvider>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/ProjectViewScreen.tsx
+++ b/dev-client/src/screens/ProjectViewScreen.tsx
@@ -16,7 +16,10 @@
  */
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ProjectRoleContextProvider} from 'terraso-mobile-client/context/ProjectRoleContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ProjectTabNavigator} from 'terraso-mobile-client/navigation/navigators/ProjectTabNavigator';
@@ -29,7 +32,9 @@ export const ProjectViewScreen = ({projectId}: Props) => {
   const project = useSelector(state => state.project.projects[projectId]);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
 
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
@@ -22,7 +22,7 @@ import {Keyboard} from 'react-native';
 import {SiteNoteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -75,7 +75,7 @@ export const AddSiteNoteScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenFormWrapper
           ref={formWrapperRef}
@@ -95,6 +95,6 @@ export const AddSiteNoteScreen = ({siteId}: Props) => {
           )}
         </ScreenFormWrapper>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
@@ -21,6 +21,8 @@ import {Keyboard} from 'react-native';
 
 import {SiteNoteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   Box,
   Column,
@@ -30,7 +32,8 @@ import {ScreenFormWrapper} from 'terraso-mobile-client/components/ScreenFormWrap
 import {addSiteNote} from 'terraso-mobile-client/model/site/siteSlice';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteNoteForm} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteForm';
-import {useDispatch} from 'terraso-mobile-client/store';
+import {useDispatch, useSelector} from 'terraso-mobile-client/store';
+import {selectSite} from 'terraso-mobile-client/store/selectors';
 
 type Props = {
   siteId: string;
@@ -67,23 +70,31 @@ export const AddSiteNoteScreen = ({siteId}: Props) => {
     navigation.pop();
   };
 
+  const site = useSelector(selectSite(siteId));
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScreenFormWrapper
-      ref={formWrapperRef}
-      initialValues={{content: ''}}
-      onSubmit={handleAddNote}
-      onDelete={handleDelete}
-      isSubmitting={isSubmitting}>
-      {formikProps => (
-        <Column pt={10} pl={5} pr={5} pb={10} flex={1}>
-          <Heading variant="h6" pb={7}>
-            {t('site.notes.add_title')}
-          </Heading>
-          <Box flexGrow={1}>
-            <SiteNoteForm content={formikProps.values.content || ''} />
-          </Box>
-        </Column>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenFormWrapper
+          ref={formWrapperRef}
+          initialValues={{content: ''}}
+          onSubmit={handleAddNote}
+          onDelete={handleDelete}
+          isSubmitting={isSubmitting}>
+          {formikProps => (
+            <Column pt={10} pl={5} pr={5} pb={10} flex={1}>
+              <Heading variant="h6" pb={7}>
+                {t('site.notes.add_title')}
+              </Heading>
+              <Box flexGrow={1}>
+                <SiteNoteForm content={formikProps.values.content || ''} />
+              </Box>
+            </Column>
+          )}
+        </ScreenFormWrapper>
       )}
-    </ScreenFormWrapper>
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
@@ -22,7 +22,10 @@ import {Keyboard} from 'react-native';
 import {SiteNoteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -72,7 +75,9 @@ export const AddSiteNoteScreen = ({siteId}: Props) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
@@ -21,7 +21,7 @@ import {Keyboard} from 'react-native';
 
 import {SiteNoteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
@@ -71,7 +71,7 @@ export const AddSiteNoteScreen = ({siteId}: Props) => {
   };
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -16,11 +16,11 @@
  */
 
 import {useCallback} from 'react';
-import {ToastAndroid} from 'react-native';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
+import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteTabNavigator';
 import {EditSiteNoteContent} from 'terraso-mobile-client/screens/SiteNotesScreen/components/EditSiteNoteContent';
@@ -34,6 +34,7 @@ type Props = {
 
 export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
   const navigation = useNavigation();
+  const syncNotifications = useSyncNotificationContext();
 
   const site = useSelector(state => selectSite(siteId)(state));
   const note = site?.notes[noteId];
@@ -45,11 +46,10 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
       siteId: siteId,
       initialTab: 'NOTES' as SiteTabName,
     });
-    // TODO: Decide design / how to show toasts / use en.json string
     if (isFlagEnabled('FF_offline')) {
-      ToastAndroid.show('Sorry, someone deleted that!', ToastAndroid.SHORT);
+      syncNotifications.showError();
     }
-  }, [navigation, siteId]);
+  }, [navigation, siteId, syncNotifications]);
   const requirements = [
     {data: site, doIfMissing: handleMissingSite},
     {data: note, doIfMissing: handleMissingSiteNote},

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -18,7 +18,10 @@
 import {useCallback} from 'react';
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -50,10 +53,10 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
       syncNotifications.showError();
     }
   }, [navigation, siteId, syncNotifications]);
-  const requirements = [
+  const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
     {data: note, doIfMissing: handleMissingSiteNote},
-  ];
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -17,7 +17,7 @@
 
 import {useCallback} from 'react';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
@@ -40,7 +40,7 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
   const note = site?.notes[noteId];
   // TODO: Also handle the case where user no longer has permissions to edit notes
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleMissingSiteNote = useCallback(() => {
     navigation.navigate('SITE_TABS', {
       siteId: siteId,

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -18,7 +18,7 @@
 import {useCallback} from 'react';
 import {ToastAndroid} from 'react-native';
 
-import {useHandleMissingSite} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -39,7 +39,7 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
   const note = site?.notes[noteId];
   // TODO: Also handle the case where user no longer has permissions to edit notes
 
-  const handleMissingSite = useHandleMissingSite();
+  const handleMissingSite = useHandleMissingSiteOrProject();
   const handleMissingSiteNote = useCallback(() => {
     navigation.navigate('SITE_TABS', {
       siteId: siteId,

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -18,7 +18,7 @@
 import {useCallback} from 'react';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -56,8 +56,8 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
   ];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => <EditSiteNoteContent note={note} />}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
@@ -15,12 +15,14 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {Button, ScrollView, Spacer} from 'native-base';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useHandleMissingSiteOrProject,
+  usePopNavigationAndSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Column,
@@ -28,8 +30,6 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
-import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
@@ -42,7 +42,6 @@ type Props = {
 export const ReadPinnedNoteScreen = ({projectId}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
-  const syncNotifications = useSyncNotificationContext();
 
   const project = useSelector(selectProject(projectId));
   const content = project?.siteInstructions;
@@ -52,12 +51,7 @@ export const ReadPinnedNoteScreen = ({projectId}: Props) => {
   };
 
   const handleMissingProject = useHandleMissingSiteOrProject();
-  const handleMissingPinnedNote = useCallback(() => {
-    navigation.pop();
-    if (isFlagEnabled('FF_offline')) {
-      syncNotifications.showError();
-    }
-  }, [navigation, syncNotifications]);
+  const handleMissingPinnedNote = usePopNavigationAndSyncError();
   const requirements = [
     {data: project, doIfMissing: handleMissingProject},
     {data: content, doIfMissing: handleMissingPinnedNote},

--- a/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
@@ -21,7 +21,7 @@ import {useTranslation} from 'react-i18next';
 import {Button, ScrollView, Spacer} from 'native-base';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Column,
   Heading,
@@ -64,7 +64,7 @@ export const ReadPinnedNoteScreen = ({projectId}: Props) => {
   ];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold BottomNavigation={null} AppBar={null}>
           <Column pt={10} pl={5} pr={5} pb={10} flexGrow={1}>
@@ -87,6 +87,6 @@ export const ReadPinnedNoteScreen = ({projectId}: Props) => {
           </Column>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
@@ -20,8 +20,8 @@ import {useTranslation} from 'react-i18next';
 import {Button, ScrollView, Spacer} from 'native-base';
 
 import {
-  useHandleMissingSiteOrProject,
-  usePopNavigationAndSyncError,
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
 } from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
@@ -50,8 +50,8 @@ export const ReadPinnedNoteScreen = ({projectId}: Props) => {
     navigation.pop();
   };
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
-  const handleMissingPinnedNote = usePopNavigationAndSyncError();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
+  const handleMissingPinnedNote = usePopNavigationAndShowSyncError();
   const requirements = [
     {data: project, doIfMissing: handleMissingProject},
     {data: content, doIfMissing: handleMissingPinnedNote},

--- a/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/ReadPinnedNoteScreen.tsx
@@ -23,7 +23,10 @@ import {
   useNavToBottomTabsAndShowSyncError,
   usePopNavigationAndShowSyncError,
 } from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Column,
   Heading,
@@ -52,10 +55,10 @@ export const ReadPinnedNoteScreen = ({projectId}: Props) => {
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingPinnedNote = usePopNavigationAndShowSyncError();
-  const requirements = [
+  const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
     {data: content, doIfMissing: handleMissingPinnedNote},
-  ];
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
@@ -21,6 +21,8 @@ import {ScrollView} from 'react-native';
 
 import {Button} from 'native-base';
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   Box,
   Column,
@@ -35,11 +37,12 @@ import {OfflineMessageBox} from 'terraso-mobile-client/screens/LocationScreens/c
 import {PinnedNoteCard} from 'terraso-mobile-client/screens/SiteNotesScreen/components/PinnedNoteCard';
 import {SiteNoteCard} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteCard';
 import {useSelector} from 'terraso-mobile-client/store';
+import {selectSite} from 'terraso-mobile-client/store/selectors';
 
 export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
-  const site = useSelector(state => state.site.sites[siteId]);
+  const site = useSelector(selectSite(siteId));
   const project = useSelector(state =>
     site.projectId === undefined
       ? undefined
@@ -52,39 +55,46 @@ export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
 
   const isOffline = useIsOffline();
 
-  return (
-    <ScrollView>
-      <Column>
-        <Row backgroundColor="background.default" px="16px" py="12px">
-          <Heading variant="h6">{t('site.notes.title')}</Heading>
-        </Row>
-        <Box height="16px" />
-        {project?.siteInstructions && <PinnedNoteCard project={project} />}
-        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-          <Box
-            pl={4}
-            pb={4}
-            pr={4}
-            alignItems={isOffline ? undefined : 'flex-start'}>
-            {isOffline ? (
-              <OfflineMessageBox message={t('site.notes.offline')} />
-            ) : (
-              <Button
-                size="lg"
-                shadow={5}
-                onPress={onAddNote}
-                _text={{textTransform: 'uppercase'}}>
-                {t('site.notes.add_note_label')}
-              </Button>
-            )}
-          </Box>
-        </RestrictBySiteRole>
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
-        {Object.values(site.notes).map(note => (
-          <SiteNoteCard note={note} key={note.id} />
-        ))}
-        {site.notes && <Box height="300px" />}
-      </Column>
-    </ScrollView>
+  return (
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScrollView>
+          <Column>
+            <Row backgroundColor="background.default" px="16px" py="12px">
+              <Heading variant="h6">{t('site.notes.title')}</Heading>
+            </Row>
+            <Box height="16px" />
+            {project?.siteInstructions && <PinnedNoteCard project={project} />}
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
+              <Box
+                pl={4}
+                pb={4}
+                pr={4}
+                alignItems={isOffline ? undefined : 'flex-start'}>
+                {isOffline ? (
+                  <OfflineMessageBox message={t('site.notes.offline')} />
+                ) : (
+                  <Button
+                    size="lg"
+                    shadow={5}
+                    onPress={onAddNote}
+                    _text={{textTransform: 'uppercase'}}>
+                    {t('site.notes.add_note_label')}
+                  </Button>
+                )}
+              </Box>
+            </RestrictBySiteRole>
+
+            {Object.values(site.notes).map(note => (
+              <SiteNoteCard note={note} key={note.id} />
+            ))}
+            {site.notes && <Box height="300px" />}
+          </Column>
+        </ScrollView>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
@@ -21,7 +21,7 @@ import {ScrollView} from 'react-native';
 
 import {Button} from 'native-base';
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
@@ -55,7 +55,7 @@ export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
 
   const isOffline = useIsOffline();
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
@@ -22,7 +22,7 @@ import {ScrollView} from 'react-native';
 import {Button} from 'native-base';
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -59,7 +59,7 @@ export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScrollView>
           <Column>
@@ -95,6 +95,6 @@ export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
           </Column>
         </ScrollView>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/SiteNotesScreen.tsx
@@ -22,7 +22,10 @@ import {ScrollView} from 'react-native';
 import {Button} from 'native-base';
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -56,7 +59,9 @@ export const SiteNotesScreen = ({siteId}: {siteId: string}) => {
   const isOffline = useIsOffline();
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -22,6 +22,8 @@ import {PressableProps} from 'react-native';
 import {Fab} from 'native-base';
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {
@@ -78,42 +80,47 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     navigation.navigate('BOTTOM_TABS');
   }, [dispatch, navigation, site]);
 
-  if (!site) {
-    return null;
-  }
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <ScreenScaffold BottomNavigation={null} AppBar={<AppBar title={name} />}>
-      <Column px="16px" py="22px" space="20px" alignItems="flex-start">
-        <Heading variant="h6">{t('site.dashboard.settings_title')}</Heading>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold
+          BottomNavigation={null}
+          AppBar={<AppBar title={name} />}>
+          <Column px="16px" py="22px" space="20px" alignItems="flex-start">
+            <Heading variant="h6">{t('site.dashboard.settings_title')}</Heading>
 
-        <TextInput
-          maxLength={SITE_NAME_MAX_LENGTH}
-          disabled={isOffline}
-          value={name}
-          onChangeText={setName}
-          label={t('site.create.name_label')}
-          placeholder={t('site.create.name_label')}
-        />
-        {isOffline ? (
-          <DeleteButtonWrapper disabled={true} />
-        ) : (
-          <ConfirmModal
-            trigger={onOpen => <DeleteButtonWrapper onPress={onOpen} />}
-            title={t('projects.sites.delete_site_modal.title')}
-            body={t('projects.sites.delete_site_modal.body', {
-              siteName: site.name,
-            })}
-            actionName={t('projects.sites.delete_site_modal.action_name')}
-            handleConfirm={onDelete}
+            <TextInput
+              maxLength={SITE_NAME_MAX_LENGTH}
+              disabled={isOffline}
+              value={name}
+              onChangeText={setName}
+              label={t('site.create.name_label')}
+              placeholder={t('site.create.name_label')}
+            />
+            {isOffline ? (
+              <DeleteButtonWrapper disabled={true} />
+            ) : (
+              <ConfirmModal
+                trigger={onOpen => <DeleteButtonWrapper onPress={onOpen} />}
+                title={t('projects.sites.delete_site_modal.title')}
+                body={t('projects.sites.delete_site_modal.body', {
+                  siteName: site.name,
+                })}
+                actionName={t('projects.sites.delete_site_modal.action_name')}
+                handleConfirm={onDelete}
+              />
+            )}
+          </Column>
+          <Fab
+            label={t('general.save_fab')}
+            onPress={onSave}
+            isDisabled={isOffline}
           />
-        )}
-      </Column>
-      <Fab
-        label={t('general.save_fab')}
-        onPress={onSave}
-        isDisabled={isOffline}
-      />
-    </ScreenScaffold>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -23,7 +23,7 @@ import {Fab} from 'native-base';
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {
@@ -84,7 +84,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           BottomNavigation={null}
@@ -121,6 +121,6 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
           />
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -22,7 +22,7 @@ import {PressableProps} from 'react-native';
 import {Fab} from 'native-base';
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
@@ -80,7 +80,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     navigation.navigate('BOTTOM_TABS');
   }, [dispatch, navigation, site]);
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -23,7 +23,10 @@ import {Fab} from 'native-base';
 
 import DeleteButton from 'terraso-mobile-client/components/buttons/DeleteButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {TextInput} from 'terraso-mobile-client/components/inputs/TextInput';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {
@@ -81,7 +84,9 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   }, [dispatch, navigation, site]);
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -29,7 +29,7 @@ type Props = {
 export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const site = useSelector(state => state.site.sites[siteId]);
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -26,9 +28,17 @@ type Props = {
 
 export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const site = useSelector(state => state.site.sites[siteId]);
+
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScreenScaffold AppBar={<AppBar title={site.name} />}>
-      <Text>Unimplemented team settings page</Text>
-    </ScreenScaffold>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold AppBar={<AppBar title={site.name} />}>
+          <Text>Unimplemented team settings page</Text>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -16,7 +16,7 @@
  */
 
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -33,12 +33,12 @@ export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold AppBar={<AppBar title={site.name} />}>
           <Text>Unimplemented team settings page</Text>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -16,7 +16,10 @@
  */
 
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -30,7 +33,9 @@ export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const site = useSelector(state => state.site.sites[siteId]);
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -23,7 +23,10 @@ import {Fab} from 'native-base';
 
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useTextSearch} from 'terraso-mobile-client/hooks/useTextSearch';
@@ -192,7 +195,9 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
   }, [dispatch, navigation, projectId, checkedSites]);
 
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: project, doIfMissing: handleMissingProject}];
+  const requirements = useMemoizedRequirements([
+    {data: project, doIfMissing: handleMissingProject},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -22,7 +22,7 @@ import {ScrollView} from 'react-native';
 import {Fab} from 'native-base';
 
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
@@ -191,7 +191,7 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
     return navigation.pop();
   }, [dispatch, navigation, projectId, checkedSites]);
 
-  const handleMissingProject = useHandleMissingSiteOrProject();
+  const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -23,7 +23,7 @@ import {Fab} from 'native-base';
 
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useTextSearch} from 'terraso-mobile-client/hooks/useTextSearch';
@@ -195,7 +195,7 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
   const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           BottomNavigation={null}
@@ -263,6 +263,6 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
           </ScrollView>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -22,6 +22,8 @@ import {ScrollView} from 'react-native';
 import {Fab} from 'native-base';
 
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useTextSearch} from 'terraso-mobile-client/hooks/useTextSearch';
@@ -189,71 +191,78 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
     return navigation.pop();
   }, [dispatch, navigation, projectId, checkedSites]);
 
-  return (
-    <ScreenScaffold
-      BottomNavigation={null}
-      AppBar={<AppBar title={project.name} />}>
-      <ScrollView>
-        <ListHeader query={query} setQuery={setQuery} />
-        {listData.map(item => {
-          const [projId, {projectName, sites: projectSites}] = item;
+  const handleMissingProject = useHandleMissingSiteOrProject();
+  const requirements = [{data: project, doIfMissing: handleMissingProject}];
 
-          return (
-            <Accordion
-              key={projId.toString()}
-              Head={
-                <Text
-                  variant="body1"
-                  fontWeight={700}
-                  color="primary.contrast"
-                  py="14px">
-                  {projectName} ({projectSites.length})
-                </Text>
-              }
-              boxProps={{
-                mb: '2px',
-              }}
-              initiallyOpen={projectSites.length > 0}
-              disableOpen={projectSites.length === 0}>
-              {projectSites.length > 0 ? (
-                <Box px="15px" my="15px">
-                  <CheckboxGroup
-                    groupName={projectName}
-                    groupId={projId}
-                    checkboxes={projectSites
-                      .map(({siteId, siteName}) => ({
-                        label: siteName,
-                        id: siteId,
-                        checked:
-                          projState && projState[projId]
-                            ? projState[projId][siteId]
-                            : false,
-                      }))
-                      .sort((a, b) => a.label.localeCompare(b.label))}
-                    onChangeValue={onCheckboxChange}
-                  />
-                </Box>
-              ) : undefined}
-            </Accordion>
-          );
-        })}
-        <ConfirmModal
-          trigger={onOpen => (
-            <Fab
-              label={t('projects.sites.transfer')}
-              onPress={onOpen}
-              isDisabled={disabled}
-              _disabled={{
-                shadow: 0,
-              }}
+  return (
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold
+          BottomNavigation={null}
+          AppBar={<AppBar title={project.name} />}>
+          <ScrollView>
+            <ListHeader query={query} setQuery={setQuery} />
+            {listData.map(item => {
+              const [projId, {projectName, sites: projectSites}] = item;
+
+              return (
+                <Accordion
+                  key={projId.toString()}
+                  Head={
+                    <Text
+                      variant="body1"
+                      fontWeight={700}
+                      color="primary.contrast"
+                      py="14px">
+                      {projectName} ({projectSites.length})
+                    </Text>
+                  }
+                  boxProps={{
+                    mb: '2px',
+                  }}
+                  initiallyOpen={projectSites.length > 0}
+                  disableOpen={projectSites.length === 0}>
+                  {projectSites.length > 0 ? (
+                    <Box px="15px" my="15px">
+                      <CheckboxGroup
+                        groupName={projectName}
+                        groupId={projId}
+                        checkboxes={projectSites
+                          .map(({siteId, siteName}) => ({
+                            label: siteName,
+                            id: siteId,
+                            checked:
+                              projState && projState[projId]
+                                ? projState[projId][siteId]
+                                : false,
+                          }))
+                          .sort((a, b) => a.label.localeCompare(b.label))}
+                        onChangeValue={onCheckboxChange}
+                      />
+                    </Box>
+                  ) : undefined}
+                </Accordion>
+              );
+            })}
+            <ConfirmModal
+              trigger={onOpen => (
+                <Fab
+                  label={t('projects.sites.transfer')}
+                  onPress={onOpen}
+                  isDisabled={disabled}
+                  _disabled={{
+                    shadow: 0,
+                  }}
+                />
+              )}
+              title={t('projects.sites.transfer_site_modal.title')}
+              body={t('projects.sites.transfer_site_modal.body')}
+              actionName={t('projects.sites.transfer_site_modal.action_name')}
+              handleConfirm={onSubmit}
             />
-          )}
-          title={t('projects.sites.transfer_site_modal.title')}
-          body={t('projects.sites.transfer_site_modal.body')}
-          actionName={t('projects.sites.transfer_site_modal.action_name')}
-          handleConfirm={onSubmit}
-        />
-      </ScrollView>
-    </ScreenScaffold>
+          </ScrollView>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -55,20 +55,22 @@ import {
 } from 'terraso-mobile-client/screens/SitesScreen/SitesScreenCallout';
 import {getSitesScreenFilters} from 'terraso-mobile-client/screens/SitesScreen/utils/sitesScreenFilters';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
-import {selectSitesAndUserRoles} from 'terraso-mobile-client/store/selectors';
+import {
+  selectCurrentUserID,
+  selectSites,
+  selectSitesAndUserRoles,
+} from 'terraso-mobile-client/store/selectors';
 
 export const SitesScreen = memo(() => {
   const siteListBottomSheetRef = useRef<BottomSheet>(null);
   const [mapStyleURL, setMapStyleURL] = useState(Mapbox.StyleURL.Street);
   const [calloutState, setCalloutState] = useState<CalloutState>(noneCallout());
-  const currentUserID = useSelector(
-    state => state.account.currentUser?.data?.id,
-  );
-  const sites = useSelector(state => state.site.sites);
+  const currentUserID = useSelector(selectCurrentUserID);
+  const sites = useSelector(selectSites);
   const siteList = useMemo(() => Object.values(sites), [sites]);
   const dispatch = useDispatch();
   const mapRef = useRef<MapRef>(null);
-  const siteProjectRoles = useSelector(state => selectSitesAndUserRoles(state));
+  const siteProjectRoles = useSelector(selectSitesAndUserRoles);
   const sitesScreenContext = useContext(SitesScreenContext);
 
   const showSiteOnMap = useCallback(

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -28,6 +28,8 @@ import {BigCloseButton} from 'terraso-mobile-client/components/buttons/icons/com
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {PermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
 import {
@@ -41,7 +43,8 @@ import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigatio
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {SlopeMeterInfoContent} from 'terraso-mobile-client/screens/SlopeScreen/components/SlopeMeterInfoContent';
 import {degreeToPercent} from 'terraso-mobile-client/screens/SlopeScreen/utils/steepnessConversion';
-import {useDispatch} from 'terraso-mobile-client/store';
+import {useDispatch, useSelector} from 'terraso-mobile-client/store';
+import {selectSite} from 'terraso-mobile-client/store/selectors';
 
 const toDegrees = (rad: number) => Math.round(Math.abs((rad * 180) / Math.PI));
 
@@ -87,75 +90,86 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
     navigation.pop();
   }, [dispatch, siteId, deviceTiltDeg, navigation]);
 
+  const site = useSelector(selectSite(siteId));
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScreenScaffold AppBar={null} BottomNavigation={null}>
-      <Row flex={1} alignItems="stretch" px="24px" py="20px">
-        <Box flex={1} justifyContent="center">
-          {permission?.granted ? (
-            <CameraView style={styles.camera}>
-              <Column flex={1} alignItems="stretch">
-                <Box flex={1} />
-                <Box height="3px" bg="text.primary" />
-                <Box height="3px" bg="primary.contrast" />
-                <Box flex={1} bg="#00000080" />
-              </Column>
-            </CameraView>
-          ) : (
-            <PermissionsRequestWrapper
-              requestModalTitle={t('permissions.camera_title')}
-              requestModalBody={t('permissions.camera_body', {
-                feature: t('slope.steepness.slope_meter'),
-              })}
-              permissionHook={useCameraPermissions}
-              permissionedAction={getCameraPermissionAsync}>
-              {onRequest => (
-                <Button size="lg" onPress={onRequest}>
-                  {t('slope.steepness.camera_grant')}
-                </Button>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold AppBar={null} BottomNavigation={null}>
+          <Row flex={1} alignItems="stretch" px="24px" py="20px">
+            <Box flex={1} justifyContent="center">
+              {permission?.granted ? (
+                <CameraView style={styles.camera}>
+                  <Column flex={1} alignItems="stretch">
+                    <Box flex={1} />
+                    <Box height="3px" bg="text.primary" />
+                    <Box height="3px" bg="primary.contrast" />
+                    <Box flex={1} bg="#00000080" />
+                  </Column>
+                </CameraView>
+              ) : (
+                <PermissionsRequestWrapper
+                  requestModalTitle={t('permissions.camera_title')}
+                  requestModalBody={t('permissions.camera_body', {
+                    feature: t('slope.steepness.slope_meter'),
+                  })}
+                  permissionHook={useCameraPermissions}
+                  permissionedAction={getCameraPermissionAsync}>
+                  {onRequest => (
+                    <Button size="lg" onPress={onRequest}>
+                      {t('slope.steepness.camera_grant')}
+                    </Button>
+                  )}
+                </PermissionsRequestWrapper>
               )}
-            </PermissionsRequestWrapper>
-          )}
-        </Box>
-        <Column alignItems="center">
-          <Box {...styles.closeButtonBox}>
-            <BigCloseButton onPress={onClose} />
-          </Box>
-          <Column
-            px="56px"
-            flex={1}
-            justifyContent="center"
-            alignItems="center">
-            <Row alignItems="center">
-              <Heading variant="h6">{t('slope.steepness.slope_meter')}</Heading>
-              <HelpContentSpacer />
-              <InfoButton
-                sheetHeading={
-                  <TranslatedHeading i18nKey="slope.steepness.info.title" />
-                }>
-                <SlopeMeterInfoContent />
-              </InfoButton>
-            </Row>
-            <Box height="12px" />
-            <Heading variant="h5" fontWeight={700}>
-              {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
-            </Heading>
-            <Box height="5px" />
-            <Heading variant="h6">
-              {deviceTiltDeg !== null && `${degreeToPercent(deviceTiltDeg)}%`}
-            </Heading>
-            <Box height="18px" />
-            <Button
-              onPress={onUse}
-              size="lg"
-              px="46px"
-              py="18px"
-              {...styles.useButton}>
-              {t('general.use')}
-            </Button>
-          </Column>
-        </Column>
-      </Row>
-    </ScreenScaffold>
+            </Box>
+            <Column alignItems="center">
+              <Box {...styles.closeButtonBox}>
+                <BigCloseButton onPress={onClose} />
+              </Box>
+              <Column
+                px="56px"
+                flex={1}
+                justifyContent="center"
+                alignItems="center">
+                <Row alignItems="center">
+                  <Heading variant="h6">
+                    {t('slope.steepness.slope_meter')}
+                  </Heading>
+                  <HelpContentSpacer />
+                  <InfoButton
+                    sheetHeading={
+                      <TranslatedHeading i18nKey="slope.steepness.info.title" />
+                    }>
+                    <SlopeMeterInfoContent />
+                  </InfoButton>
+                </Row>
+                <Box height="12px" />
+                <Heading variant="h5" fontWeight={700}>
+                  {deviceTiltDeg !== null && `${deviceTiltDeg}°`}
+                </Heading>
+                <Box height="5px" />
+                <Heading variant="h6">
+                  {deviceTiltDeg !== null &&
+                    `${degreeToPercent(deviceTiltDeg)}%`}
+                </Heading>
+                <Box height="18px" />
+                <Button
+                  onPress={onUse}
+                  size="lg"
+                  px="46px"
+                  py="18px"
+                  {...styles.useButton}>
+                  {t('general.use')}
+                </Button>
+              </Column>
+            </Column>
+          </Row>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };
 

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -29,7 +29,7 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {PermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
 import {
@@ -95,7 +95,7 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold AppBar={null} BottomNavigation={null}>
           <Row flex={1} alignItems="stretch" px="24px" py="20px">
@@ -169,7 +169,7 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
           </Row>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };
 

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -29,7 +29,10 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {PermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
 import {
@@ -92,7 +95,9 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeMeterScreen.tsx
@@ -28,7 +28,7 @@ import {BigCloseButton} from 'terraso-mobile-client/components/buttons/icons/com
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {PermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
@@ -91,7 +91,7 @@ export const SlopeMeterScreen = ({siteId}: {siteId: string}) => {
   }, [dispatch, siteId, deviceTiltDeg, navigation]);
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
@@ -24,6 +24,8 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {DataInputSummary} from 'terraso-mobile-client/components/DataInputSummary';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   Heading,
   Row,
@@ -36,6 +38,7 @@ import {
 } from 'terraso-mobile-client/screens/SlopeScreen/utils/renderValues';
 import {useSelector} from 'terraso-mobile-client/store';
 import {
+  selectSite,
   selectSoilData,
   useSiteProjectSoilSettings,
 } from 'terraso-mobile-client/store/selectors';
@@ -59,32 +62,40 @@ export const SlopeScreen = ({siteId}: {siteId: string}) => {
     [navigation, siteId],
   );
 
+  const site = useSelector(selectSite(siteId));
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScrollView backgroundColor="grey.300">
-      <Row backgroundColor="primary.contrast" p="15px" alignItems="center">
-        <Heading variant="h6">{t('slope.title')}</Heading>
-        <HelpContentSpacer />
-        <InfoButton
-          sheetHeading={<TranslatedHeading i18nKey="slope.info.title" />}>
-          <SlopeInfoContent />
-        </InfoButton>
-      </Row>
-      <Divider />
-      <DataInputSummary
-        required={required}
-        complete={steepnessValue !== undefined}
-        label={t('slope.steepness.short_title')}
-        value={steepnessValue}
-        onPress={onSteepness}
-      />
-      <Divider />
-      <DataInputSummary
-        required={required}
-        complete={shapeValue !== undefined}
-        label={t('slope.shape.title')}
-        value={shapeValue}
-        onPress={onShape}
-      />
-    </ScrollView>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScrollView backgroundColor="grey.300">
+          <Row backgroundColor="primary.contrast" p="15px" alignItems="center">
+            <Heading variant="h6">{t('slope.title')}</Heading>
+            <HelpContentSpacer />
+            <InfoButton
+              sheetHeading={<TranslatedHeading i18nKey="slope.info.title" />}>
+              <SlopeInfoContent />
+            </InfoButton>
+          </Row>
+          <Divider />
+          <DataInputSummary
+            required={required}
+            complete={steepnessValue !== undefined}
+            label={t('slope.steepness.short_title')}
+            value={steepnessValue}
+            onPress={onSteepness}
+          />
+          <Divider />
+          <DataInputSummary
+            required={required}
+            complete={shapeValue !== undefined}
+            label={t('slope.shape.title')}
+            value={shapeValue}
+            onPress={onShape}
+          />
+        </ScrollView>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
@@ -24,7 +24,7 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {DataInputSummary} from 'terraso-mobile-client/components/DataInputSummary';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Heading,
@@ -63,7 +63,7 @@ export const SlopeScreen = ({siteId}: {siteId: string}) => {
   );
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
@@ -25,7 +25,7 @@ import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpCo
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {DataInputSummary} from 'terraso-mobile-client/components/DataInputSummary';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Heading,
   Row,
@@ -67,7 +67,7 @@ export const SlopeScreen = ({siteId}: {siteId: string}) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScrollView backgroundColor="grey.300">
           <Row backgroundColor="primary.contrast" p="15px" alignItems="center">
@@ -96,6 +96,6 @@ export const SlopeScreen = ({siteId}: {siteId: string}) => {
           />
         </ScrollView>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeScreen.tsx
@@ -25,7 +25,10 @@ import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpCo
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {DataInputSummary} from 'terraso-mobile-client/components/DataInputSummary';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Heading,
   Row,
@@ -64,7 +67,9 @@ export const SlopeScreen = ({siteId}: {siteId: string}) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -39,7 +39,7 @@ import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImageRadio,
@@ -148,7 +148,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
   );
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -40,7 +40,10 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImageRadio,
   ImageRadioOption,
@@ -149,7 +152,9 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -39,6 +39,8 @@ import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {
   ImageRadio,
   ImageRadioOption,
@@ -61,6 +63,7 @@ import {SlopeShapeInfoContent} from 'terraso-mobile-client/screens/SlopeScreen/c
 import {renderShape} from 'terraso-mobile-client/screens/SlopeScreen/utils/renderValues';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {
+  selectSite,
   selectSoilData,
   selectUserRoleSite,
 } from 'terraso-mobile-client/store/selectors';
@@ -144,40 +147,54 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
     [dispatch, siteId],
   );
 
+  const site = useSelector(selectSite(siteId));
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScreenScaffold AppBar={<AppBar title={name} />} BottomNavigation={null}>
-      <SiteRoleContextProvider siteId={siteId}>
-        <ScrollView
-          bg="primary.contrast"
-          _contentContainerStyle={styles.scrollContentContainer}>
-          <Column>
-            <Column p="15px" bg="primary.contrast">
-              <Row alignItems="center">
-                <Heading variant="h6">{t('slope.shape.long_title')}</Heading>
-                <HelpContentSpacer />
-                <InfoButton
-                  sheetHeading={
-                    <TranslatedHeading i18nKey="slope.shape.info.title" />
-                  }>
-                  <SlopeShapeInfoContent />
-                </InfoButton>
-              </Row>
-            </Column>
-          </Column>
-          <ImageRadio
-            value={
-              downSlope && crossSlope ? `${downSlope}:${crossSlope}` : undefined
-            }
-            options={options}
-            onChange={isViewer ? () => {} : onChange}
-            minimumPerRow={3}
-          />
-        </ScrollView>
-        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-          <DoneButton />
-        </RestrictBySiteRole>
-      </SiteRoleContextProvider>
-    </ScreenScaffold>
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold
+          AppBar={<AppBar title={name} />}
+          BottomNavigation={null}>
+          <SiteRoleContextProvider siteId={siteId}>
+            <ScrollView
+              bg="primary.contrast"
+              _contentContainerStyle={styles.scrollContentContainer}>
+              <Column>
+                <Column p="15px" bg="primary.contrast">
+                  <Row alignItems="center">
+                    <Heading variant="h6">
+                      {t('slope.shape.long_title')}
+                    </Heading>
+                    <HelpContentSpacer />
+                    <InfoButton
+                      sheetHeading={
+                        <TranslatedHeading i18nKey="slope.shape.info.title" />
+                      }>
+                      <SlopeShapeInfoContent />
+                    </InfoButton>
+                  </Row>
+                </Column>
+              </Column>
+              <ImageRadio
+                value={
+                  downSlope && crossSlope
+                    ? `${downSlope}:${crossSlope}`
+                    : undefined
+                }
+                options={options}
+                onChange={isViewer ? () => {} : onChange}
+                minimumPerRow={3}
+              />
+            </ScrollView>
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
+              <DoneButton />
+            </RestrictBySiteRole>
+          </SiteRoleContextProvider>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };
 

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -40,7 +40,7 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImageRadio,
   ImageRadioOption,
@@ -152,7 +152,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           AppBar={<AppBar title={name} />}
@@ -194,7 +194,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
           </SiteRoleContextProvider>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };
 

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -24,6 +24,8 @@ import {Button, ScrollView} from 'native-base';
 import {SoilIdSoilDataSlopeSteepnessSelectChoices} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   ImageRadio,
@@ -59,6 +61,7 @@ import {
 import {STEEPNESS_IMAGES} from 'terraso-mobile-client/screens/SlopeScreen/utils/steepnessImages';
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {
+  selectSite,
   selectSoilData,
   selectUserRoleSite,
 } from 'terraso-mobile-client/store/selectors';
@@ -134,66 +137,80 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
     [navigation, siteId],
   );
 
+  const site = useSelector(selectSite(siteId));
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScreenScaffold AppBar={<AppBar title={name} />} BottomNavigation={null}>
-      <SiteRoleContextProvider siteId={siteId}>
-        <ScrollView
-          bg="primary.contrast"
-          _contentContainerStyle={styles.scrollContentContainer}>
-          <Column>
-            <Column p="15px" bg="primary.contrast">
-              <Heading variant="h6">{t('slope.steepness.long_title')}</Heading>
-            </Column>
-          </Column>
-          <Column p="15px" bg="grey.300">
-            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-              <Text variant="body1">{t('slope.steepness.description')}</Text>
-              <Box height="30px" />
-              <Row justifyContent="space-between">
-                <Modal
-                  trigger={onOpen => (
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold
+          AppBar={<AppBar title={name} />}
+          BottomNavigation={null}>
+          <SiteRoleContextProvider siteId={siteId}>
+            <ScrollView
+              bg="primary.contrast"
+              _contentContainerStyle={styles.scrollContentContainer}>
+              <Column>
+                <Column p="15px" bg="primary.contrast">
+                  <Heading variant="h6">
+                    {t('slope.steepness.long_title')}
+                  </Heading>
+                </Column>
+              </Column>
+              <Column p="15px" bg="grey.300">
+                <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
+                  <Text variant="body1">
+                    {t('slope.steepness.description')}
+                  </Text>
+                  <Box height="30px" />
+                  <Row justifyContent="space-between">
+                    <Modal
+                      trigger={onOpen => (
+                        <Button
+                          onPress={onOpen}
+                          _text={{textTransform: 'uppercase'}}
+                          rightIcon={<Icon name="chevron-right" />}>
+                          {t('slope.steepness.manual_label')}
+                        </Button>
+                      )}>
+                      <ManualSteepnessModal siteId={siteId} />
+                    </Modal>
                     <Button
-                      onPress={onOpen}
                       _text={{textTransform: 'uppercase'}}
-                      rightIcon={<Icon name="chevron-right" />}>
-                      {t('slope.steepness.manual_label')}
+                      rightIcon={<Icon name="chevron-right" />}
+                      onPress={onMeter}>
+                      {t('slope.steepness.slope_meter')}
                     </Button>
-                  )}>
-                  <ManualSteepnessModal siteId={siteId} />
-                </Modal>
-                <Button
-                  _text={{textTransform: 'uppercase'}}
-                  rightIcon={<Icon name="chevron-right" />}
-                  onPress={onMeter}>
-                  {t('slope.steepness.slope_meter')}
-                </Button>
-              </Row>
-              <Box height="15px" />
+                  </Row>
+                  <Box height="15px" />
+                </RestrictBySiteRole>
+                <Text variant="body1" fontWeight={700} alignSelf="center">
+                  {renderSteepness(t, soilData)}
+                </Text>
+              </Column>
+              <ConfirmModal
+                ref={confirmationModalRef}
+                title={t('slope.steepness.confirm_title')}
+                body={t('slope.steepness.confirm_body')}
+                actionName={t('general.change')}
+                handleConfirm={onConfirmSteepness}
+                isConfirmError={false}
+              />
+              <ImageRadio
+                value={soilData.slopeSteepnessSelect}
+                options={steepnessOptions as any}
+                onChange={isViewer ? () => {} : onSteepnessOptionSelected}
+                minimumPerRow={2}
+              />
+            </ScrollView>
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
+              <DoneButton />
             </RestrictBySiteRole>
-            <Text variant="body1" fontWeight={700} alignSelf="center">
-              {renderSteepness(t, soilData)}
-            </Text>
-          </Column>
-          <ConfirmModal
-            ref={confirmationModalRef}
-            title={t('slope.steepness.confirm_title')}
-            body={t('slope.steepness.confirm_body')}
-            actionName={t('general.change')}
-            handleConfirm={onConfirmSteepness}
-            isConfirmError={false}
-          />
-          <ImageRadio
-            value={soilData.slopeSteepnessSelect}
-            options={steepnessOptions as any}
-            onChange={isViewer ? () => {} : onSteepnessOptionSelected}
-            minimumPerRow={2}
-          />
-        </ScrollView>
-        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-          <DoneButton />
-        </RestrictBySiteRole>
-      </SiteRoleContextProvider>
-    </ScreenScaffold>
+          </SiteRoleContextProvider>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };
 

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -25,7 +25,7 @@ import {SoilIdSoilDataSlopeSteepnessSelectChoices} from 'terraso-client-shared/g
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   ImageRadio,
@@ -142,7 +142,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
           AppBar={<AppBar title={name} />}
@@ -210,7 +210,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
           </SiteRoleContextProvider>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };
 

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -25,7 +25,10 @@ import {SoilIdSoilDataSlopeSteepnessSelectChoices} from 'terraso-client-shared/g
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   ImageRadio,
@@ -139,7 +142,9 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -24,7 +24,7 @@ import {Button, ScrollView} from 'native-base';
 import {SoilIdSoilDataSlopeSteepnessSelectChoices} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
@@ -138,7 +138,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
   );
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -24,7 +24,10 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -103,7 +106,9 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
   const site = useSelector(selectSite(props.siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   // TODO-cknipe: Require the depth interval to exist for the site/project
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -24,7 +24,7 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -106,7 +106,7 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <SoilPitInputScreenScaffold {...props}>
           <SiteRoleContextProvider siteId={props.siteId}>
@@ -170,6 +170,6 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
           </SiteRoleContextProvider>
         </SoilPitInputScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -23,7 +23,7 @@ import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
@@ -101,7 +101,7 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
   );
 
   const site = useSelector(selectSite(props.siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   // TODO-cknipe: Require the depth interval to exist for the site/project
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 

--- a/dev-client/src/screens/SoilScreen/SoilScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SoilScreen.tsx
@@ -26,7 +26,7 @@ import {AddDepthModalBody} from 'terraso-mobile-client/components/AddDepthModal'
 import {TextButton} from 'terraso-mobile-client/components/buttons/TextButton';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Modal} from 'terraso-mobile-client/components/modals/Modal';
 import {
@@ -91,7 +91,7 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScrollView backgroundColor="grey.300">
           <SoilSurfaceStatus siteId={siteId} />
@@ -163,6 +163,6 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
           </RestrictBySiteRole>
         </ScrollView>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/SoilScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SoilScreen.tsx
@@ -25,7 +25,7 @@ import {SoilIdSoilDataDepthIntervalPresetChoices} from 'terraso-client-shared/gr
 import {AddDepthModalBody} from 'terraso-mobile-client/components/AddDepthModal';
 import {TextButton} from 'terraso-mobile-client/components/buttons/TextButton';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Modal} from 'terraso-mobile-client/components/modals/Modal';
@@ -87,7 +87,7 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
   );
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SoilScreen/SoilScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SoilScreen.tsx
@@ -26,7 +26,10 @@ import {AddDepthModalBody} from 'terraso-mobile-client/components/AddDepthModal'
 import {TextButton} from 'terraso-mobile-client/components/buttons/TextButton';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Modal} from 'terraso-mobile-client/components/modals/Modal';
 import {
@@ -88,7 +91,9 @@ export const SoilScreen = ({siteId}: {siteId: string}) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -28,7 +28,7 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   ImageRadio,
@@ -162,7 +162,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <SoilPitInputScreenScaffold {...props}>
           <SiteRoleContextProvider siteId={siteId}>
@@ -230,6 +230,6 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
           </SiteRoleContextProvider>
         </SoilPitInputScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -27,7 +27,7 @@ import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useHandleMissingSite} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
@@ -92,7 +92,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
   const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
   const site = useSelector(state => selectSite(siteId)(state));
-  const handleMissingSite = useHandleMissingSite();
+  const handleMissingSite = useHandleMissingSiteOrProject();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   const onTextureChange = useCallback(

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -28,7 +28,10 @@ import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
   ImageRadio,
@@ -159,7 +162,9 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
 
   const site = useSelector(selectSite(siteId));
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -91,10 +91,6 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
 
   const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
-  const site = useSelector(state => selectSite(siteId)(state));
-  const handleMissingSite = useHandleMissingSiteOrProject();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
-
   const onTextureChange = useCallback(
     (texture: SoilTexture | null) => {
       dispatch(
@@ -160,6 +156,10 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
     },
     [dispatch, siteId, depthInterval],
   );
+
+  const site = useSelector(selectSite(siteId));
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
     <RestrictByRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -27,7 +27,7 @@ import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {
@@ -158,7 +158,7 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
   );
 
   const site = useSelector(selectSite(siteId));
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -24,7 +24,7 @@ import {
 } from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
-import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Select} from 'terraso-mobile-client/components/inputs/Select';
 import {
@@ -72,7 +72,7 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
 
   const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
-  const handleMissingSite = useHandleMissingSiteOrProject();
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -25,7 +25,7 @@ import {
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Select} from 'terraso-mobile-client/components/inputs/Select';
 import {
   Box,
@@ -76,7 +76,7 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
   const requirements = [{data: site, doIfMissing: handleMissingSite}];
 
   return (
-    <RestrictByRequirements requirements={requirements}>
+    <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold AppBar={<AppBar title={site.name} />}>
           <SiteRoleContextProvider siteId={siteId}>
@@ -140,6 +140,6 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
           </SiteRoleContextProvider>
         </ScreenScaffold>
       )}
-    </RestrictByRequirements>
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -24,6 +24,8 @@ import {
 } from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
+import {useHandleMissingSiteOrProject} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {RestrictByRequirements} from 'terraso-mobile-client/components/dataRequirements/RestrictByRequirements';
 import {Select} from 'terraso-mobile-client/components/inputs/Select';
 import {
   Box,
@@ -70,67 +72,74 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
 
   const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
+  const handleMissingSite = useHandleMissingSiteOrProject();
+  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+
   return (
-    <ScreenScaffold AppBar={<AppBar title={site.name} />}>
-      <SiteRoleContextProvider siteId={siteId}>
-        <Column padding="md">
-          <Heading variant="h6">
-            {t('soil.collection_method.verticalCracking')}
-          </Heading>
-          <Select
-            disabled={isViewer}
-            nullable
-            value={cracking ?? null}
-            onValueChange={onUpdate}
-            options={surfaceCracks}
-            renderValue={renderSurfaceCrack}
-            label={t('soil.collection_method.verticalCracking')}
-          />
-          <Box height="lg" />
+    <RestrictByRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold AppBar={<AppBar title={site.name} />}>
+          <SiteRoleContextProvider siteId={siteId}>
+            <Column padding="md">
+              <Heading variant="h6">
+                {t('soil.collection_method.verticalCracking')}
+              </Heading>
+              <Select
+                disabled={isViewer}
+                nullable
+                value={cracking ?? null}
+                onValueChange={onUpdate}
+                options={surfaceCracks}
+                renderValue={renderSurfaceCrack}
+                label={t('soil.collection_method.verticalCracking')}
+              />
+              <Box height="lg" />
 
-          <Paragraph>{t('soil.vertical_cracking.description')}</Paragraph>
+              <Paragraph>{t('soil.vertical_cracking.description')}</Paragraph>
 
-          <Paragraph>
-            <Trans
-              i18nKey="soil.vertical_cracking.no_cracks"
-              components={{
-                bold: <Text bold />,
-              }}
-            />
-          </Paragraph>
+              <Paragraph>
+                <Trans
+                  i18nKey="soil.vertical_cracking.no_cracks"
+                  components={{
+                    bold: <Text bold />,
+                  }}
+                />
+              </Paragraph>
 
-          <Paragraph>
-            <Trans
-              i18nKey="soil.vertical_cracking.surface_cracks"
-              values={{units: 'METRIC'}}
-              components={{
-                bold: <Text bold />,
-              }}
-            />
-          </Paragraph>
+              <Paragraph>
+                <Trans
+                  i18nKey="soil.vertical_cracking.surface_cracks"
+                  values={{units: 'METRIC'}}
+                  components={{
+                    bold: <Text bold />,
+                  }}
+                />
+              </Paragraph>
 
-          <Paragraph>
-            <Trans
-              i18nKey="soil.vertical_cracking.deep_vertical_cracks"
-              values={{units: 'METRIC'}}
-              components={{
-                bold: <Text bold />,
-              }}
-            />
-          </Paragraph>
+              <Paragraph>
+                <Trans
+                  i18nKey="soil.vertical_cracking.deep_vertical_cracks"
+                  values={{units: 'METRIC'}}
+                  components={{
+                    bold: <Text bold />,
+                  }}
+                />
+              </Paragraph>
 
-          <Box width="100%" alignItems="center">
-            <Image
-              source={require('terraso-mobile-client/assets/surface/vertical-cracking.png')}
-            />
-          </Box>
-        </Column>
-        <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
-          <Box position="absolute" bottom="0" right="0">
-            <DoneButton isDisabled={!cracking} />
-          </Box>
-        </RestrictBySiteRole>
-      </SiteRoleContextProvider>
-    </ScreenScaffold>
+              <Box width="100%" alignItems="center">
+                <Image
+                  source={require('terraso-mobile-client/assets/surface/vertical-cracking.png')}
+                />
+              </Box>
+            </Column>
+            <RestrictBySiteRole role={SITE_EDITOR_ROLES}>
+              <Box position="absolute" bottom="0" right="0">
+                <DoneButton isDisabled={!cracking} />
+              </Box>
+            </RestrictBySiteRole>
+          </SiteRoleContextProvider>
+        </ScreenScaffold>
+      )}
+    </RestrictByRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/components/SoilSurfaceScreen.tsx
@@ -25,7 +25,10 @@ import {
 
 import {DoneButton} from 'terraso-mobile-client/components/buttons/DoneButton';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Select} from 'terraso-mobile-client/components/inputs/Select';
 import {
   Box,
@@ -73,7 +76,9 @@ export const SoilSurfaceScreen = ({siteId}: Props) => {
   const isViewer = useMemo(() => isProjectViewer(userRole), [userRole]);
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const requirements = [{data: site, doIfMissing: handleMissingSite}];
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/store/selectors.ts
+++ b/dev-client/src/store/selectors.ts
@@ -77,12 +77,12 @@ export const selectProjectMembershipsWithUsers = createSelector(
 export const selectProject = (projectId: string) => (state: AppState) =>
   state.project.projects[projectId];
 
-const selectProjects = (state: AppState) => state.project.projects;
+export const selectProjects = (state: AppState) => state.project.projects;
 
 export const selectSite = (siteId: string) => (state: AppState) =>
   state.site.sites[siteId];
 
-const selectSites = (state: AppState) => state.site.sites;
+export const selectSites = (state: AppState) => state.site.sites;
 
 const selectUserRole = (_state: AppState, userRole: ProjectRole) => userRole;
 


### PR DESCRIPTION
## Description
- Relevant screens specify what data is required to show the screen, and what to do if the data is missing
- Some minor refactoring

**NOTES**:
- There will be another PR for screens that require depth dependent data (to support a "deleted depth interval" scenario) -- just figured I could split up the PRs
- It may be helpful to go through individual commits to review

### Related Issues
Implements part of #2290

