### PR TITLE
fix: make soil id location cache use same precision as ui elements

### DIFF
--- a/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
@@ -40,7 +40,13 @@ describe('isErrorStatus', () => {
 
 describe('coordsKey', () => {
   test('produces keys for coords', () => {
-    expect(coordsKey({longitude: 1, latitude: 2})).toBe('(1, 2)');
+    expect(coordsKey({longitude: 1, latitude: 2})).toBe('(1.00000, 2.00000)');
+  });
+
+  test('produces keys for coords with appropriate precision', () => {
+    expect(coordsKey({longitude: 1.000014, latitude: 2.000014})).toBe(
+      '(1.00001, 2.00001)',
+    );
   });
 });
 

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.ts
@@ -23,7 +23,9 @@ import {
 import {SoilIdStatus} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
-export type CoordsKey = `(${number}, ${number})`;
+import {COORDINATE_PRECISION} from 'terraso-mobile-client/constants';
+
+export type CoordsKey = `(${string}, ${string})`;
 
 export type SoilIdLocationEntry = {
   input: Coords;
@@ -47,7 +49,7 @@ export const isErrorStatus = (status: SoilIdStatus): boolean => {
 };
 
 export const coordsKey = (coords: Coords): CoordsKey => {
-  return `(${coords.longitude}, ${coords.latitude})`;
+  return `(${coords.longitude.toFixed(COORDINATE_PRECISION)}, ${coords.latitude.toFixed(COORDINATE_PRECISION)})`;
 };
 
 export const locationEntryForStatus = (


### PR DESCRIPTION
## Description

Improve consistency of offline soil ID experience by caching location-based matches with the same precision used by UI coordinate rendering.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
#2415

### Verification steps

Select a point on the map while online, loading soil ID data, and note its coordinates. Go offline and search for the same coordinates. Verify that soil ID data is still displayed.
