### PR TITLE
feat: actions modal buttons

### DIFF
--- a/dev-client/src/components/ScreenFormWrapper.tsx
+++ b/dev-client/src/components/ScreenFormWrapper.tsx
@@ -109,7 +109,7 @@ export const ScreenFormWrapper = forwardRef(
               )}
               title={t('site.notes.confirm_removal_title')}
               body={t('site.notes.confirm_removal_body')}
-              actionName={t('general.delete_fab')}
+              actionLabel={t('general.delete_fab')}
               handleConfirm={onDelete}
             />
             <Button

--- a/dev-client/src/components/modals/ActionsModal.tsx
+++ b/dev-client/src/components/modals/ActionsModal.tsx
@@ -17,8 +17,6 @@
 
 import {forwardRef, useImperativeHandle, useMemo, useRef} from 'react';
 
-import {Button} from 'native-base';
-
 import {
   Modal,
   ModalHandle,
@@ -29,60 +27,6 @@ import {
   Heading,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-
-type ActionButtonProps = {
-  onPress: () => void;
-  variant: keyof typeof ACTION_BUTTON_VARIANTS;
-};
-
-const ACTION_BUTTON_DEFAULTS = {
-  px: '24px',
-  py: '10px',
-  _text: {
-    fontWeight: 400,
-    fontSize: '14px',
-  },
-} as const satisfies React.ComponentProps<typeof Button>;
-
-const ACTION_BUTTON_VARIANTS = {
-  default: {
-    _text: {
-      ...ACTION_BUTTON_DEFAULTS._text,
-      color: 'primary.contrast',
-    },
-  },
-  subtle: {
-    backgroundColor: 'grey.200',
-    borderWidth: '1px',
-    borderColor: 'm3.sys.light.outline',
-    _text: {
-      ...ACTION_BUTTON_DEFAULTS._text,
-      color: 'text.primary',
-    },
-  },
-  warning: {
-    backgroundColor: 'error.main',
-    _text: {
-      ...ACTION_BUTTON_DEFAULTS._text,
-      color: 'error.contrast',
-    },
-  },
-} as const satisfies Record<string, React.ComponentProps<typeof Button>>;
-
-export const ActionButton = ({
-  variant,
-  onPress,
-  children,
-}: React.PropsWithChildren<ActionButtonProps>) => {
-  return (
-    <Button
-      {...ACTION_BUTTON_DEFAULTS}
-      {...ACTION_BUTTON_VARIANTS[variant]}
-      onPress={onPress}>
-      {children}
-    </Button>
-  );
-};
 
 export type ActionsModalProps = Pick<ModalProps, 'trigger'> & {
   title?: string;

--- a/dev-client/src/components/modals/ConfirmDeleteDepthModal.tsx
+++ b/dev-client/src/components/modals/ConfirmDeleteDepthModal.tsx
@@ -36,7 +36,7 @@ export const ConfirmDeleteDepthModal = ({
       trigger={trigger}
       title={t('soil.depth.delete_modal.title')}
       body={t('soil.depth.delete_modal.body')}
-      actionName={t('soil.depth.delete_modal.action')}
+      actionLabel={t('soil.depth.delete_modal.action')}
       handleConfirm={onConfirm}
     />
   );

--- a/dev-client/src/components/modals/ConfirmModal.tsx
+++ b/dev-client/src/components/modals/ConfirmModal.tsx
@@ -24,8 +24,8 @@ import {
 } from 'react';
 import {useTranslation} from 'react-i18next';
 
+import {DialogButton} from 'terraso-mobile-client/components/buttons/DialogButton';
 import {
-  ActionButton,
   ActionsModal,
   ActionsModalProps,
 } from 'terraso-mobile-client/components/modals/ActionsModal';
@@ -35,9 +35,9 @@ import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 type Props = Omit<ActionsModalProps, 'actions'> & {
   title?: string;
   body: string;
-  actionName: string;
+  actionLabel: string;
+  destructive?: boolean;
   handleConfirm: () => void;
-  isConfirmError?: boolean;
 };
 
 /**
@@ -48,9 +48,9 @@ export const ConfirmModal = forwardRef<ModalHandle, Props>(
     {
       title,
       body,
-      actionName,
+      actionLabel,
       handleConfirm,
-      isConfirmError = true,
+      destructive = true,
       ...modalProps
     }: Props,
     forwardedRef,
@@ -68,17 +68,19 @@ export const ConfirmModal = forwardRef<ModalHandle, Props>(
     const actions = useMemo(
       () => (
         <>
-          <ActionButton variant="subtle" onPress={onClose}>
-            {t('general.cancel')}
-          </ActionButton>
-          <ActionButton
+          <DialogButton
+            label={t('general.cancel')}
+            type="outlined"
+            onPress={onClose}
+          />
+          <DialogButton
+            label={actionLabel}
             onPress={onConfirm}
-            variant={isConfirmError ? 'warning' : 'default'}>
-            {actionName}
-          </ActionButton>
+            type={destructive ? 'destructive' : 'default'}
+          />
         </>
       ),
-      [onConfirm, onClose, actionName, t, isConfirmError],
+      [onConfirm, onClose, actionLabel, t, destructive],
     );
 
     return (

--- a/dev-client/src/components/modals/PermissionsRequestWrapper.tsx
+++ b/dev-client/src/components/modals/PermissionsRequestWrapper.tsx
@@ -124,8 +124,8 @@ const PermissionsRequestWrapperImpl = ({
     <>
       <ConfirmModal
         ref={ref}
-        isConfirmError={false}
-        actionName={t('general.open_settings')}
+        destructive={false}
+        actionLabel={t('general.open_settings')}
         title={requestModalTitle}
         body={requestModalBody}
         handleConfirm={Linking.openSettings}

--- a/dev-client/src/components/modals/SignOutModal.tsx
+++ b/dev-client/src/components/modals/SignOutModal.tsx
@@ -37,8 +37,8 @@ export function SignOutModal({trigger}: LogoutModalProps) {
     <ConfirmModal
       trigger={trigger}
       body={t('sign_out.confirm_body')}
-      actionName={t('sign_out.confirm_action')}
-      isConfirmError={false}
+      actionLabel={t('sign_out.confirm_action')}
+      destructive={false}
       handleConfirm={onSignOut}
     />
   );

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisHomeScreen.tsx
@@ -21,12 +21,10 @@ import {Image, Pressable, StyleSheet} from 'react-native';
 
 import {Fab} from 'native-base';
 
+import {DialogButton} from 'terraso-mobile-client/components/buttons/DialogButton';
 import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
-import {
-  ActionButton,
-  ActionsModal,
-} from 'terraso-mobile-client/components/modals/ActionsModal';
+import {ActionsModal} from 'terraso-mobile-client/components/modals/ActionsModal';
 import {ModalHandle} from 'terraso-mobile-client/components/modals/Modal';
 import {
   Box,
@@ -111,16 +109,15 @@ export const ColorAnalysisHomeScreen = () => {
     () =>
       colorResult && (
         <>
-          <ActionButton
-            variant="subtle"
-            onPress={() => dispatchColor(colorResult!.nearestValidResult)}>
-            {t('soil.color.unexpected_color.use_suggestion')}
-          </ActionButton>
-          <ActionButton
-            variant="default"
-            onPress={() => dispatchColor(colorResult!.invalidResult)}>
-            {t('general.proceed')}
-          </ActionButton>
+          <DialogButton
+            type="outlined"
+            onPress={() => dispatchColor(colorResult!.nearestValidResult)}
+            label={t('soil.color.unexpected_color.use_suggestion')}
+          />
+          <DialogButton
+            onPress={() => dispatchColor(colorResult!.invalidResult)}
+            label={t('general.proceed')}
+          />
         </>
       ),
     [dispatchColor, colorResult, t],

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -130,7 +130,7 @@ export const ManageTeamMemberScreen = ({
                 )}
                 title={t('projects.manage_member.confirm_removal_title')}
                 body={t('projects.manage_member.confirm_removal_body')}
-                actionName={t('projects.manage_member.confirm_removal_action')}
+                actionLabel={t('projects.manage_member.confirm_removal_action')}
                 handleConfirm={removeMembership}
               />
               <Text ml="20px" variant="caption">

--- a/dev-client/src/screens/ProjectInputScreen/SoilPitSettings.tsx
+++ b/dev-client/src/screens/ProjectInputScreen/SoilPitSettings.tsx
@@ -112,7 +112,7 @@ export const SoilPitSettings = ({projectId}: {projectId: string}) => {
         )}
         title={t('projects.inputs.depths.confirm_preset.title')}
         body={t('projects.inputs.depths.confirm_preset.body')}
-        actionName={t('projects.inputs.depths.confirm_preset.confirm')}
+        actionLabel={t('projects.inputs.depths.confirm_preset.confirm')}
         handleConfirm={onChangeDepthPreset}
       />
       {settings.depthIntervalPreset !== 'NONE' && (

--- a/dev-client/src/screens/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen.tsx
@@ -97,7 +97,7 @@ export function ProjectSettingsScreen({
             <RestrictByProjectRole role={PROJECT_MANAGER_ROLES}>
               <ConfirmModal
                 title={t('projects.settings.delete_button_prompt')}
-                actionName={t('projects.settings.delete_button')}
+                actionLabel={t('projects.settings.delete_button')}
                 body={t('projects.settings.delete_description')}
                 handleConfirm={triggerDeleteProject}
                 trigger={onOpen => (

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -110,7 +110,7 @@ const SiteMenu = ({site}: SiteProps) => {
         body={t('projects.sites.remove_site_modal.body', {
           siteName: site.name,
         })}
-        actionName={t('projects.sites.remove_site_modal.action_name')}
+        actionLabel={t('projects.sites.remove_site_modal.action_name')}
         handleConfirm={removeSiteFromProjectCallback}
       />
 
@@ -129,7 +129,7 @@ const SiteMenu = ({site}: SiteProps) => {
             siteName: site.name,
           }) + t('projects.sites.delete_site_modal.projects')
         }
-        actionName={t('projects.sites.delete_site_modal.action_name')}
+        actionLabel={t('projects.sites.delete_site_modal.action_name')}
         handleConfirm={deleteSiteCallback}
       />
     </Menu>

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -105,7 +105,7 @@ export const UserItem = ({
           )}
           title={t('projects.team.leave_project_modal.title')}
           body={t('projects.team.leave_project_modal.body')}
-          actionName={t('projects.team.leave_project_modal.action_name')}
+          actionLabel={t('projects.team.leave_project_modal.action_name')}
           handleConfirm={removeUser}
         />
       )}

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -114,7 +114,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
                 body={t('projects.sites.delete_site_modal.body', {
                   siteName: site.name,
                 })}
-                actionName={t('projects.sites.delete_site_modal.action_name')}
+                actionLabel={t('projects.sites.delete_site_modal.action_name')}
                 handleConfirm={onDelete}
               />
             )}

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -262,7 +262,7 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
               )}
               title={t('projects.sites.transfer_site_modal.title')}
               body={t('projects.sites.transfer_site_modal.body')}
-              actionName={t('projects.sites.transfer_site_modal.action_name')}
+              actionLabel={t('projects.sites.transfer_site_modal.action_name')}
               handleConfirm={onSubmit}
             />
           </ScrollView>

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -19,9 +19,8 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {ScrollView} from 'react-native';
 
-import {Fab} from 'native-base';
-
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
+import {Fab} from 'terraso-mobile-client/components/buttons/Fab';
 import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
@@ -254,12 +253,10 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
                 <Fab
                   label={t('projects.sites.transfer')}
                   onPress={onOpen}
-                  isDisabled={disabled}
-                  _disabled={{
-                    shadow: 0,
-                  }}
+                  disabled={disabled}
                 />
               )}
+              destructive={false}
               title={t('projects.sites.transfer_site_modal.title')}
               body={t('projects.sites.transfer_site_modal.body')}
               actionLabel={t('projects.sites.transfer_site_modal.action_name')}

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -198,9 +198,9 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
                 ref={confirmationModalRef}
                 title={t('slope.steepness.confirm_title')}
                 body={t('slope.steepness.confirm_body')}
-                actionName={t('general.change')}
+                actionLabel={t('general.change')}
                 handleConfirm={onConfirmSteepness}
-                isConfirmError={false}
+                destructive={false}
               />
               <ImageRadio
                 value={soilData.slopeSteepnessSelect}

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/ColorDisplay.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/ColorDisplay.tsx
@@ -54,7 +54,7 @@ export const ColorDisplay = ({onDelete, color, variant}: Props) => {
           <ConfirmModal
             title={t('soil.color.confirm_delete.title')}
             body={t('soil.color.confirm_delete.body')}
-            actionName={t('soil.color.confirm_delete.action_name')}
+            actionLabel={t('soil.color.confirm_delete.action_name')}
             handleConfirm={onDelete}
             trigger={onPress => (
               <View position="absolute" top="-18px" right="-18px">

--- a/dev-client/src/screens/SoilScreen/ColorScreen/components/SwitchWorkflowButton.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/components/SwitchWorkflowButton.tsx
@@ -82,7 +82,7 @@ export const SwitchWorkflowButton = ({
     <ConfirmModal
       title={t('soil.color.confirm_delete.title')}
       body={t('soil.color.confirm_delete.body')}
-      actionName={t('soil.color.confirm_delete.action_name')}
+      actionLabel={t('soil.color.confirm_delete.action_name')}
       handleConfirm={switchWorkflow}
       trigger={button}
     />

--- a/dev-client/src/screens/SoilScreen/components/EditDepthModal.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditDepthModal.tsx
@@ -304,7 +304,7 @@ const ConfirmEditingModal = ({
       )}
       title={t('soil.depth.update_modal.title')}
       body={t('soil.depth.update_modal.body')}
-      actionName={t('soil.depth.update_modal.action')}
+      actionLabel={t('soil.depth.update_modal.action')}
       handleConfirm={() => handleSubmit()}
     />
   );

--- a/dev-client/src/screens/SoilScreen/components/EditSiteSoilDepthPreset.tsx
+++ b/dev-client/src/screens/SoilScreen/components/EditSiteSoilDepthPreset.tsx
@@ -82,7 +82,7 @@ export const EditSiteSoilDepthPreset = ({selected, updateChoice}: Props) => {
         handleConfirm={onConfirm}
         title={t('projects.inputs.depths.confirm_preset.title')}
         body={t('projects.inputs.depths.confirm_preset.body')}
-        actionName={t('projects.inputs.depths.confirm_preset.confirm')}
+        actionLabel={t('projects.inputs.depths.confirm_preset.confirm')}
       />
     </Column>
   );


### PR DESCRIPTION
## Description

Update `ActionsModal` button usages to replace old `ActionButton` with `DialogButton`. Along the way, update `SiteTransferProjectScreen` to use correct button styling.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#2709

### Verification steps

Transfer sites to a project and verify confirm dialog styling. Verify other ActionsModal styles (for example, logging out or deleting a depth interval.)