### PR TITLE
feat: require depth intervals and permissions on relevant screens

### DIFF
--- a/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
+++ b/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
@@ -32,15 +32,15 @@ jest.mock('terraso-mobile-client/navigation/hooks/useNavigation', () => {
   };
 });
 
-const mockedUserMayEditSiteNote = jest.spyOn(
+const mockedUserCanEditSiteNote = jest.spyOn(
   permissionHooks,
-  'useUserMayEditSiteNote',
+  'useUserCanEditSiteNote',
 );
-mockedUserMayEditSiteNote.mockReturnValue(true);
+mockedUserCanEditSiteNote.mockReturnValue(true);
 
 afterEach(() => {
   mockedNavigate.mockClear();
-  mockedUserMayEditSiteNote.mockReset();
+  mockedUserCanEditSiteNote.mockReset();
 });
 
 describe('EditSiteNoteScreen', () => {
@@ -90,7 +90,7 @@ describe('EditSiteNoteScreen', () => {
   });
 
   test('renders null if user does not have permissions to edit the note', () => {
-    mockedUserMayEditSiteNote.mockReturnValue(false);
+    mockedUserCanEditSiteNote.mockReturnValue(false);
 
     const screen = render(
       <EditSiteNoteScreen noteId="nonexistent-note" siteId="1" />,

--- a/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
+++ b/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
@@ -18,6 +18,7 @@
 import {testState} from '@testing/integration/data';
 import {render} from '@testing/integration/utils';
 
+import * as permissionHooks from 'terraso-mobile-client/hooks/permissionHooks';
 import {EditSiteNoteScreen} from 'terraso-mobile-client/screens/SiteNotesScreen/EditSiteNoteScreen';
 
 const mockedNavigate = jest.fn();
@@ -27,12 +28,19 @@ jest.mock('terraso-mobile-client/navigation/hooks/useNavigation', () => {
   );
   return {
     ...actualNav,
-    useNavigation: () => ({navigate: mockedNavigate}),
+    useNavigation: () => ({navigate: mockedNavigate, pop: mockedNavigate}),
   };
 });
 
+const mockedUserMayEditSiteNote = jest.spyOn(
+  permissionHooks,
+  'useUserMayEditSiteNote',
+);
+mockedUserMayEditSiteNote.mockReturnValue(true);
+
 afterEach(() => {
   mockedNavigate.mockClear();
+  mockedUserMayEditSiteNote.mockReset();
 });
 
 describe('EditSiteNoteScreen', () => {
@@ -64,6 +72,26 @@ describe('EditSiteNoteScreen', () => {
   });
 
   test('renders null if note missing', () => {
+    const screen = render(
+      <EditSiteNoteScreen noteId="nonexistent-note" siteId="1" />,
+      {
+        route: 'EDIT_SITE_NOTE',
+        initialState: testState,
+      },
+    );
+
+    expect(screen.queryByText('Site Note')).toBeNull();
+    expect(screen.queryByText('note 1 contents')).toBeNull();
+    expect(mockedNavigate).toHaveBeenCalledTimes(1);
+    expect(mockedNavigate).toHaveBeenCalledWith('SITE_TABS', {
+      initialTab: 'NOTES',
+      siteId: '1',
+    });
+  });
+
+  test('renders null if user does not have permissions to edit the note', () => {
+    mockedUserMayEditSiteNote.mockReturnValue(false);
+
     const screen = render(
       <EditSiteNoteScreen noteId="nonexistent-note" siteId="1" />,
       {

--- a/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
+++ b/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
@@ -28,7 +28,7 @@ jest.mock('terraso-mobile-client/navigation/hooks/useNavigation', () => {
   );
   return {
     ...actualNav,
-    useNavigation: () => ({navigate: mockedNavigate, pop: mockedNavigate}),
+    useNavigation: () => ({navigate: mockedNavigate}),
   };
 });
 

--- a/dev-client/__tests__/integration/ScreenDataRequirements.test.tsx
+++ b/dev-client/__tests__/integration/ScreenDataRequirements.test.tsx
@@ -100,7 +100,7 @@ describe('ScreenDataRequirements', () => {
     expect(thingsDone).toEqual('null');
   });
 
-  test('renders children and triggers no action when required data exists, even if it is a boolean equal to false', () => {
+  test('does not render children and triggers action when required data is falsy', () => {
     let thingsDone = '';
     const requirements = [
       {
@@ -115,7 +115,7 @@ describe('ScreenDataRequirements', () => {
       </ScreenDataRequirements>,
     );
 
-    expect(queryByText('Hello world')).toBeTruthy();
-    expect(thingsDone).toEqual('');
+    expect(queryByText('Hello world')).toBeNull();
+    expect(thingsDone).toEqual('false');
   });
 });

--- a/dev-client/__tests__/integration/ScreenDataRequirements.test.tsx
+++ b/dev-client/__tests__/integration/ScreenDataRequirements.test.tsx
@@ -27,12 +27,27 @@ describe('ScreenDataRequirements', () => {
     const requirements = [
       {
         data: {dummyData: 1},
-        doIfMissing: () => (thingsDone += 'object1'),
+        doIfMissing: () => (thingsDone += 'object'),
       },
       {
         // This is an object, so it exists despite having only undefined properties
         data: {dummyData: undefined},
-        doIfMissing: () => (thingsDone += 'object2'),
+        doIfMissing: () => (thingsDone += 'object with undefined'),
+      },
+      {
+        // Some falsy things are still considered valid
+        data: 0,
+        doIfMissing: () => (thingsDone += '0'),
+      },
+      {
+        // Some falsy things are still considered valid
+        data: '',
+        doIfMissing: () => (thingsDone += 'empty string'),
+      },
+      {
+        // Some falsy things are still considered valid
+        data: NaN,
+        doIfMissing: () => (thingsDone += 'NaN'),
       },
     ];
 

--- a/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
+++ b/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
@@ -23,7 +23,7 @@ type Requirement = {
 };
 
 const dataExists = (data: object | undefined | null) => {
-  return data !== null && data !== undefined;
+  return !!data;
 };
 // First item should be the entity with the largest scope
 // Example: if EditSiteNoteScreen is missing the site and the site note,
@@ -50,9 +50,9 @@ type Props = {
 };
 
 /*
- * This is intended to wrap components (mostly screens as of 2024-12) so they only render
- * if required data is truthy. This prevents screens from breaking if, for example, a pull
- * happens that deletes data that is required to view the screen.
+ * This is intended to wrap Screen components so they only render if required data is truthy, and do
+ * an action if not. This prevents screens from breaking if, for example, a pull happens that
+ * deletes data that is required to view the screen.
  */
 export const ScreenDataRequirements = ({requirements, children}: Props) => {
   const requiredDataExists = useRequiredData(requirements);

--- a/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
+++ b/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
@@ -22,8 +22,8 @@ type Requirement = {
   doIfMissing?: () => void;
 };
 
-const dataExists = (data: object | undefined | null) => {
-  return Boolean(data);
+const dataExists = (data: object | undefined | null | boolean) => {
+  return data !== undefined && data !== null && data !== false;
 };
 // First item should be the entity with the largest scope
 // Example: if EditSiteNoteScreen is missing the site and the site note,

--- a/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
+++ b/dev-client/src/components/dataRequirements/ScreenDataRequirements.tsx
@@ -23,7 +23,7 @@ type Requirement = {
 };
 
 const dataExists = (data: object | undefined | null) => {
-  return !!data;
+  return Boolean(data);
 };
 // First item should be the entity with the largest scope
 // Example: if EditSiteNoteScreen is missing the site and the site note,

--- a/dev-client/src/components/dataRequirements/commonRequirements.ts
+++ b/dev-client/src/components/dataRequirements/commonRequirements.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2025 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {DepthInterval} from 'terraso-client-shared/graphqlSchema/graphql';
+
+import {
+  useNavToBottomTabsAndShowSyncError,
+  useNavToSiteAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useMemoizedRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {useSelector} from 'terraso-mobile-client/store';
+import {
+  selectSite,
+  useSiteSoilInterval,
+} from 'terraso-mobile-client/store/selectors';
+
+export const useDefaultSiteDepthRequirements = (
+  siteId: string,
+  depthIntervalSpec: DepthInterval,
+) => {
+  const site = useSelector(selectSite(siteId));
+  const realDepthInterval = useSiteSoilInterval(siteId, depthIntervalSpec);
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
+  const handleMissingDepth = useNavToSiteAndShowSyncError(siteId);
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+    {data: realDepthInterval, doIfMissing: handleMissingDepth},
+  ]);
+  return requirements;
+};

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -17,17 +17,9 @@
 
 import {useCallback} from 'react';
 
-import {DepthInterval} from 'terraso-client-shared/graphqlSchema/graphql';
-
-import {useMemoizedRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {useSelector} from 'terraso-mobile-client/store';
-import {
-  selectSite,
-  useSiteSoilInterval,
-} from 'terraso-mobile-client/store/selectors';
 
 export const useNavToBottomTabsAndShowSyncError = () => {
   const navigation = useNavigation();
@@ -63,19 +55,4 @@ export const useNavToSiteAndShowSyncError = (siteId: string) => {
       syncNotifications.showError();
     }
   }, [siteId, navigation, syncNotifications]);
-};
-
-export const useDefaultSiteDepthRequirements = (
-  siteId: string,
-  depthIntervalSpec: DepthInterval,
-) => {
-  const site = useSelector(selectSite(siteId));
-  const realDepthInterval = useSiteSoilInterval(siteId, depthIntervalSpec);
-  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const handleMissingDepth = useNavToSiteAndShowSyncError(siteId);
-  const requirements = useMemoizedRequirements([
-    {data: site, doIfMissing: handleMissingSite},
-    {data: realDepthInterval, doIfMissing: handleMissingDepth},
-  ]);
-  return requirements;
 };

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -17,9 +17,17 @@
 
 import {useCallback} from 'react';
 
+import {DepthInterval} from 'terraso-client-shared/graphqlSchema/graphql';
+
+import {useMemoizedRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {useSelector} from 'terraso-mobile-client/store';
+import {
+  selectSite,
+  useSiteSoilInterval,
+} from 'terraso-mobile-client/store/selectors';
 
 export const useNavToBottomTabsAndShowSyncError = () => {
   const navigation = useNavigation();
@@ -55,4 +63,19 @@ export const useNavToSiteAndShowSyncError = (siteId: string) => {
       syncNotifications.showError();
     }
   }, [siteId, navigation, syncNotifications]);
+};
+
+export const useDefaultSiteDepthRequirements = (
+  siteId: string,
+  depthIntervalSpec: DepthInterval,
+) => {
+  const site = useSelector(selectSite(siteId));
+  const realDepthInterval = useSiteSoilInterval(siteId, depthIntervalSpec);
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
+  const handleMissingDepth = useNavToSiteAndShowSyncError(siteId);
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+    {data: realDepthInterval, doIfMissing: handleMissingDepth},
+  ]);
+  return requirements;
 };

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -44,3 +44,15 @@ export const usePopNavigationAndShowSyncError = () => {
     }
   }, [navigation, syncNotifications]);
 };
+
+export const useNavToSiteAndShowSyncError = (siteId: string) => {
+  const navigation = useNavigation();
+  const syncNotifications = useSyncNotificationContext();
+
+  return useCallback(() => {
+    navigation.navigate('SITE_TABS', {siteId: siteId});
+    if (isFlagEnabled('FF_offline')) {
+      syncNotifications.showError();
+    }
+  }, [siteId, navigation, syncNotifications]);
+};

--- a/dev-client/src/components/restrictions/RestrictByRole.tsx
+++ b/dev-client/src/components/restrictions/RestrictByRole.tsx
@@ -51,6 +51,14 @@ const RestrictByRole = <RoleType,>({
   return display ? <>{children}</> : <></>;
 };
 
+export const projectRolesEqual = (a: ProjectRole, b: ProjectRole) => {
+  return a === b;
+};
+
+export const siteRolesEqual = (a: SiteUserRole, b: SiteUserRole) => {
+  return a.kind === b.kind && a.role === b.role;
+};
+
 export const RestrictByProjectRole = ({
   role,
   children,
@@ -59,7 +67,7 @@ export const RestrictByProjectRole = ({
   return (
     <RestrictByRole
       userRole={userRole}
-      cmp={(a, b) => a === b}
+      cmp={projectRolesEqual}
       allowedRole={role}>
       {children}
     </RestrictByRole>
@@ -73,10 +81,7 @@ export const RestrictBySiteRole = ({
   const siteRole = useSiteRoleContext();
 
   return (
-    <RestrictByRole
-      userRole={siteRole}
-      cmp={(a, b) => a.kind === b.kind && a.role === b.role}
-      allowedRole={role}>
+    <RestrictByRole userRole={siteRole} cmp={siteRolesEqual} allowedRole={role}>
       {children}
     </RestrictByRole>
   );

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -43,19 +43,19 @@ export const useProjectUserRolesFilter = (
   );
 };
 
-export const useRoleMayEditProject = (projectId: string) => {
+export const useRoleCanEditProject = (projectId: string) => {
   const userRole = useSelector(state =>
     selectUserRoleProject(state, projectId),
   );
   return canEditProject(userRole);
 };
 
-export const useRoleMayEditSite = (siteId: string) => {
+export const useRoleCanEditSite = (siteId: string) => {
   const userRole = useSelector(state => selectUserRoleSite(state, siteId));
   return canEditSite(userRole);
 };
 
-export const useUserMayEditSiteNote = ({
+export const useUserCanEditSiteNote = ({
   siteId,
   noteId,
 }: {

--- a/dev-client/src/hooks/permissionHooks.ts
+++ b/dev-client/src/hooks/permissionHooks.ts
@@ -19,8 +19,20 @@ import {useCallback} from 'react';
 
 import {Project, ProjectRole} from 'terraso-client-shared/project/projectTypes';
 
-import {userHasProjectRole} from 'terraso-mobile-client/model/permissions/permissions';
+import {
+  projectRolesEqual,
+  siteRolesEqual,
+} from 'terraso-mobile-client/components/restrictions/RestrictByRole';
+import {
+  PROJECT_EDITOR_ROLES,
+  SITE_EDITOR_ROLES,
+  userHasProjectRole,
+} from 'terraso-mobile-client/model/permissions/permissions';
 import {useSelector} from 'terraso-mobile-client/store';
+import {
+  selectUserRoleProject,
+  selectUserRoleSite,
+} from 'terraso-mobile-client/store/selectors';
 
 type ProjectFilter = (project: Project) => boolean;
 
@@ -32,4 +44,21 @@ export const useProjectUserRolesFilter = (
     project => userHasProjectRole(currentUser, project, userRoles),
     [currentUser, userRoles],
   );
+};
+
+export const useRoleMayEditProject = (projectId: string) => {
+  const userRole = useSelector(state =>
+    selectUserRoleProject(state, projectId),
+  );
+  return !!PROJECT_EDITOR_ROLES.find(editorRole => {
+    return userRole !== null && projectRolesEqual(userRole, editorRole);
+  });
+};
+
+export const useRoleMayEditSite = (siteId: string) => {
+  const userRole = useSelector(state => selectUserRoleSite(state, siteId));
+  const foundRole = SITE_EDITOR_ROLES.find(editorRole => {
+    return userRole !== null && siteRolesEqual(userRole, editorRole);
+  });
+  return !!foundRole;
 };

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -55,7 +55,7 @@ export const isProjectViewer = (userRole: SiteUserRole | null) => {
   return Boolean(userRole && ['VIEWER'].includes(userRole.role));
 };
 
-export const isProjectEditor = (userRole: SiteUserRole | null) => {
+export const canEditSite = (userRole: SiteUserRole | null) => {
   return Boolean(
     userRole && ['MANAGER', 'CONTRIBUTOR', 'OWNER'].includes(userRole.role),
   );

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -61,6 +61,10 @@ export const canEditSite = (userRole: SiteUserRole | null) => {
   );
 };
 
+export const canEditProject = (userRole: ProjectRole | null) => {
+  return Boolean(userRole && PROJECT_EDITOR_ROLES.includes(userRole));
+};
+
 export const userHasProjectRole = (
   currentUser: User | null,
   project: Project | null,

--- a/dev-client/src/model/permissions/permissions.ts
+++ b/dev-client/src/model/permissions/permissions.ts
@@ -63,10 +63,10 @@ export const isProjectEditor = (userRole: SiteUserRole | null) => {
 
 export const userHasProjectRole = (
   currentUser: User | null,
-  project: Project,
+  project: Project | null,
   userRoles?: ProjectRole[],
 ) => {
-  if (!currentUser) {
+  if (!currentUser || !project) {
     return false;
   }
 

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -37,7 +37,7 @@ import {
   Column,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {addUserToProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {TabRoutes} from 'terraso-mobile-client/navigation/constants';
@@ -74,7 +74,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
-  const roleIsEditor = useRoleMayEditProject(projectId);
+  const roleIsEditor = useRoleCanEditProject(projectId);
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -37,6 +37,7 @@ import {
   Column,
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {addUserToProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {TabRoutes} from 'terraso-mobile-client/navigation/constants';
@@ -73,10 +74,13 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, user, selectedRole, navigation]);
 
+  const roleIsEditor = useRoleMayEditProject(projectId);
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
     {data: user, doIfMissing: handleMissingUser},
   ]);
 

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -58,30 +58,30 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
   const navigation = useNavigation();
 
   const project = useSelector(state => state.project.projects[projectId]);
-  const user = useSelector(state => state.account.users[userId]);
+  const newUser = useSelector(state => state.account.users[userId]);
 
   const [selectedRole, setSelectedRole] = useState<ProjectRole>('VIEWER');
 
   const addUser = useCallback(async () => {
     try {
       dispatch(
-        addUserToProject({userId: user.id, role: selectedRole, projectId}),
+        addUserToProject({userId: newUser.id, role: selectedRole, projectId}),
       );
     } catch (e) {
       console.error(e);
     }
     navigation.navigate('PROJECT_VIEW', {projectId: projectId});
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
-  }, [dispatch, projectId, user, selectedRole, navigation]);
+  }, [dispatch, projectId, newUser, selectedRole, navigation]);
 
-  const roleIsEditor = useRoleCanEditProject(projectId);
+  const userCanEditProject = useRoleCanEditProject(projectId);
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
-  const handleMissingUser = usePopNavigationAndShowSyncError();
+  const handleMissingNewUser = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
-    {data: user, doIfMissing: handleMissingUser},
+    {data: userCanEditProject, doIfMissing: handleInsufficientPermissions},
+    {data: newUser, doIfMissing: handleMissingNewUser},
   ]);
 
   return (
@@ -91,7 +91,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
           <ScreenContentSection title={t('projects.add_user.heading')}>
             <Column>
               <Box ml="md" my="lg">
-                <MinimalUserDisplay user={user} />
+                <MinimalUserDisplay user={newUser} />
               </Box>
 
               <ProjectRoleRadioBlock

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -27,7 +27,7 @@ import {
   useMemoizedRequirements,
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AddTeamMemberForm} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/AddTeamMemberForm';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -47,7 +47,7 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
   // wanting to add multiple users at the same time.
 
-  const roleIsEditor = useRoleMayEditProject(projectId);
+  const roleIsEditor = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -47,12 +47,12 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
   // wanting to add multiple users at the same time.
 
-  const roleIsEditor = useRoleCanEditProject(projectId);
+  const userCanEditProject = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
+    {data: userCanEditProject, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectScreen.tsx
@@ -18,12 +18,16 @@
 import {useTranslation} from 'react-i18next';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {AddTeamMemberForm} from 'terraso-mobile-client/screens/AddUserToProjectScreen/components/AddTeamMemberForm';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
@@ -43,9 +47,12 @@ export const AddUserToProjectScreen = ({projectId}: Props) => {
   // This was replaced, but we could refer back to `userRecord` in previous versions if we ever end up
   // wanting to add multiple users at the same time.
 
+  const roleIsEditor = useRoleMayEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
@@ -17,7 +17,7 @@
 
 import {useMemo, useState} from 'react';
 
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Photo} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {DEFAULT_STACK_NAVIGATOR_OPTIONS} from 'terraso-mobile-client/navigation/constants';

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorAnalysisScreen.tsx
@@ -17,6 +17,8 @@
 
 import {useMemo, useState} from 'react';
 
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Photo} from 'terraso-mobile-client/components/inputs/image/ImagePicker';
 import {DEFAULT_STACK_NAVIGATOR_OPTIONS} from 'terraso-mobile-client/navigation/constants';
 import {
@@ -46,13 +48,22 @@ export const ColorAnalysisScreen = ({photo, pitProps}: ColorAnalysisProps) => {
     [photo, pitProps, state, setState],
   );
 
+  const requirements = useDefaultSiteDepthRequirements(
+    pitProps.siteId,
+    pitProps.depthInterval.depthInterval,
+  );
+
   return (
-    <ColorAnalysisContext.Provider value={contextValue}>
-      <Stack.Navigator
-        initialRouteName="COLOR_ANALYSIS_HOME"
-        screenOptions={DEFAULT_STACK_NAVIGATOR_OPTIONS}>
-        {screens}
-      </Stack.Navigator>
-    </ColorAnalysisContext.Provider>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <ColorAnalysisContext.Provider value={contextValue}>
+          <Stack.Navigator
+            initialRouteName="COLOR_ANALYSIS_HOME"
+            screenOptions={DEFAULT_STACK_NAVIGATOR_OPTIONS}>
+            {screens}
+          </Stack.Navigator>
+        </ColorAnalysisContext.Provider>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -76,12 +76,12 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
     await handleUpdateProject({content: ''});
   };
 
-  const roleIsEditor = useRoleCanEditProject(projectId);
+  const userCanEditProject = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
+    {data: userCanEditProject, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -21,7 +21,10 @@ import {Keyboard} from 'react-native';
 
 import {ProjectUpdateMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
@@ -32,6 +35,7 @@ import {
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {ScreenFormWrapper} from 'terraso-mobile-client/components/ScreenFormWrapper';
+import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {updateProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteNoteForm} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteForm';
@@ -72,9 +76,12 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
     await handleUpdateProject({content: ''});
   };
 
+  const roleIsEditor = useRoleMayEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/EditPinnedNoteScreen.tsx
+++ b/dev-client/src/screens/EditPinnedNoteScreen.tsx
@@ -35,7 +35,7 @@ import {
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {ScreenFormWrapper} from 'terraso-mobile-client/components/ScreenFormWrapper';
-import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {updateProject} from 'terraso-mobile-client/model/project/projectGlobalReducer';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteNoteForm} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteForm';
@@ -76,7 +76,7 @@ export const EditPinnedNoteScreen = ({projectId}: Props) => {
     await handleUpdateProject({content: ''});
   };
 
-  const roleIsEditor = useRoleMayEditProject(projectId);
+  const roleIsEditor = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -38,7 +38,7 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {
   deleteUserFromProject,
   updateUserRole,
@@ -88,7 +88,7 @@ export const ManageTeamMemberScreen = ({
     navigation.pop();
   }, [dispatch, projectId, userId, selectedRole, navigation]);
 
-  const roleIsEditor = useRoleMayEditProject(projectId);
+  const roleIsEditor = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -88,13 +88,13 @@ export const ManageTeamMemberScreen = ({
     navigation.pop();
   }, [dispatch, projectId, userId, selectedRole, navigation]);
 
-  const roleIsEditor = useRoleCanEditProject(projectId);
+  const userCanEditProject = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
+    {data: userCanEditProject, doIfMissing: handleInsufficientPermissions},
     {data: user, doIfMissing: handleMissingUser},
   ]);
 

--- a/dev-client/src/screens/ManageTeamMemberScreen.tsx
+++ b/dev-client/src/screens/ManageTeamMemberScreen.tsx
@@ -38,6 +38,7 @@ import {
   Row,
   Text,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {
   deleteUserFromProject,
   updateUserRole,
@@ -87,10 +88,13 @@ export const ManageTeamMemberScreen = ({
     navigation.pop();
   }, [dispatch, projectId, userId, selectedRole, navigation]);
 
+  const roleIsEditor = useRoleMayEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleMissingUser = usePopNavigationAndShowSyncError();
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
     {data: user, doIfMissing: handleMissingUser},
   ]);
 

--- a/dev-client/src/screens/ProjectSettingsScreen/ProjectSettingsScreen.tsx
+++ b/dev-client/src/screens/ProjectSettingsScreen/ProjectSettingsScreen.tsx
@@ -72,6 +72,8 @@ export function ProjectSettingsScreen({
 
   const userRole = useProjectRoleContext();
 
+  // FYI we don't need to require role permissions to view this tab; that's handled
+  // further up in the project tab navigator
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},

--- a/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/AddSiteNoteScreen.tsx
@@ -21,7 +21,10 @@ import {Keyboard} from 'react-native';
 
 import {SiteNoteAddMutationInput} from 'terraso-client-shared/graphqlSchema/graphql';
 
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
@@ -32,6 +35,7 @@ import {
   Heading,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {ScreenFormWrapper} from 'terraso-mobile-client/components/ScreenFormWrapper';
+import {useRoleCanEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
 import {addSiteNote} from 'terraso-mobile-client/model/site/siteSlice';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteNoteForm} from 'terraso-mobile-client/screens/SiteNotesScreen/components/SiteNoteForm';
@@ -74,9 +78,13 @@ export const AddSiteNoteScreen = ({siteId}: Props) => {
   };
 
   const site = useSelector(selectSite(siteId));
+  const userCanEditSite = useRoleCanEditSite(siteId);
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
+
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
+    {data: userCanEditSite, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -17,13 +17,17 @@
 
 import {useCallback} from 'react';
 
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
+import {useUserMayEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteTabNavigator';
 import {EditSiteNoteContent} from 'terraso-mobile-client/screens/SiteNotesScreen/components/EditSiteNoteContent';
@@ -41,8 +45,7 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
 
   const site = useSelector(state => selectSite(siteId)(state));
   const note = site?.notes[noteId];
-  // TODO: Also handle the case where user no longer has permissions to edit notes
-
+  const userCanEditNote = useUserMayEditSiteNote({siteId, noteId});
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleMissingSiteNote = useCallback(() => {
     navigation.navigate('SITE_TABS', {
@@ -53,9 +56,11 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
       syncNotifications.showError();
     }
   }, [navigation, siteId, syncNotifications]);
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
     {data: note, doIfMissing: handleMissingSiteNote},
+    {data: userCanEditNote, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -27,7 +27,7 @@ import {
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {useSyncNotificationContext} from 'terraso-mobile-client/context/SyncNotificationContext';
-import {useUserMayEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useUserCanEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SiteTabName} from 'terraso-mobile-client/navigation/navigators/SiteTabNavigator';
 import {EditSiteNoteContent} from 'terraso-mobile-client/screens/SiteNotesScreen/components/EditSiteNoteContent';
@@ -45,7 +45,7 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
 
   const site = useSelector(state => selectSite(siteId)(state));
   const note = site?.notes[noteId];
-  const userCanEditNote = useUserMayEditSiteNote({siteId, noteId});
+  const userCanEditNote = useUserCanEditSiteNote({siteId, noteId});
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleMissingSiteNote = useCallback(() => {
     navigation.navigate('SITE_TABS', {

--- a/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
@@ -25,10 +25,9 @@ import {SiteNote} from 'terraso-client-shared/site/siteTypes';
 import {Card} from 'terraso-mobile-client/components/Card';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useSiteRoleContext} from 'terraso-mobile-client/context/SiteRoleContext';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
+import {useUserMayEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {useSelector} from 'terraso-mobile-client/store';
 import {formatDate, formatFullName} from 'terraso-mobile-client/util';
 
 type Props = {
@@ -39,17 +38,12 @@ export const SiteNoteCard = ({note}: Props) => {
   const {t} = useTranslation();
   const navigation = useNavigation();
 
-  const currentUser = useSelector(state => state.account.currentUser.data);
-  const currentUserIsAuthor = note.authorId === currentUser?.id;
-  const siteRole = useSiteRoleContext();
-  const currentUserIsOwner = siteRole?.role === 'OWNER';
-  const currentUserIsManager = siteRole?.role === 'MANAGER';
-
   const isOffline = useIsOffline();
-
-  const canViewEditScreen =
-    !isOffline &&
-    (currentUserIsAuthor || currentUserIsOwner || currentUserIsManager);
+  const userCanEditNote = useUserMayEditSiteNote({
+    siteId: note.siteId,
+    noteId: note.id,
+  });
+  const canViewEditScreen = !isOffline && userCanEditNote;
 
   const onEditNote = useCallback(() => {
     if (canViewEditScreen) {

--- a/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
@@ -26,7 +26,7 @@ import {Card} from 'terraso-mobile-client/components/Card';
 import {Icon} from 'terraso-mobile-client/components/icons/Icon';
 import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
-import {useUserMayEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useUserCanEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {formatDate, formatFullName} from 'terraso-mobile-client/util';
 
@@ -39,7 +39,7 @@ export const SiteNoteCard = ({note}: Props) => {
   const navigation = useNavigation();
 
   const isOffline = useIsOffline();
-  const userCanEditNote = useUserMayEditSiteNote({
+  const userCanEditNote = useUserCanEditSiteNote({
     siteId: note.siteId,
     noteId: note.id,
   });

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -88,12 +88,12 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     navigation.navigate('BOTTOM_TABS');
   }, [dispatch, navigation, site]);
 
-  const roleIsEditor = useRoleCanEditSite(siteId);
+  const userCanEditSite = useRoleCanEditSite(siteId);
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
+    {data: userCanEditSite, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -21,7 +21,10 @@ import {PressableProps} from 'react-native';
 
 import {DeleteButton} from 'terraso-mobile-client/components/buttons/common/DeleteButton';
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
@@ -34,6 +37,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {SITE_NAME_MAX_LENGTH} from 'terraso-mobile-client/constants';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
+import {useRoleMayEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
 import {
   deleteSite,
   updateSite,
@@ -84,9 +88,12 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     navigation.navigate('BOTTOM_TABS');
   }, [dispatch, navigation, site]);
 
+  const roleIsEditor = useRoleMayEditSite(siteId);
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -37,7 +37,7 @@ import {
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {SITE_NAME_MAX_LENGTH} from 'terraso-mobile-client/constants';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
-import {useRoleMayEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
 import {
   deleteSite,
   updateSite,
@@ -88,7 +88,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
     navigation.navigate('BOTTOM_TABS');
   }, [dispatch, navigation, site]);
 
-  const roleIsEditor = useRoleMayEditSite(siteId);
+  const roleIsEditor = useRoleCanEditSite(siteId);
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -36,12 +36,12 @@ type Props = {
 export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const site = useSelector(state => state.site.sites[siteId]);
 
-  const roleIsEditor = useRoleCanEditSite(siteId);
+  const userCanEditSite = useRoleCanEditSite(siteId);
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
+    {data: userCanEditSite, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -24,7 +24,7 @@ import {
   useMemoizedRequirements,
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useRoleMayEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
@@ -36,7 +36,7 @@ type Props = {
 export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const site = useSelector(state => state.site.sites[siteId]);
 
-  const roleIsEditor = useRoleMayEditSite(siteId);
+  const roleIsEditor = useRoleCanEditSite(siteId);
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([

--- a/dev-client/src/screens/SiteTeamSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteTeamSettingsScreen.tsx
@@ -15,12 +15,16 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useRoleMayEditSite} from 'terraso-mobile-client/hooks/permissionHooks';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
@@ -32,9 +36,12 @@ type Props = {
 export const SiteTeamSettingsScreen = ({siteId}: Props) => {
   const site = useSelector(state => state.site.sites[siteId]);
 
+  const roleIsEditor = useRoleMayEditSite(siteId);
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -21,13 +21,17 @@ import {ScrollView} from 'react-native';
 
 import {Accordion} from 'terraso-mobile-client/components/Accordion';
 import {Fab} from 'terraso-mobile-client/components/buttons/Fab';
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  usePopNavigationAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useTextSearch} from 'terraso-mobile-client/hooks/useTextSearch';
 import {transferSites} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -193,9 +197,12 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
     return navigation.pop();
   }, [dispatch, navigation, projectId, checkedSites]);
 
+  const roleIsEditor = useRoleMayEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
+  const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
+    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -197,12 +197,12 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
     return navigation.pop();
   }, [dispatch, navigation, projectId, checkedSites]);
 
-  const roleIsEditor = useRoleCanEditProject(projectId);
+  const userCanEditProject = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([
     {data: project, doIfMissing: handleMissingProject},
-    {data: roleIsEditor, doIfMissing: handleInsufficientPermissions},
+    {data: userCanEditProject, doIfMissing: handleInsufficientPermissions},
   ]);
 
   return (

--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -31,7 +31,7 @@ import {
 } from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {ConfirmModal} from 'terraso-mobile-client/components/modals/ConfirmModal';
 import {Box, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
-import {useRoleMayEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
+import {useRoleCanEditProject} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useTextSearch} from 'terraso-mobile-client/hooks/useTextSearch';
 import {transferSites} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
@@ -197,7 +197,7 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
     return navigation.pop();
   }, [dispatch, navigation, projectId, checkedSites]);
 
-  const roleIsEditor = useRoleMayEditProject(projectId);
+  const roleIsEditor = useRoleCanEditProject(projectId);
   const handleMissingProject = useNavToBottomTabsAndShowSyncError();
   const handleInsufficientPermissions = usePopNavigationAndShowSyncError();
   const requirements = useMemoizedRequirements([

--- a/dev-client/src/screens/SoilScreen/CarbonatesScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/CarbonatesScreen.tsx
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SoilPitInputScreenProps,
@@ -21,9 +23,18 @@ import {
 } from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
 export const CarbonatesScreen = (props: SoilPitInputScreenProps) => {
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <SoilPitInputScreenScaffold {...props}>
-      <Text>Unimplemented Carbonates Screen</Text>
-    </SoilPitInputScreenScaffold>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <SoilPitInputScreenScaffold {...props}>
+          <Text>Unimplemented Carbonates Screen</Text>
+        </SoilPitInputScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/CarbonatesScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/CarbonatesScreen.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
@@ -21,6 +21,8 @@ import {Image, ScrollView, StyleSheet} from 'react-native';
 
 import {BulletList} from 'terraso-mobile-client/components/BulletList';
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImagePicker,
   Photo,
@@ -143,21 +145,33 @@ export const ColorGuideScreen = (props: SoilPitInputScreenProps) => {
     </>,
   ] satisfies React.ReactNode[];
 
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <ScreenScaffold>
-      <ScrollView>
-        <Column backgroundColor="grey.300" space="md">
-          {stepContent.map((content, index) => (
-            <Column backgroundColor="primary.contrast" key={index} padding="md">
-              <Text variant="body1-strong">
-                {t(`soil.color.guide.step${index + 1}.title`)}
-              </Text>
-              {content}
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold>
+          <ScrollView>
+            <Column backgroundColor="grey.300" space="md">
+              {stepContent.map((content, index) => (
+                <Column
+                  backgroundColor="primary.contrast"
+                  key={index}
+                  padding="md">
+                  <Text variant="body1-strong">
+                    {t(`soil.color.guide.step${index + 1}.title`)}
+                  </Text>
+                  {content}
+                </Column>
+              ))}
             </Column>
-          ))}
-        </Column>
-      </ScrollView>
-    </ScreenScaffold>
+          </ScrollView>
+        </ScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };
 

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorGuideScreen.tsx
@@ -21,7 +21,7 @@ import {Image, ScrollView, StyleSheet} from 'react-native';
 
 import {BulletList} from 'terraso-mobile-client/components/BulletList';
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImagePicker,

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -23,7 +23,7 @@ import {DoneFab} from 'terraso-mobile-client/components/buttons/common/DoneFab';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -38,7 +38,7 @@ import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleCon
 import {isColorComplete} from 'terraso-mobile-client/model/color/colorConversions';
 import {MunsellColor} from 'terraso-mobile-client/model/color/types';
 import {
-  isProjectEditor,
+  canEditSite,
   SITE_EDITOR_ROLES,
 } from 'terraso-mobile-client/model/permissions/permissions';
 import {updateDepthDependentSoilData} from 'terraso-mobile-client/model/soilData/soilDataSlice';
@@ -80,7 +80,7 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
     selectUserRoleSite(state, props.siteId),
   );
 
-  const canDelete = useMemo(() => isProjectEditor(userRole), [userRole]);
+  const canDelete = useMemo(() => canEditSite(userRole), [userRole]);
 
   const onClearValues = useCallback(() => {
     dispatch(

--- a/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ColorScreen/ColorScreen.tsx
@@ -23,11 +23,8 @@ import {DoneFab} from 'terraso-mobile-client/components/buttons/common/DoneFab';
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {
-  ScreenDataRequirements,
-  useMemoizedRequirements,
-} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -57,7 +54,6 @@ import {
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {
   selectDepthDependentData,
-  selectSite,
   selectUserRoleSite,
 } from 'terraso-mobile-client/store/selectors';
 
@@ -103,12 +99,10 @@ export const ColorScreen = (props: SoilPitInputScreenProps) => {
     [data],
   );
 
-  const site = useSelector(selectSite(props.siteId));
-  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  // TODO-cknipe: Require the depth interval to exist for the site/project
-  const requirements = useMemoizedRequirements([
-    {data: site, doIfMissing: handleMissingSite},
-  ]);
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/ConductivityScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ConductivityScreen.tsx
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SoilPitInputScreenProps,
@@ -21,9 +23,18 @@ import {
 } from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
 export const ConductivityScreen = (props: SoilPitInputScreenProps) => {
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <SoilPitInputScreenScaffold {...props}>
-      <Text>Unimplemented Conductivity Screen</Text>
-    </SoilPitInputScreenScaffold>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <SoilPitInputScreenScaffold {...props}>
+          <Text>Unimplemented Conductivity Screen</Text>
+        </SoilPitInputScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/ConductivityScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/ConductivityScreen.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {

--- a/dev-client/src/screens/SoilScreen/PhScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/PhScreen.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {

--- a/dev-client/src/screens/SoilScreen/PhScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/PhScreen.tsx
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SoilPitInputScreenProps,
@@ -21,9 +23,18 @@ import {
 } from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
 export const PhScreen = (props: SoilPitInputScreenProps) => {
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <SoilPitInputScreenScaffold {...props}>
-      <Text>Unimplemented Ph Screen</Text>
-    </SoilPitInputScreenScaffold>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <SoilPitInputScreenScaffold {...props}>
+          <Text>Unimplemented Ph Screen</Text>
+        </SoilPitInputScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/SARScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SARScreen.tsx
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SoilPitInputScreenProps,
@@ -21,9 +23,18 @@ import {
 } from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
 export const SARScreen = (props: SoilPitInputScreenProps) => {
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <SoilPitInputScreenScaffold {...props}>
-      <Text>Unimplemented SAR Screen</Text>
-    </SoilPitInputScreenScaffold>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <SoilPitInputScreenScaffold {...props}>
+          <Text>Unimplemented SAR Screen</Text>
+        </SoilPitInputScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/SARScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SARScreen.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {

--- a/dev-client/src/screens/SoilScreen/SOCSOMScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SOCSOMScreen.tsx
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SoilPitInputScreenProps,
@@ -21,9 +23,18 @@ import {
 } from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
 export const SOCSOMScreen = (props: SoilPitInputScreenProps) => {
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <SoilPitInputScreenScaffold {...props}>
-      <Text>Unimplemented SOCSOM Screen</Text>
-    </SoilPitInputScreenScaffold>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <SoilPitInputScreenScaffold {...props}>
+          <Text>Unimplemented SOCSOM Screen</Text>
+        </SoilPitInputScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/SOCSOMScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/SOCSOMScreen.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {

--- a/dev-client/src/screens/SoilScreen/StructureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/StructureScreen.tsx
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {
   SoilPitInputScreenProps,
@@ -21,9 +23,18 @@ import {
 } from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
 
 export const StructureScreen = (props: SoilPitInputScreenProps) => {
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
+  );
+
   return (
-    <SoilPitInputScreenScaffold {...props}>
-      <Text>Unimplemented Structure Screen</Text>
-    </SoilPitInputScreenScaffold>
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <SoilPitInputScreenScaffold {...props}>
+          <Text>Unimplemented Structure Screen</Text>
+        </SoilPitInputScreenScaffold>
+      )}
+    </ScreenDataRequirements>
   );
 };

--- a/dev-client/src/screens/SoilScreen/StructureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/StructureScreen.tsx
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {

--- a/dev-client/src/screens/SoilScreen/TextureGuideScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureGuideScreen.tsx
@@ -25,7 +25,7 @@ import {ScrollView} from 'native-base';
 
 import {BulletList} from 'terraso-mobile-client/components/BulletList';
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,

--- a/dev-client/src/screens/SoilScreen/TextureGuideScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureGuideScreen.tsx
@@ -25,14 +25,8 @@ import {ScrollView} from 'native-base';
 
 import {BulletList} from 'terraso-mobile-client/components/BulletList';
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
-import {
-  useNavToBottomTabsAndShowSyncError,
-  useNavToSiteAndShowSyncError,
-} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {
-  ScreenDataRequirements,
-  useMemoizedRequirements,
-} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   Box,
   Column,
@@ -47,11 +41,7 @@ import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {SoilPitInputScreenProps} from 'terraso-mobile-client/screens/SoilScreen/components/SoilPitInputScreenScaffold';
-import {useDispatch, useSelector} from 'terraso-mobile-client/store';
-import {
-  selectSite,
-  useSiteSoilInterval,
-} from 'terraso-mobile-client/store/selectors';
+import {useDispatch} from 'terraso-mobile-client/store';
 
 const LENGTH_IMAGE = require('terraso-mobile-client/assets/texture/guide/length.png');
 
@@ -102,17 +92,10 @@ export const TextureGuideScreen = (props: SoilPitInputScreenProps) => {
     };
   }, [props, dispatch, result, navigation]);
 
-  const site = useSelector(selectSite(props.siteId));
-  const depthInterval = useSiteSoilInterval(
+  const requirements = useDefaultSiteDepthRequirements(
     props.siteId,
     props.depthInterval.depthInterval,
   );
-  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const handleMissingDepth = useNavToSiteAndShowSyncError(props.siteId);
-  const requirements = useMemoizedRequirements([
-    {data: site, doIfMissing: handleMissingSite},
-    {data: depthInterval, doIfMissing: handleMissingDepth},
-  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -28,7 +28,10 @@ import {ContainedButton} from 'terraso-mobile-client/components/buttons/Containe
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  useNavToBottomTabsAndShowSyncError,
+  useNavToSiteAndShowSyncError,
+} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
 import {
   ScreenDataRequirements,
   useMemoizedRequirements,
@@ -69,6 +72,7 @@ import {
   selectDepthDependentData,
   selectSite,
   selectUserRoleSite,
+  useSiteSoilInterval,
 } from 'terraso-mobile-client/store/selectors';
 
 const FRAGMENT_IMAGES = {
@@ -161,9 +165,15 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
   );
 
   const site = useSelector(selectSite(siteId));
+  const existingDepthInterval = useSiteSoilInterval(
+    siteId,
+    depthInterval.depthInterval,
+  );
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
+  const handleMissingDepth = useNavToSiteAndShowSyncError(siteId);
   const requirements = useMemoizedRequirements([
     {data: site, doIfMissing: handleMissingSite},
+    {data: existingDepthInterval, doIfMissing: handleMissingDepth},
   ]);
 
   return (

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -28,14 +28,8 @@ import {ContainedButton} from 'terraso-mobile-client/components/buttons/Containe
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {
-  useNavToBottomTabsAndShowSyncError,
-  useNavToSiteAndShowSyncError,
-} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
-import {
-  ScreenDataRequirements,
-  useMemoizedRequirements,
-} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImageRadio,
   radioImage,
@@ -70,9 +64,7 @@ import {TextureInfoContent} from 'terraso-mobile-client/screens/SoilScreen/compo
 import {useDispatch, useSelector} from 'terraso-mobile-client/store';
 import {
   selectDepthDependentData,
-  selectSite,
   selectUserRoleSite,
-  useSiteSoilInterval,
 } from 'terraso-mobile-client/store/selectors';
 
 const FRAGMENT_IMAGES = {
@@ -164,17 +156,10 @@ export const TextureScreen = (props: SoilPitInputScreenProps) => {
     [dispatch, siteId, depthInterval],
   );
 
-  const site = useSelector(selectSite(siteId));
-  const existingDepthInterval = useSiteSoilInterval(
-    siteId,
-    depthInterval.depthInterval,
+  const requirements = useDefaultSiteDepthRequirements(
+    props.siteId,
+    props.depthInterval.depthInterval,
   );
-  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
-  const handleMissingDepth = useNavToSiteAndShowSyncError(siteId);
-  const requirements = useMemoizedRequirements([
-    {data: site, doIfMissing: handleMissingSite},
-    {data: existingDepthInterval, doIfMissing: handleMissingDepth},
-  ]);
 
   return (
     <ScreenDataRequirements requirements={requirements}>

--- a/dev-client/src/screens/SoilScreen/TextureScreen.tsx
+++ b/dev-client/src/screens/SoilScreen/TextureScreen.tsx
@@ -28,7 +28,7 @@ import {ContainedButton} from 'terraso-mobile-client/components/buttons/Containe
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
 import {TranslatedHeading} from 'terraso-mobile-client/components/content/typography/TranslatedHeading';
-import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {useDefaultSiteDepthRequirements} from 'terraso-mobile-client/components/dataRequirements/commonRequirements';
 import {ScreenDataRequirements} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
 import {
   ImageRadio,

--- a/dev-client/src/store/selectors.ts
+++ b/dev-client/src/store/selectors.ts
@@ -338,9 +338,11 @@ export const useSiteSoilIntervals = (siteId: string): AggregatedInterval[] => {
   );
 };
 
-// This confirms that a given DepthInterval is actually part of the site's
-// displayed depth intervals. (There may be a mismatch if, for example, a
-// depth interval got deleted in redux, but a sheet takes depth as a prop)
+/*
+ * This confirms that a given DepthInterval (just start & end depths) is
+ * one of the site's displayed depth intervals. If so, it returns the
+ * interval with its interval settings.
+ */
 export const useSiteSoilInterval = (
   siteId: string,
   depthInterval: DepthInterval,

--- a/dev-client/src/store/selectors.ts
+++ b/dev-client/src/store/selectors.ts
@@ -338,6 +338,24 @@ export const useSiteSoilIntervals = (siteId: string): AggregatedInterval[] => {
   );
 };
 
+// This confirms that a given DepthInterval is actually part of the site's
+// displayed depth intervals. (There may be a mismatch if, for example, a
+// depth interval got deleted in redux, but a sheet takes depth as a prop)
+export const useSiteSoilInterval = (
+  siteId: string,
+  depthInterval: DepthInterval,
+): AggregatedInterval | undefined => {
+  const allSiteSoilIntervals = useSiteSoilIntervals(siteId);
+  const foundInterval = useMemo(
+    () =>
+      allSiteSoilIntervals.find(aggInterval =>
+        sameDepth({depthInterval})(aggInterval.interval),
+      ),
+    [allSiteSoilIntervals, depthInterval],
+  );
+  return foundInterval;
+};
+
 export const selectDepthDependentData = ({
   siteId,
   depthInterval,


### PR DESCRIPTION
## Description
Screens that depend on the existence of a depth interval now require the depth interval. 
Screens that depend on a user having certain permissions to view, now require those permissions.
To support permissions in particular,`ScreenDataRequirements` changed from requiring the data's existence, to requiring the data to be truthy. 

### Related Issues
Part 2 of #2290 
(There will be another PR for deletion of site/project not triggering the sync error)
