### PR TITLE
fix: incorrect callback usage for pinned note button

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/PinnedNoteButton.tsx
+++ b/dev-client/src/screens/LocationScreens/components/PinnedNoteButton.tsx
@@ -32,10 +32,9 @@ export const PinnedNoteButton = ({project}: Props) => {
   const navigation = useNavigation();
 
   const onShowNote = useCallback(() => {
-    return () =>
-      navigation.navigate('READ_PINNED_NOTE', {
-        projectId: project.id,
-      });
+    navigation.navigate('READ_PINNED_NOTE', {
+      projectId: project.id,
+    });
   }, [navigation, project]);
 
   return (


### PR DESCRIPTION
## Description

Fix incorrect callback usage for `PinnedNoteButton`.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1856

### Verification steps

Verify that the pinned note button correctly navigates to the pinned note screen.
