### PR TITLE
fix: correct placement of transfer sites screen FAB

### DIFF
--- a/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
+++ b/dev-client/src/screens/SiteTransferProjectScreen/SiteTransferProjectScreen.tsx
@@ -248,21 +248,21 @@ export const SiteTransferProjectScreen = ({projectId}: Props) => {
                 </Accordion>
               );
             })}
-            <ConfirmModal
-              trigger={onOpen => (
-                <Fab
-                  label={t('projects.sites.transfer')}
-                  onPress={onOpen}
-                  disabled={disabled}
-                />
-              )}
-              destructive={false}
-              title={t('projects.sites.transfer_site_modal.title')}
-              body={t('projects.sites.transfer_site_modal.body')}
-              actionLabel={t('projects.sites.transfer_site_modal.action_name')}
-              handleConfirm={onSubmit}
-            />
           </ScrollView>
+          <ConfirmModal
+            trigger={onOpen => (
+              <Fab
+                label={t('projects.sites.transfer')}
+                onPress={onOpen}
+                disabled={disabled}
+              />
+            )}
+            destructive={false}
+            title={t('projects.sites.transfer_site_modal.title')}
+            body={t('projects.sites.transfer_site_modal.body')}
+            actionLabel={t('projects.sites.transfer_site_modal.action_name')}
+            handleConfirm={onSubmit}
+          />
         </ScreenScaffold>
       )}
     </ScreenDataRequirements>


### PR DESCRIPTION
## Description

Fix the placement of the FAB on the transfer sites screen to correctly position itself relative to the screen's other content.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1856

### Verification steps

Verify FAB position with accordion open and closed, and for site list long enough to trigger scroll behavior.