### PR TITLE
fix: don't use disabled color for offline search alert box.

### DIFF
--- a/dev-client/src/screens/SitesScreen/components/search/MapSearchOfflineAlertBox.tsx
+++ b/dev-client/src/screens/SitesScreen/components/search/MapSearchOfflineAlertBox.tsx
@@ -15,18 +15,17 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, Text, View} from 'react-native';
 
-import {DisableableText} from 'terraso-mobile-client/components/content/typography/DisableableText';
 import {TranslatedContent} from 'terraso-mobile-client/components/content/typography/TranslatedContent';
 import {convertColorProp} from 'terraso-mobile-client/components/util/nativeBaseAdapters';
 
 export const MapSearchOfflineAlertBox = () => {
   return (
     <View style={styles.container}>
-      <DisableableText disabled={true}>
+      <Text>
         <TranslatedContent i18nKey="site.search.offline" />
-      </DisableableText>
+      </Text>
     </View>
   );
 };


### PR DESCRIPTION
## Description

Fix color for offline map search alert box.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #2367

### Verification steps

Search while offline and observe color of alert box.
