### PR TITLE
build: use version 1.3.9 of MMKV and MMKVCore CocoaPods

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -144,6 +144,23 @@ const defaultConfig: ExpoConfig = {
       },
     ],
     [
+      'expo-build-properties',
+      {
+        ios: {
+          extraPods: [
+            {
+              name: 'MMKV',
+              version: '1.3.9',
+            },
+            {
+              name: 'MMKVCore',
+              version: '1.3.9',
+            },
+          ],
+        },
+      },
+    ],
+    [
       ((modConfig: ExpoConfig): ExpoConfig => {
         // Avoid double signing with debug keychain when using GitHub actions.
         if (ENV_CONFIG.CI === 'true') {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -26,6 +26,7 @@
         "expo-apple-authentication": "~6.4.2",
         "expo-auth-session": "~5.5.2",
         "expo-av": "~14.0.7",
+        "expo-build-properties": "^0.13.1",
         "expo-camera": "~15.0.16",
         "expo-constants": "~16.0.2",
         "expo-crypto": "~13.0.2",
@@ -14164,6 +14165,53 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.13.1.tgz",
+      "integrity": "sha512-7tDlAM0PPkXC0B00C6/FG19sMzwxZNyiDfn22AWVbBxWxZE1/3RqxPgT3MlPVNfvy+wJw7jt/qbAb0S06wFYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-camera": {
       "version": "15.0.16",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-15.0.16.tgz",
@@ -14669,6 +14717,22 @@
     "node_modules/fast-loops": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.1",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -44,6 +44,7 @@
     "expo-apple-authentication": "~6.4.2",
     "expo-auth-session": "~5.5.2",
     "expo-av": "~14.0.7",
+    "expo-build-properties": "^0.13.1",
     "expo-camera": "~15.0.16",
     "expo-constants": "~16.0.2",
     "expo-crypto": "~13.0.2",


### PR DESCRIPTION
## Description
Use version 1.3.9 of MMKV and MMKVCore CocoaPods

### Related Issues
Works around https://github.com/Tencent/MMKV/issues/1468 and https://github.com/ammarahm-ed/react-native-mmkv-storage/issues/372