### PR TITLE
build: automatically merge dependabot PRs on dependencies branch (if they pass tests)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,11 +2,12 @@ name: Auto approve
 
 on: pull_request_target
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
       - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.ref == 'refs/heads/depdendencies'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge ${{ github.event.pull_request.number }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.ref == 'refs/heads/depdendencies'
+    if: github.actor == 'dependabot[bot]' && github.ref == 'refs/heads/dependencies'
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependencies-branch.yml
+++ b/.github/workflows/dependencies-branch.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: "depdendencies"
+          branch: "dependencies"

--- a/.github/workflows/dependencies-branch.yml
+++ b/.github/workflows/dependencies-branch.yml
@@ -1,15 +1,19 @@
 name: Dependabot auto-merge
 
 on:
-  schedule:
-    - cron: "0 2 * * 6"
-
+  pull_request:
+    branches:
+      - dependencies
+    types:
+      - closed
+      
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  dependabot:
+  make_branch:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Create dependencies branch

--- a/.github/workflows/dependencies-branch.yml
+++ b/.github/workflows/dependencies-branch.yml
@@ -2,7 +2,7 @@ name: Dependabot auto-merge
 
 on:
   schedule:
-    - cron: "0 2 * * 1"
+    - cron: "0 2 * * 6"
 
 permissions:
   contents: write

--- a/.github/workflows/dependencies-branch.yml
+++ b/.github/workflows/dependencies-branch.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create dependencies branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: "depdendencies"


### PR DESCRIPTION
## Description
Sunday: Automatically merge dependabot PRs on depdendencies branch (if they pass tests). This will allow the merge queue to be auto-populated instead of requiring someone to click "add to queue" for each PR.

Monday: Create a PR for the dependencies branch into main (the merge queue should be empty at this point).

Saturday: Create a fresh dependencies branch.