### PR TITLE
fix: display "Not available" when LCC is not available

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilInfoDisplay.tsx
@@ -17,6 +17,8 @@
 
 import {useTranslation} from 'react-i18next';
 
+import {TFunction} from 'i18next';
+
 import {
   LandCapabilityClass,
   SoilInfo,
@@ -36,7 +38,13 @@ type SoilInfoDisplayProps = {
   soilInfo: SoilInfo;
 };
 
-const renderLCCString = ({capabilityClass, subClass}: LandCapabilityClass) => {
+const renderLCCString = (
+  t: TFunction,
+  {capabilityClass, subClass}: LandCapabilityClass,
+) => {
+  if (!capabilityClass) {
+    return t('general.not_available');
+  }
   if (!subClass) {
     return capabilityClass;
   }
@@ -82,7 +90,7 @@ export function SoilInfoDisplay({dataSource, soilInfo}: SoilInfoDisplayProps) {
       <Box>
         <TranslatedParagraph
           i18nKey="site.soil_id.soil_info.land_class_label"
-          values={{land: renderLCCString(soilInfo.landCapabilityClass)}}
+          values={{land: renderLCCString(t, soilInfo.landCapabilityClass)}}
         />
         <TranslatedParagraph
           i18nKey="site.soil_id.soil_info.data_source_label"

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -472,7 +472,8 @@
         },
         "not_available_offine": "Not available offline",
         "offline_sign_in_title": "Sign in not available offline",
-        "offline_sign_in_body": "To use LandPKS Soil ID offline, you must first sign in while online."
+        "offline_sign_in_body": "To use LandPKS Soil ID offline, you must first sign in while online.",
+        "not_available": "Not available"
     },
     "permissions": {
         "camera_title": "LandPKS Soil ID needs to access your camera",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -419,6 +419,7 @@
         "not_available_offine": "Not available offline TK",
         "offline_sign_in_title": "TK Sign in not available offline",
         "offline_sign_in_body": "TK To use LandPKS Soil ID offline, you must first sign in while online.",
+        "not_available": "TK Not available",
         "last_modified": "Última modificación",
         "dismiss": "Dismiss TK",
         "last_modified_by": "última modificación {{user}}, {{date}}",


### PR DESCRIPTION
## Description
Display "Not available" when LCC is not available on the soil info screens.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes, once QA'd, https://github.com/techmatters/soil-id-algorithm/issues/119

### Verification steps
Soil info screen should now show "Not available" for LCC at certain coordinates (see issue for context).
