### PR TITLE
fix: bandaid navigation fix (just use `navigateDeprecated`)

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -126,7 +126,10 @@ function App(): React.JSX.Element {
   return (
     <GestureHandlerRootView style={style}>
       <Provider store={store}>
-        <NavigationContainer>
+        <NavigationContainer
+        // uncomment to enable screen stack debugging
+        // onStateChange={console.log}
+        >
           <ConnectivityContextProvider>
             <HeaderHeightContext.Provider
               value={{headerHeight, setHeaderHeight}}>

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -26,7 +26,7 @@ export const useNavToBottomTabsAndShowSyncError = () => {
   const syncNotifications = useSyncNotificationContext();
 
   return useCallback(() => {
-    navigation.navigate('BOTTOM_TABS');
+    navigation.popTo('BOTTOM_TABS');
     if (isFlagEnabled('FF_offline')) {
       syncNotifications.showError();
     }

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -70,7 +70,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
     } catch (e) {
       console.error(e);
     }
-    navigation.navigate('PROJECT_VIEW', {projectId: projectId});
+    navigation.popTo('PROJECT_VIEW', {projectId: projectId});
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, newUser, selectedRole, navigation]);
 

--- a/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/components/AddTeamMemberForm.tsx
@@ -73,7 +73,10 @@ export const AddTeamMemberForm = ({projectId}: FormProps) => {
         else {
           const user = userOrError as UserFields;
           const userId = user.id;
-          navigation.navigate('ADD_USER_PROJECT_ROLE', {projectId, userId});
+          navigation.navigate('ADD_USER_PROJECT_ROLE', {
+            projectId,
+            userId,
+          });
         }
       }
     } catch (e) {

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorCropReferenceScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorCropReferenceScreen.tsx
@@ -38,7 +38,7 @@ export const ColorCropReferenceScreen = () => {
     (crop: CropResult) => {
       setState(state => ({...state, reference: crop}));
       if (soil !== undefined) {
-        colorAnalysisNavigation.navigate('COLOR_ANALYSIS_HOME');
+        colorAnalysisNavigation.popTo('COLOR_ANALYSIS_HOME');
       } else {
         colorAnalysisNavigation.navigate('COLOR_CROP_SOIL');
       }

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorCropSoilScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorCropSoilScreen.tsx
@@ -38,7 +38,7 @@ export const ColorCropSoilScreen = () => {
     (crop: CropResult) => {
       setState(state => ({...state, soil: crop}));
       if (reference !== undefined) {
-        colorAnalysisNavigation.navigate('COLOR_ANALYSIS_HOME');
+        colorAnalysisNavigation.popTo('COLOR_ANALYSIS_HOME');
       } else {
         colorAnalysisNavigation.navigate('COLOR_CROP_REFERENCE');
       }

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -63,7 +63,7 @@ export const CreateSiteView = ({
       const createdSite = await createSiteCallback({...site, elevation});
       if (createdSite !== undefined) {
         sitesScreen?.showSiteOnMap(createdSite);
-        navigation.navigate('BOTTOM_TABS');
+        navigation.popTo('BOTTOM_TABS');
       }
     },
     [createSiteCallback, navigation, validationSchema, sitesScreen, elevation],

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -80,7 +80,10 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
 
   const onExploreDataPress = useCallback(() => {
     if (site?.id) {
-      navigation.navigate('SITE_LOCATION_SOIL_ID', {siteId: site.id, coords});
+      navigation.navigate('SITE_LOCATION_SOIL_ID', {
+        siteId: site.id,
+        coords,
+      });
     } else {
       navigation.navigate('TEMPORARY_LOCATION_SOIL_ID', {coords});
     }

--- a/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
+++ b/dev-client/src/screens/ProjectListScreen/components/ProjectPreviewCard.tsx
@@ -36,7 +36,9 @@ export const ProjectPreviewCard = ({project}: Props) => {
   const navigation = useNavigation();
 
   const goToProject = useCallback(async () => {
-    return navigation.navigate('PROJECT_VIEW', {projectId: project.id});
+    return navigation.navigate('PROJECT_VIEW', {
+      projectId: project.id,
+    });
   }, [project, navigation]);
 
   return (

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -48,7 +48,7 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
   const userCanEditNote = useUserCanEditSiteNote({siteId, noteId});
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleMissingSiteNote = useCallback(() => {
-    navigation.navigate('SITE_TABS', {
+    navigation.popTo('SITE_TABS', {
       siteId: siteId,
       initialTab: 'NOTES' as SiteTabName,
     });

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -92,7 +92,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   const userCanEditSite = useRoleCanEditSite(siteId);
 
   const navToBottomTabs = useCallback(() => {
-    navigation.navigate('BOTTOM_TABS');
+    navigation.popTo('BOTTOM_TABS');
   }, [navigation]);
   const navToBottomTabsAndShowSyncError = useNavToBottomTabsAndShowSyncError();
   // On purposeful delete, this screen re-renders with null site (but before

--- a/dev-client/src/screens/WelcomeScreen.tsx
+++ b/dev-client/src/screens/WelcomeScreen.tsx
@@ -41,7 +41,7 @@ export const WelcomeScreen = () => {
   // Welcome screen will only show on first time app is opened, so we expect user needs to log in next
   const onGetStarted = useCallback(() => {
     setWelcomeScreenAlreadySeen(true);
-    navigation.navigate('LOGIN');
+    navigation.popTo('LOGIN');
   }, [navigation, setWelcomeScreenAlreadySeen]);
 
   return (


### PR DESCRIPTION
## Description
Changes all of our uses of `navigate` to `navigateDeprecated`. I'm not sure if this is the right thing to do yet, but it seems like a workable bandaid solution if that's what we want.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Fixes https://github.com/techmatters/terraso-mobile-client/issues/2513

### Verification steps
Creating a site should once again return you to the home screen zoomed in on the site.