### PR TITLE
fix: bandaid revert broken react-native-autocomplete-input dependency to known-good version

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -49,7 +49,7 @@
         "react": "18.3.1",
         "react-i18next": "^15.4.0",
         "react-native": "^0.75.4",
-        "react-native-autocomplete-input": "^5.5.5",
+        "react-native-autocomplete-input": "^5.4.0",
         "react-native-gesture-handler": "^2.21.2",
         "react-native-get-random-values": "^1.11.0",
         "react-native-gradle-plugin": "^0.71.19",
@@ -7940,6 +7940,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.74.85",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.85.tgz",
@@ -12781,6 +12787,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/deprecated-react-native-prop-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+      "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
       }
     },
     "node_modules/deps-regex": {
@@ -22033,10 +22050,13 @@
       }
     },
     "node_modules/react-native-autocomplete-input": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/react-native-autocomplete-input/-/react-native-autocomplete-input-5.5.5.tgz",
-      "integrity": "sha512-sE5wnzmaIYG80K/ztqYPUSQR5ZZkS8CAMSJL7uoNy+ZTtGxxny3jG5l+EYxOaB2DiilVmHpZO2KJ0NjojB5U7A==",
-      "license": "MIT"
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-autocomplete-input/-/react-native-autocomplete-input-5.4.0.tgz",
+      "integrity": "sha512-Fw4jv4a7ySF08JGJfVILkL52LTwGRSbn5BF5EmOIu3CqRAwhkE5JtaEWT2kgCKBr9YE+lZZYNYpOQrRALxOszA==",
+      "license": "MIT",
+      "dependencies": {
+        "deprecated-react-native-prop-types": "^2.3.0"
+      }
     },
     "node_modules/react-native-gesture-handler": {
       "version": "2.21.2",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -67,7 +67,7 @@
     "react": "18.3.1",
     "react-i18next": "^15.4.0",
     "react-native": "^0.75.4",
-    "react-native-autocomplete-input": "^5.5.5",
+    "react-native-autocomplete-input": "^5.4.0",
     "react-native-gesture-handler": "^2.21.2",
     "react-native-get-random-values": "^1.11.0",
     "react-native-gradle-plugin": "^0.71.19",


### PR DESCRIPTION
## Description
Bandaid fix to revert the react-native-autocomplete-input dependency to a known good version, not sure if this is what we wanna go with. Would also be nice to add a test for this.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Related to https://github.com/techmatters/terraso-mobile-client/issues/2826
