### PR TITLE
fix: app navigation for react navigation v7

### DIFF
--- a/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
+++ b/dev-client/__tests__/integration/EditSiteNoteScreen.test.tsx
@@ -21,14 +21,14 @@ import {render} from '@testing/integration/utils';
 import * as permissionHooks from 'terraso-mobile-client/hooks/permissionHooks';
 import {EditSiteNoteScreen} from 'terraso-mobile-client/screens/SiteNotesScreen/EditSiteNoteScreen';
 
-const mockedNavigate = jest.fn();
+const mockedPopTo = jest.fn();
 jest.mock('terraso-mobile-client/navigation/hooks/useNavigation', () => {
   const actualNav = jest.requireActual(
     'terraso-mobile-client/navigation/hooks/useNavigation',
   );
   return {
     ...actualNav,
-    useNavigation: () => ({navigate: mockedNavigate}),
+    useNavigation: () => ({popTo: mockedPopTo}),
   };
 });
 
@@ -39,7 +39,7 @@ const mockedUserCanEditSiteNote = jest.spyOn(
 mockedUserCanEditSiteNote.mockReturnValue(true);
 
 afterEach(() => {
-  mockedNavigate.mockClear();
+  mockedPopTo.mockClear();
   mockedUserCanEditSiteNote.mockReset();
 });
 
@@ -52,7 +52,7 @@ describe('EditSiteNoteScreen', () => {
 
     expect(screen.getByText('Site Note')).toBeOnTheScreen();
     expect(screen.getByDisplayValue('note 1 contents')).toBeOnTheScreen();
-    expect(mockedNavigate).toHaveBeenCalledTimes(0);
+    expect(mockedPopTo).toHaveBeenCalledTimes(0);
   });
 
   test('renders null if site missing', () => {
@@ -67,8 +67,8 @@ describe('EditSiteNoteScreen', () => {
     // Ideally would want to test that navigation worked, but I can't figure out how to do that
     expect(screen.queryByText('Site Note')).toBeNull();
     expect(screen.queryByText('note 1 contents')).toBeNull();
-    expect(mockedNavigate).toHaveBeenCalledTimes(1);
-    expect(mockedNavigate).toHaveBeenCalledWith('BOTTOM_TABS');
+    expect(mockedPopTo).toHaveBeenCalledTimes(1);
+    expect(mockedPopTo).toHaveBeenCalledWith('BOTTOM_TABS');
   });
 
   test('renders null if note missing', () => {
@@ -82,8 +82,8 @@ describe('EditSiteNoteScreen', () => {
 
     expect(screen.queryByText('Site Note')).toBeNull();
     expect(screen.queryByText('note 1 contents')).toBeNull();
-    expect(mockedNavigate).toHaveBeenCalledTimes(1);
-    expect(mockedNavigate).toHaveBeenCalledWith('SITE_TABS', {
+    expect(mockedPopTo).toHaveBeenCalledTimes(1);
+    expect(mockedPopTo).toHaveBeenCalledWith('SITE_TABS', {
       initialTab: 'NOTES',
       siteId: '1',
     });
@@ -102,8 +102,8 @@ describe('EditSiteNoteScreen', () => {
 
     expect(screen.queryByText('Site Note')).toBeNull();
     expect(screen.queryByText('note 1 contents')).toBeNull();
-    expect(mockedNavigate).toHaveBeenCalledTimes(1);
-    expect(mockedNavigate).toHaveBeenCalledWith('SITE_TABS', {
+    expect(mockedPopTo).toHaveBeenCalledTimes(1);
+    expect(mockedPopTo).toHaveBeenCalledWith('SITE_TABS', {
       initialTab: 'NOTES',
       siteId: '1',
     });

--- a/dev-client/__tests__/integration/screens/SiteSettingsScreen.test.tsx
+++ b/dev-client/__tests__/integration/screens/SiteSettingsScreen.test.tsx
@@ -43,15 +43,18 @@ jest.mock('terraso-mobile-client/hooks/connectivityHooks', () => {
   };
 });
 
-const mockedNavigate = jest.fn();
 const mockedPopNav = jest.fn();
+const mockedPopTo = jest.fn();
 jest.mock('terraso-mobile-client/navigation/hooks/useNavigation', () => {
   const actualNav = jest.requireActual(
     'terraso-mobile-client/navigation/hooks/useNavigation',
   );
   return {
     ...actualNav,
-    useNavigation: () => ({navigate: mockedNavigate, pop: mockedPopNav}),
+    useNavigation: () => ({
+      pop: mockedPopNav,
+      popTo: mockedPopTo,
+    }),
   };
 });
 
@@ -105,7 +108,7 @@ describe('SiteSettingsScreen', () => {
   } as Partial<ReduxAppState>;
 
   beforeEach(() => {
-    mockedNavigate.mockClear();
+    mockedPopTo.mockClear();
     mockedPopNav.mockClear();
   });
 
@@ -120,7 +123,7 @@ describe('SiteSettingsScreen', () => {
       },
     );
 
-    expect(mockedNavigate).not.toHaveBeenCalled();
+    expect(mockedPopTo).not.toHaveBeenCalled();
     expect(screen.queryByTestId('error-dialog')).not.toBeOnTheScreen();
   });
 
@@ -135,7 +138,7 @@ describe('SiteSettingsScreen', () => {
       },
     );
 
-    expect(mockedNavigate).toHaveBeenCalledWith('BOTTOM_TABS');
+    expect(mockedPopTo).toHaveBeenCalledWith('BOTTOM_TABS');
     expect(screen.getByTestId('error-dialog')).toBeOnTheScreen();
   });
 
@@ -193,7 +196,7 @@ describe('SiteSettingsScreen', () => {
     );
 
     expect(mockApiCall).toHaveBeenCalled();
-    expect(mockedNavigate).toHaveBeenCalledWith('BOTTOM_TABS');
+    expect(mockedPopTo).toHaveBeenCalledWith('BOTTOM_TABS');
     expect(screen.queryByTestId('error-dialog')).not.toBeOnTheScreen();
   });
 });

--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -126,7 +126,10 @@ function App(): React.JSX.Element {
   return (
     <GestureHandlerRootView style={style}>
       <Provider store={store}>
-        <NavigationContainer>
+        <NavigationContainer
+        // uncomment to enable screen stack debugging
+        // onStateChange={console.log}
+        >
           <ConnectivityContextProvider>
             <HeaderHeightContext.Provider
               value={{headerHeight, setHeaderHeight}}>

--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -26,7 +26,7 @@ export const useNavToBottomTabsAndShowSyncError = () => {
   const syncNotifications = useSyncNotificationContext();
 
   return useCallback(() => {
-    navigation.navigate('BOTTOM_TABS');
+    navigation.popTo('BOTTOM_TABS');
     if (isFlagEnabled('FF_offline')) {
       syncNotifications.showError();
     }

--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -70,7 +70,7 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
     } catch (e) {
       console.error(e);
     }
-    navigation.navigate('PROJECT_VIEW', {projectId: projectId});
+    navigation.popTo('PROJECT_VIEW', {projectId: projectId});
     navigation.dispatch(TabActions.jumpTo(TabRoutes.TEAM));
   }, [dispatch, projectId, newUser, selectedRole, navigation]);
 

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorCropReferenceScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorCropReferenceScreen.tsx
@@ -38,7 +38,7 @@ export const ColorCropReferenceScreen = () => {
     (crop: CropResult) => {
       setState(state => ({...state, reference: crop}));
       if (soil !== undefined) {
-        colorAnalysisNavigation.navigate('COLOR_ANALYSIS_HOME');
+        colorAnalysisNavigation.popTo('COLOR_ANALYSIS_HOME');
       } else {
         colorAnalysisNavigation.navigate('COLOR_CROP_SOIL');
       }

--- a/dev-client/src/screens/ColorAnalysisScreen/ColorCropSoilScreen.tsx
+++ b/dev-client/src/screens/ColorAnalysisScreen/ColorCropSoilScreen.tsx
@@ -38,7 +38,7 @@ export const ColorCropSoilScreen = () => {
     (crop: CropResult) => {
       setState(state => ({...state, soil: crop}));
       if (reference !== undefined) {
-        colorAnalysisNavigation.navigate('COLOR_ANALYSIS_HOME');
+        colorAnalysisNavigation.popTo('COLOR_ANALYSIS_HOME');
       } else {
         colorAnalysisNavigation.navigate('COLOR_CROP_REFERENCE');
       }

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -63,7 +63,7 @@ export const CreateSiteView = ({
       const createdSite = await createSiteCallback({...site, elevation});
       if (createdSite !== undefined) {
         sitesScreen?.showSiteOnMap(createdSite);
-        navigation.navigate('BOTTOM_TABS');
+        navigation.popTo('BOTTOM_TABS');
       }
     },
     [createSiteCallback, navigation, validationSchema, sitesScreen, elevation],

--- a/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/EditSiteNoteScreen.tsx
@@ -48,7 +48,7 @@ export const EditSiteNoteScreen = ({noteId, siteId}: Props) => {
   const userCanEditNote = useUserCanEditSiteNote({siteId, noteId});
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
   const handleMissingSiteNote = useCallback(() => {
-    navigation.navigate('SITE_TABS', {
+    navigation.popTo('SITE_TABS', {
       siteId: siteId,
       initialTab: 'NOTES' as SiteTabName,
     });

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -92,7 +92,7 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
   const userCanEditSite = useRoleCanEditSite(siteId);
 
   const navToBottomTabs = useCallback(() => {
-    navigation.navigate('BOTTOM_TABS');
+    navigation.popTo('BOTTOM_TABS');
   }, [navigation]);
   const navToBottomTabsAndShowSyncError = useNavToBottomTabsAndShowSyncError();
   // On purposeful delete, this screen re-renders with null site (but before

--- a/dev-client/src/screens/WelcomeScreen.tsx
+++ b/dev-client/src/screens/WelcomeScreen.tsx
@@ -41,7 +41,7 @@ export const WelcomeScreen = () => {
   // Welcome screen will only show on first time app is opened, so we expect user needs to log in next
   const onGetStarted = useCallback(() => {
     setWelcomeScreenAlreadySeen(true);
-    navigation.navigate('LOGIN');
+    navigation.popTo('LOGIN');
   }, [navigation, setWelcomeScreenAlreadySeen]);
 
   return (


### PR DESCRIPTION
## Description
Use `popTo` instead of `navigate` in places where we want `navigate` to pop instead of push for screens which are already in the stack, since `navigate` no longer does that for us.

I still need to look into how to add tests for this.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Related to #2513 

### Verification steps
Navigation flows should no longer have weird behavior for:
- create site
- adding user to a project
- color algorithm camera workflow
- deleting a site
- welcome screen
- viewing a screen which is deleted remotely