### PR TITLE
fix: map search

### DIFF
--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -41,7 +41,7 @@ import {SitesScreenContext} from 'terraso-mobile-client/context/SitesScreenConte
 import {fetchSoilDataForUser} from 'terraso-mobile-client/model/soilData/soilDataGlobalReducer';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
-import {MapSearch} from 'terraso-mobile-client/screens/SitesScreen/components/search/MapSearch';
+import {MapHeader} from 'terraso-mobile-client/screens/SitesScreen/components/MapHeader';
 import {SiteListBottomSheet} from 'terraso-mobile-client/screens/SitesScreen/components/SiteListBottomSheet';
 import {
   MapRef,
@@ -168,7 +168,7 @@ export const SitesScreen = memo(() => {
       <ListFilterProvider items={siteList} filters={filters}>
         <Box flex={1}>
           <Box flex={1} zIndex={-1}>
-            <MapSearch
+            <MapHeader
               zoomTo={searchFunction}
               zoomToUser={moveToUserAndShowCallout}
               toggleMapLayer={toggleMapLayer}

--- a/dev-client/src/screens/SitesScreen/components/MapHeader.tsx
+++ b/dev-client/src/screens/SitesScreen/components/MapHeader.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+
+import {Coords} from 'terraso-client-shared/types';
+
+import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
+import {UpdatedPermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
+import {
+  Box,
+  Column,
+  Row,
+} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {useUpdatedForegroundPermissions} from 'terraso-mobile-client/hooks/appPermissionsHooks';
+import {MapSearch} from 'terraso-mobile-client/screens/SitesScreen/components/search/MapSearch';
+
+type Props = {
+  zoomTo?: (coords: Coords) => void;
+  zoomToUser?: () => void;
+  toggleMapLayer?: () => void;
+};
+
+export const MapHeader = ({zoomTo, zoomToUser, toggleMapLayer}: Props) => {
+  const {t} = useTranslation();
+
+  return (
+    <Box
+      flex={1}
+      left={0}
+      position="absolute"
+      right={0}
+      top={0}
+      zIndex={1}
+      px={3}
+      py={3}
+      pointerEvents="box-none">
+      <Row space={3} pointerEvents="box-none">
+        <MapSearch zoomTo={zoomTo} />
+        <Column space={3}>
+          <IconButton
+            name="layers"
+            variant="light-filled"
+            type="md"
+            onPress={toggleMapLayer}
+          />
+          <UpdatedPermissionsRequestWrapper
+            requestModalTitle={t('permissions.location_title')}
+            requestModalBody={t('permissions.location_body')}
+            permissionHook={useUpdatedForegroundPermissions}
+            permissionedAction={zoomToUser}>
+            {onRequest => (
+              <IconButton
+                name="my-location"
+                variant="light-filled"
+                type="md"
+                onPress={onRequest}
+              />
+            )}
+          </UpdatedPermissionsRequestWrapper>
+        </Column>
+      </Row>
+    </Box>
+  );
+};

--- a/dev-client/src/screens/SitesScreen/components/search/MapSearch.tsx
+++ b/dev-client/src/screens/SitesScreen/components/search/MapSearch.tsx
@@ -32,33 +32,19 @@ import {Searchbar} from 'react-native-paper';
 
 import {Coords} from 'terraso-client-shared/types';
 
-import {IconButton} from 'terraso-mobile-client/components/buttons/icons/IconButton';
 import {searchBarStyles} from 'terraso-mobile-client/components/ListFilter';
-import {UpdatedPermissionsRequestWrapper} from 'terraso-mobile-client/components/modals/PermissionsRequestWrapper';
-import {
-  Box,
-  Column,
-  Row,
-  View,
-} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {View} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {MAP_QUERY_MIN_LENGTH} from 'terraso-mobile-client/constants';
 import {useSitesScreenContext} from 'terraso-mobile-client/context/SitesScreenContext';
-import {useUpdatedForegroundPermissions} from 'terraso-mobile-client/hooks/appPermissionsHooks';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 import {useMapSuggestions} from 'terraso-mobile-client/hooks/useMapSuggestions';
 import {MapSearchOfflineAlertBox} from 'terraso-mobile-client/screens/SitesScreen/components/search/MapSearchOfflineAlertBox';
 import {MapSearchSuggestionBox} from 'terraso-mobile-client/screens/SitesScreen/components/search/MapSearchSuggestionBox';
 import {Suggestion} from 'terraso-mobile-client/services/mapSearchService';
 
-type Props = {
-  zoomTo?: (site: Coords) => void;
-  zoomToUser?: () => void;
-  toggleMapLayer?: () => void;
-};
-
 const ShowAutocompleteContext = createContext(false);
 
-export const MapSearchInput = ({value, ...props}: TextInputProps) => {
+const MapSearchInput = ({value, ...props}: TextInputProps) => {
   const isOffline = useIsOffline();
   const showAutocomplete = useContext(ShowAutocompleteContext);
 
@@ -72,13 +58,17 @@ export const MapSearchInput = ({value, ...props}: TextInputProps) => {
         }}
         inputStyle={searchBarStyles.input}
         value={value ?? ''}
+        testID="MAP_SEARCH_INPUT"
       />
       {isOffline && showAutocomplete ? <MapSearchOfflineAlertBox /> : <></>}
     </>
   );
 };
 
-export const MapSearch = ({zoomTo, zoomToUser, toggleMapLayer}: Props) => {
+type MapSearchProps = {
+  zoomTo?: (coords: Coords) => void;
+};
+export const MapSearch = ({zoomTo}: MapSearchProps) => {
   const isOffline = useIsOffline();
   const {t} = useTranslation();
   const [query, setQuery] = useState('');
@@ -144,57 +134,22 @@ export const MapSearch = ({zoomTo, zoomToUser, toggleMapLayer}: Props) => {
   }, [setShowAutocomplete]);
 
   return (
-    <Box
-      flex={1}
-      left={0}
-      position="absolute"
-      right={0}
-      top={0}
-      zIndex={1}
-      px={3}
-      py={3}
-      pointerEvents="box-none">
-      <Row space={3} pointerEvents="box-none">
-        <View flex={1} pointerEvents="box-none">
-          <ShowAutocompleteContext.Provider value={showAutocomplete}>
-            <Autocomplete
-              data={suggestions}
-              hideResults={!showAutocomplete || isOffline}
-              flatListProps={flatListProps}
-              inputContainerStyle={styles.inputContainer}
-              onChangeText={onChangeText}
-              onFocus={onFocus}
-              onEndEditing={onEndEditing}
-              value={query}
-              placeholder={t('search.placeholder')}
-              renderTextInput={MapSearchInput}
-            />
-          </ShowAutocompleteContext.Provider>
-        </View>
-        <Column space={3}>
-          <IconButton
-            name="layers"
-            variant="light-filled"
-            type="md"
-            onPress={toggleMapLayer}
-          />
-          <UpdatedPermissionsRequestWrapper
-            requestModalTitle={t('permissions.location_title')}
-            requestModalBody={t('permissions.location_body')}
-            permissionHook={useUpdatedForegroundPermissions}
-            permissionedAction={zoomToUser}>
-            {onRequest => (
-              <IconButton
-                name="my-location"
-                variant="light-filled"
-                type="md"
-                onPress={onRequest}
-              />
-            )}
-          </UpdatedPermissionsRequestWrapper>
-        </Column>
-      </Row>
-    </Box>
+    <View flex={1} pointerEvents="box-none">
+      <ShowAutocompleteContext.Provider value={showAutocomplete}>
+        <Autocomplete
+          data={suggestions}
+          hideResults={!showAutocomplete || isOffline}
+          flatListProps={flatListProps}
+          inputContainerStyle={styles.inputContainer}
+          onChangeText={onChangeText}
+          onFocus={onFocus}
+          onEndEditing={onEndEditing}
+          value={query}
+          placeholder={t('search.placeholder')}
+          renderTextInput={MapSearchInput}
+        />
+      </ShowAutocompleteContext.Provider>
+    </View>
   );
 };
 


### PR DESCRIPTION
## Description
Reorganizes the map search code so that we are memoizing the autocomplete props properly. It'll be easier to review if you do it one commit at a time, as there's a fix commit followed by a refactor commit.

I struggled to write a test for this:
- i got the following error just from trying to render the component in a test:
    ```
    Cannot load null or undefined font source: { "material-community":  }. 
    Expected asset of type `FontSource` for fontFamily of name: "material-community"
    ```
- even if i can get the component to render, i'm not sure how to test focus state :thinking: 

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Related to #2826 

### Verification steps
Map search should be focusable again.
