### PR TITLE
fix: screen data requirement bugs

### DIFF
--- a/dev-client/src/components/dataRequirements/handleMissingData.ts
+++ b/dev-client/src/components/dataRequirements/handleMissingData.ts
@@ -50,7 +50,7 @@ export const useNavToSiteAndShowSyncError = (siteId: string) => {
   const syncNotifications = useSyncNotificationContext();
 
   return useCallback(() => {
-    navigation.navigate('SITE_TABS', {siteId: siteId});
+    navigation.popTo('SITE_TABS', {siteId: siteId});
     if (isFlagEnabled('FF_offline')) {
       syncNotifications.showError();
     }

--- a/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeShapeScreen.tsx
@@ -79,7 +79,6 @@ type CombinedSlope =
   `${SoilIdSoilDataDownSlopeChoices}:${SoilIdSoilDataCrossSlopeChoices}`;
 
 export const SlopeShapeScreen = ({siteId}: Props) => {
-  const name = useSelector(state => state.site.sites[siteId].name);
   const {t} = useTranslation();
   const {downSlope, crossSlope} = useSelector(selectSoilData(siteId));
   const dispatch = useDispatch();
@@ -160,7 +159,7 @@ export const SlopeShapeScreen = ({siteId}: Props) => {
     <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
-          AppBar={<AppBar title={name} />}
+          AppBar={<AppBar title={site.name} />}
           BottomNavigation={null}>
           <SiteRoleContextProvider siteId={siteId}>
             <ScrollView

--- a/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
+++ b/dev-client/src/screens/SlopeScreen/SlopeSteepnessScreen.tsx
@@ -74,7 +74,6 @@ type Props = {
 };
 
 export const SlopeSteepnessScreen = ({siteId}: Props) => {
-  const name = useSelector(state => state.site.sites[siteId].name);
   const {t} = useTranslation();
   const soilData = useSelector(selectSoilData(siteId));
   const dispatch = useDispatch();
@@ -150,7 +149,7 @@ export const SlopeSteepnessScreen = ({siteId}: Props) => {
     <ScreenDataRequirements requirements={requirements}>
       {() => (
         <ScreenScaffold
-          AppBar={<AppBar title={name} />}
+          AppBar={<AppBar title={site.name} />}
           BottomNavigation={null}>
           <SiteRoleContextProvider siteId={siteId}>
             <ScrollView

--- a/dev-client/src/store/selectors.ts
+++ b/dev-client/src/store/selectors.ts
@@ -277,7 +277,7 @@ export const useProjectSoilSettings = (projectId: string) =>
   useProjectSoilSettingsBase(projectId);
 
 export const useSiteProjectSoilSettings = (siteId: string) =>
-  useProjectSoilSettingsBase(useSelector(selectSite(siteId)).projectId);
+  useProjectSoilSettingsBase(useSelector(selectSite(siteId))?.projectId);
 
 export type AggregatedInterval = {
   isFromPreset: boolean;


### PR DESCRIPTION
## Description
A few edge cases that slipped through the cracks! Addressing the problem more holistically with tests or more honest type annotations is out of scope for launch unfortunately, and is tracked by https://github.com/techmatters/terraso-mobile-client/issues/2854

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Related to https://github.com/techmatters/terraso-mobile-client/issues/2290

### Verification steps
Should no longer see blank screen when viewing a data input screen for a site which gets deleted remotely.