### PR TITLE
fix: Only show dev-only SyncContent if FF_testing flag is on

### DIFF
--- a/dev-client/src/components/SyncContent.tsx
+++ b/dev-client/src/components/SyncContent.tsx
@@ -32,9 +32,11 @@ export const SyncContent = () => {
   return (
     <>
       <RestrictByFlag flag="FF_offline">
-        <SyncButton />
-        <PullInfo />
-        <PushInfo />
+        <RestrictByFlag flag="FF_testing">
+          <SyncButton />
+          <PullInfo />
+          <PushInfo />
+        </RestrictByFlag>
       </RestrictByFlag>
     </>
   );


### PR DESCRIPTION
## Description
So we don't show this dev-team-only stuff when we turn on the Offline feature flag:
![Screenshot 2025-01-29 at 4 44 05 PM](https://github.com/user-attachments/assets/1fa99991-5993-4c8b-afbf-937cca127a0c)


### Related Issues
N/A 

### Verification steps
When the Offline feature flag is ON, but the Testing feature flag is OFF, make sure we don't see the sync content at the top of the app
