### PR TITLE
fix: Reorganize the Feature Flag Control Panel

### DIFF
--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -20,6 +20,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Divider, Switch} from 'react-native-paper';
 
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
+import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
 import {
   Heading,
   Text,
@@ -48,11 +49,13 @@ export const FeatureFlagControlPanel = () => {
           {show && (
             <>
               <ScrollView>
-                <Heading mb="10px">Feature Flags</Heading>
-                <FeatureFlagControl flag="FF_offline" />
-                <View style={styles.spacer} />
-                <FeatureFlagControl flag="FF_testing" />
-                <Divider />
+                <ScreenContentSection>
+                  <Heading mb="10px">Feature Flags</Heading>
+                  <FeatureFlagControl flag="FF_offline" />
+                  <View style={styles.spacer} />
+                  <FeatureFlagControl flag="FF_testing" />
+                  <Divider />
+                </ScreenContentSection>
               </ScrollView>
             </>
           )}

--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -14,10 +14,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
 import {Divider, Switch} from 'react-native-paper';
 
+import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
 import {
   Heading,
   Text,
@@ -32,17 +34,29 @@ import {
 } from 'terraso-mobile-client/config/featureFlags';
 
 export const FeatureFlagControlPanel = () => {
+  const [show, setShow] = useState(false);
+  const toggle = useCallback(() => setShow(!show), [show, setShow]);
   return (
     <>
       {APP_CONFIG.environment !== 'production' && (
-        <>
-          <Divider />
-          <View>
-            <Heading mb="10px">Feature Flags</Heading>
-            <FeatureFlagControl flag="FF_offline" />
-            <FeatureFlagControl flag="FF_testing" />
-          </View>
-        </>
+        <View>
+          <ContainedButton
+            label="Feature Flags: Show/Hide"
+            stretchToFit={true}
+            onPress={toggle}
+          />
+          {show && (
+            <>
+              <ScrollView>
+                <Heading mb="10px">Feature Flags</Heading>
+                <FeatureFlagControl flag="FF_offline" />
+                <View style={styles.spacer} />
+                <FeatureFlagControl flag="FF_testing" />
+                <Divider />
+              </ScrollView>
+            </>
+          )}
+        </View>
       )}
     </>
   );
@@ -85,4 +99,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  controlPanelContainer: {maxHeight: 300},
+  spacer: {paddingVertical: 6},
 });

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -36,6 +36,7 @@ export function UserSettingsScreen() {
       <RestrictByFlag flag="FF_testing">
         <UiComponentList />
       </RestrictByFlag>
+      <FeatureFlagControlPanel />
       <Column margin="12px">
         <UserIndicator />
         <MenuList>
@@ -46,7 +47,6 @@ export function UserSettingsScreen() {
           <DeleteAccountItem />
         </MenuList>
         <VersionIndicator />
-        <FeatureFlagControlPanel />
       </Column>
     </ScreenScaffold>
   );


### PR DESCRIPTION
## Description
- Not urgent, but it was bugging me
- Move the feature flag control panel up and into a Scrollview so it doesn't get cut off on differently sized devices
- Follows the same pattern as the UI components section

Before:
<img src=https://github.com/user-attachments/assets/abb7b1e4-d471-4421-97ef-fa8ca21be0ac height=500>


After (on a different device, to be fair): 
Collapsed / Expanded
<img src=https://github.com/user-attachments/assets/baf6e028-b486-40a9-8708-ea190c4f03d4 height=500> / <img src=https://github.com/user-attachments/assets/87ec59f1-85b0-4467-ac1a-46faa771703d height=500>

### Related Issues
N/A
