### PR TITLE
fix: use `bug` type for mobile bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
@@ -1,7 +1,7 @@
 name: "Mobile App Bug Report"
 description: Used for reporting bugs and defects in mobile apps.
-labels: ["needs triage", "Engineering"],
-type: "bug",
+labels: ["needs triage", "Engineering"]
+type: "bug"
 body:
   - type: input
     id: app-version

--- a/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/mobile_bug_report.yml
@@ -1,6 +1,7 @@
 name: "Mobile App Bug Report"
 description: Used for reporting bugs and defects in mobile apps.
-labels: ["bug", "needs triage", "Engineering"]
+labels: ["needs triage", "Engineering"],
+type: "bug",
 body:
   - type: input
     id: app-version


### PR DESCRIPTION
Please check to see that this does add the type "Bug" to the report.

## Description
Removes "bug" label from Bug Report Form and adds "bug" type to resulting issues. 

![image](https://github.com/user-attachments/assets/ba46a965-cc13-4d34-98c1-d9e4ff9f87f5)


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
