### PR TITLE
fix: flakey test

### DIFF
--- a/dev-client/src/model/sync/records.test.ts
+++ b/dev-client/src/model/sync/records.test.ts
@@ -147,11 +147,7 @@ describe('record', () => {
 
     test('record synced date', () => {
       const at = Date.now();
-      const result = errorRecord(
-        {},
-        {value: 'error', revisionId: 123},
-        Date.now(),
-      );
+      const result = errorRecord({}, {value: 'error', revisionId: 123}, at);
       expect(result.lastSyncedAt).toEqual(at);
     });
 


### PR DESCRIPTION
## Description
Fixes a typo in a test which causes it to flake non-deterministically. It seemed easier to just fix it than file an issue. The test now matches a similar test in a file. Here is an example of a failed run: https://github.com/techmatters/terraso-mobile-client/actions/runs/12896446677/attempts/1

Screenshot because the logs don't last forever:
![image](https://github.com/user-attachments/assets/a1af7fc0-0faf-4dac-84c5-163e1bb786e1)

### Verification steps
Tests should still pass. There's no way to reliably trigger the flake so :shrug: 