### PR TITLE
fix: change how we call some `mmkv` functions to avoid messing with javascript's `this`

### DIFF
--- a/dev-client/src/persistence/kvStorage.test.ts
+++ b/dev-client/src/persistence/kvStorage.test.ts
@@ -21,3 +21,11 @@ test('kvStorage mock works', () => {
   kvStorage.setObject('map-key', {testKey: 'testValue'});
   expect(kvStorage.getObject('map-key')).toEqual({testKey: 'testValue'});
 });
+
+test('kvStorage can remove values', () => {
+  expect(kvStorage.hasKey('key')).toBe(false);
+  kvStorage.setBool('key', true);
+  expect(kvStorage.hasKey('key')).toBe(true);
+  kvStorage.remove('key');
+  expect(kvStorage.hasKey('key')).toBe(false);
+});

--- a/dev-client/src/persistence/kvStorage.ts
+++ b/dev-client/src/persistence/kvStorage.ts
@@ -85,6 +85,6 @@ export const kvStorage = {
     const [value, setValue] = useMMKVObject<T>(key, mmkvStorage);
     return [value ?? defaultValue, setValue] as const;
   },
-  hasKey: mmkvStorage.contains,
-  remove: mmkvStorage.delete,
+  hasKey: (key: string) => mmkvStorage.contains(key),
+  remove: (key: string) => mmkvStorage.delete(key),
 };


### PR DESCRIPTION
## Description
I will take a bit to figure out if a test could've caught this, but I suspect there's no way to catch this in a test because the libraries' function gets mocked in tests.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Should fix the login crash #2860 

### Verification steps
Can sign out.
