### PR TITLE
fix: properly load soil ID when creating new sites

### DIFF
--- a/dev-client/__tests__/integration/models/soilId/soilIdMatchSelectors.test.ts
+++ b/dev-client/__tests__/integration/models/soilId/soilIdMatchSelectors.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2023-2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {renderSelectorHook} from '@testing/integration/utils';
+
+import {initialState as accountInitialState} from 'terraso-client-shared/account/accountSlice';
+
+import {DEFAULT_SOIL_DATA} from 'terraso-mobile-client/model/soilData/soilDataConstants';
+import {soilDataToIdInput} from 'terraso-mobile-client/model/soilIdMatch/actions/soilIdMatchInputs';
+import {selectNextDataBasedInputs} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatchSelectors';
+import {initialState as syncInitialState} from 'terraso-mobile-client/model/sync/syncSlice';
+import {AppState, useSelector} from 'terraso-mobile-client/store';
+
+const appState = (): AppState => {
+  return {
+    account: accountInitialState,
+    map: {userLocation: {accuracyM: null, coords: null}},
+    elevation: {elevationCache: {}},
+    notifications: {messages: {}},
+    preferences: {colorWorkflow: 'MANUAL'},
+    project: {projects: {}},
+    site: {sites: {}},
+    soilData: {
+      projectSettings: {},
+      soilSync: {},
+      soilData: {},
+      status: 'ready',
+    },
+    soilIdMatch: {
+      locationBasedMatches: {},
+      siteDataBasedMatches: {},
+    },
+    soilMetadata: {
+      soilMetadata: {},
+    },
+    sync: syncInitialState,
+  };
+};
+
+describe('selectNextDataBasedInputs', () => {
+  test('supplies default soil data for newly created sites', () => {
+    const state = appState();
+
+    const selected = renderSelectorHook(
+      () => useSelector(s => selectNextDataBasedInputs(s, ['id'])),
+      state,
+    );
+
+    expect(selected).toEqual({
+      id: soilDataToIdInput(DEFAULT_SOIL_DATA),
+    });
+  });
+});

--- a/dev-client/src/model/soilIdMatch/soilIdMatchSelectors.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatchSelectors.ts
@@ -25,7 +25,7 @@ import {
   SoilIdLocationEntry,
 } from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
 import {AppState} from 'terraso-mobile-client/store';
-import {pickSoilDataFromMap} from 'terraso-mobile-client/store/selectors';
+import {getSoilDataForSite} from 'terraso-mobile-client/store/selectors';
 
 export const selectLocationBasedMatches = (
   coords: Coords,
@@ -60,6 +60,8 @@ export const selectDataBasedInputs = createSelector(
 /*
  * Memoized selector to let us select the upcoming data-based inputs for a set of site IDs (potentially expensive;
  * uses nested memoization to only recalculate input when source soil data changes)
+ *
+ * NOTE: these are the _next_ inputs for the soil ID algorithm, but the _current_ inputs for the site
  */
 export const selectNextDataBasedInputs = createSelector(
   createSelector(
@@ -70,7 +72,7 @@ export const selectNextDataBasedInputs = createSelector(
     /* Combine soil data with site IDs to extract relevant entries */
     (soilData, siteIds) =>
       Object.fromEntries(
-        siteIds.map(siteId => [siteId, pickSoilDataFromMap(siteId, soilData)]),
+        siteIds.map(siteId => [siteId, getSoilDataForSite(siteId, soilData)]),
       ),
   ),
   /* Pass site-specific soil data through input format converter */

--- a/dev-client/src/model/soilIdMatch/soilIdMatchSelectors.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatchSelectors.ts
@@ -19,6 +19,7 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import {Coords} from 'terraso-client-shared/types';
 
+import {DEFAULT_SOIL_DATA} from 'terraso-mobile-client/model/soilData/soilDataConstants';
 import {soilDataToIdInput} from 'terraso-mobile-client/model/soilIdMatch/actions/soilIdMatchInputs';
 import {
   coordsKey,
@@ -68,7 +69,9 @@ export const selectNextDataBasedInputs = createSelector(
     ],
     /* Combine soil data with site IDs to extract relevant entries */
     (soilData, siteIds) =>
-      Object.fromEntries(siteIds.map(siteId => [siteId, soilData[siteId]])),
+      Object.fromEntries(
+        siteIds.map(siteId => [siteId, soilData[siteId] ?? DEFAULT_SOIL_DATA]),
+      ),
   ),
   /* Pass site-specific soil data through input format converter */
   soilData =>

--- a/dev-client/src/model/soilIdMatch/soilIdMatchSelectors.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatchSelectors.ts
@@ -19,13 +19,13 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import {Coords} from 'terraso-client-shared/types';
 
-import {DEFAULT_SOIL_DATA} from 'terraso-mobile-client/model/soilData/soilDataConstants';
 import {soilDataToIdInput} from 'terraso-mobile-client/model/soilIdMatch/actions/soilIdMatchInputs';
 import {
   coordsKey,
   SoilIdLocationEntry,
 } from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
 import {AppState} from 'terraso-mobile-client/store';
+import {pickSoilDataFromMap} from 'terraso-mobile-client/store/selectors';
 
 export const selectLocationBasedMatches = (
   coords: Coords,
@@ -70,7 +70,7 @@ export const selectNextDataBasedInputs = createSelector(
     /* Combine soil data with site IDs to extract relevant entries */
     (soilData, siteIds) =>
       Object.fromEntries(
-        siteIds.map(siteId => [siteId, soilData[siteId] ?? DEFAULT_SOIL_DATA]),
+        siteIds.map(siteId => [siteId, pickSoilDataFromMap(siteId, soilData)]),
       ),
   ),
   /* Pass site-specific soil data through input format converter */

--- a/dev-client/src/store/selectors.ts
+++ b/dev-client/src/store/selectors.ts
@@ -284,13 +284,13 @@ export type AggregatedInterval = {
   interval: SoilDataDepthInterval;
 };
 
-export const pickSoilDataFromMap = (
+export const getSoilDataForSite = (
   siteId: string,
   soilData: Record<string, SoilData | undefined>,
 ) => soilData[siteId] ?? DEFAULT_SOIL_DATA;
 
 export const selectSoilData = (siteId: string) => (state: AppState) =>
-  pickSoilDataFromMap(siteId, state.soilData.soilData);
+  getSoilDataForSite(siteId, state.soilData.soilData);
 
 export const useSiteSoilIntervals = (siteId: string): AggregatedInterval[] => {
   const projectSettings = useSiteProjectSoilSettings(siteId);

--- a/dev-client/src/store/selectors.ts
+++ b/dev-client/src/store/selectors.ts
@@ -284,8 +284,13 @@ export type AggregatedInterval = {
   interval: SoilDataDepthInterval;
 };
 
+export const pickSoilDataFromMap = (
+  siteId: string,
+  soilData: Record<string, SoilData | undefined>,
+) => soilData[siteId] ?? DEFAULT_SOIL_DATA;
+
 export const selectSoilData = (siteId: string) => (state: AppState) =>
-  state.soilData.soilData[siteId] ?? DEFAULT_SOIL_DATA;
+  pickSoilDataFromMap(siteId, state.soilData.soilData);
 
 export const useSiteSoilIntervals = (siteId: string): AggregatedInterval[] => {
   const projectSettings = useSiteProjectSoilSettings(siteId);


### PR DESCRIPTION
## Description
Yet another bug due to our house of cards of redux selector logic. Forgot to include the default soil data in a selector. This creates a bug specifically for newly created sites because when we pull, the backend supplies default soil data for all sites. So it's only when we've created a site but haven't pulled yet that we need to supply default data ourselves on the client. There's definitely a better way to architect this but it seems out of scope for this pre-launch fix, but I think I can write a localized test for it.

Not sure if there's a straightforward better way to architect this, I'm a bit scared of all the nested selectors :(

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Related to #2858

### Verification steps
Soil ID should now load for newly created sites.
