### PR TITLE
test: add some tests for offline snackbar

### DIFF
--- a/dev-client/.prettierignore
+++ b/dev-client/.prettierignore
@@ -14,5 +14,9 @@
 !src/**/*.jsx
 !src/**/*.ts
 !src/**/*.tsx
+!__tests__/**/*.ts
+!__tests__/**/*.tsx
+!__mocks__/**/*.ts
+!__mocks__/**/*.tsx
 !*/
 .expo/**

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -188,12 +188,14 @@ describe('Offline snackbar', () => {
       </PaperProvider>,
     );
 
+    // FYI: Because the snackbar has an animation transition before hiding and returning null,
+    // Need to run the jest timers, and  wrap it in act() to make sureresulting state updates 
+    // are fully applied
     act(() => {
       jest.runAllTimers();
     })
 
-    const snackbar = screen.queryByTestId(snackbarTestId);
-    expect(snackbar).not.toBeOnTheScreen();
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
 
 

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Technology Matters
+ * Copyright © 2025 Technology Matters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -18,16 +18,22 @@
 import 'terraso-mobile-client/translations';
 import 'terraso-mobile-client/config';
 
-import {PaperProvider, Portal} from 'react-native-paper';
+import { Button } from 'react-native';
+import { PaperProvider, Portal } from 'react-native-paper';
 
-import {testState} from '@testing/integration/data';
-import {render} from '@testing/integration/utils';
+import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react-native';
+import { testState } from '@testing/integration/data';
+import { render } from '@testing/integration/utils';
 
-import {OfflineSnackbar} from 'terraso-mobile-client/components/messages/OfflineSnackbar';
-import {FeatureFlagName} from 'terraso-mobile-client/config/featureFlags';
+import * as projectService from 'terraso-client-shared/project/projectService';
+
+import { OfflineSnackbar } from 'terraso-mobile-client/components/messages/OfflineSnackbar';
+import { FeatureFlagName } from 'terraso-mobile-client/config/featureFlags';
 import * as connectivityHooks from 'terraso-mobile-client/hooks/connectivityHooks';
-import {ProjectListScreen} from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
-import {ProjectViewScreen} from 'terraso-mobile-client/screens/ProjectViewScreen/ProjectViewScreen';
+import { deleteProject } from 'terraso-mobile-client/model/project/projectSlice';
+import { ProjectListScreen } from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
+import { ProjectViewScreen } from 'terraso-mobile-client/screens/ProjectViewScreen/ProjectViewScreen';
+import { AppState, useDispatch } from 'terraso-mobile-client/store';
 
 jest.mock('terraso-mobile-client/config/featureFlags', () => {
   const actual = jest.requireActual(
@@ -55,12 +61,37 @@ jest.mock('terraso-client-shared/terrasoApi/api', () => {
   };
 });
 
+jest.mock('terraso-client-shared/project/projectService', () => {
+  const actual = jest.requireActual(
+    'terraso-client-shared/project/projectService',
+  );
+  return {
+    ...actual,
+    deleteProject: jest.fn(),
+  };
+});
+
 describe('Offline snackbar', () => {
   const useIsOfflineMock = jest.mocked(connectivityHooks.useIsOffline);
+
+  // TODO-cknipe: Uhh maybe remove this? Or look at the debugger to find what to retun
+  // const requestGraphQLMock = jest.mocked(api.requestGraphQL);
+  // type GraphQLResponseType = ReturnType<typeof api.requestGraphQL>;
+  // const graphQLError = Promise.reject([
+  //   'terraso_api.error_unexpected',
+  // ]) as GraphQLResponseType;
+  // const graphQLSuccess = Promise.resolve() as GraphQLResponseType;
+
+  const deleteProjectMock = jest.mocked(projectService.deleteProject);
+
+  // TODO-cknipe: Use only one of these
   const snackbarText = "You are offline. Projects can't be edited.";
+  const snackbarTestId = 'offline-snackbar';
 
   beforeEach(() => {
     useIsOfflineMock.mockReset().mockReturnValue(false);
+    // requestGraphQLMock.mockReset();
+    deleteProjectMock.mockReset();
   });
 
   test('appears when offline and first rendering project screen', () => {
@@ -79,7 +110,7 @@ describe('Offline snackbar', () => {
       },
     );
 
-    expect(screen.getByText(snackbarText)).toBeTruthy();
+    expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
   });
 
   test('does not appear when online and first rendering project screen', () => {
@@ -98,7 +129,7 @@ describe('Offline snackbar', () => {
       },
     );
 
-    expect(screen.queryByText(snackbarText)).toBeFalsy();
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
 
   test('does not appear when offline on non-project-specific screen', () => {
@@ -117,7 +148,7 @@ describe('Offline snackbar', () => {
       },
     );
 
-    expect(screen.queryByText(snackbarText)).toBeFalsy();
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
 
   test('appears when going offline', () => {
@@ -146,11 +177,156 @@ describe('Offline snackbar', () => {
       </PaperProvider>,
     );
 
-    expect(screen.getByText(snackbarText)).toBeTruthy();
+    expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
   });
 
-  // test('disappears when returning online', () => {});
-  // test('is shown when thunk fails offline', () => {});
+  // TODO-cknipe: 
+  // Issue: I expect the snackbar to be on the screen after the first render (this is passing), 
+  // but not to be on the screen at the end (this is failing).
+  // - Putting a console.log in the snackbar component shows the component's visible prop is false on the
+  //   last render before the test's expect statement.
+  // - I hypothesized maybe this is because the snackbar is still in React's virtual DOM, but not visible. 
+  //   - In tests it seems like if the snackbar doesn't start on the screen, it's (correctly) not detected 
+  //     by toBeOnTheScreen(). But once it has been put on the screen, I have not found a way to stop it
+  //     being detected, even when I try to remove it. This behavior seems incongruent with the behavior of
+  //     both the Components hierarchy, and of what the user sees.
+  //   - When I look in the product with React Native DevTools, if the snackbar is visible to the user, 
+  //     there is a Snackbar in the Components hierarchy with visible: true. 
+  //     If it is not visible, there is a Snackbar in the Components hierarchy with visible: false.
+  //   - The presence of the Portal seems irrelevant, at least removing the Portal.Host has no
+  //     effect on the outcome of the tests.
+  test('disappears when returning online', async () => {
+    console.log('------- TEST: Disappears when returning online -------');
+    useIsOfflineMock.mockReturnValue(true);
+
+    const screen = render(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+      {
+        route: 'PROJECT_VIEW',
+        initialState: testState,
+      },
+    );
+
+    expect(screen.queryByTestId(snackbarTestId)).toBeTruthy();
+
+    // This fails, and doesn't seem like an ideal way to test this anyway
+    // expect(screen.queryByTestId(snackbarTestId).props.visible).toBe(true);
+
+    console.log('Starting 2nd render');
+    useIsOfflineMock.mockReturnValue(false);
+    screen.rerender(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+    );
+
+    await waitForElementToBeRemoved(screen.queryByTestId(snackbarTestId))
+      .then(() => {
+        console.log('Yup'); // This does not happen
+      })
+      .catch(() => {
+        console.log('Nope'); // This happens
+      });
+
+    // These all fail
+    expect(screen.queryByText(snackbarText)).toBeFalsy();
+    expect(screen.queryByText(snackbarText)).not.toBeOnTheScreen();
+    expect(screen.queryByTestId(snackbarTestId)).toBeFalsy();
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
+  });
+
+  // TODO-cknipe: Issues: 
+  // All the console.logs in OfflineSnackbar make sense, but the 
+  test('is shown when thunk fails offline', async () => {
+    console.log('------ TEST: shown when thunk fails offline ------');
+    // Mock being Offline
+    useIsOfflineMock.mockReturnValue(true);
+    deleteProjectMock.mockReturnValue(Promise.reject(['rejected']));
+
+    const projectId = 'project1';
+    const initialState = {
+      project: {
+        projects: {
+          [projectId]: {
+            id: projectId,
+            name: '1',
+            privacy: 'PRIVATE',
+            archived: false,
+            updatedAt: '',
+            measurementUnits: 'METRIC',
+            description: 'desc',
+            memberships: {},
+            sites: {},
+          },
+        },
+      },
+    } as Partial<AppState>;
+
+    // Make a button that will dispatch something to server
+    const TestButton = () => {
+      const dispatch = useDispatch();
+      return (
+        <Button
+          title="dispatch"
+          testID="test-delete-project-btn"
+          onPress={() => {
+            console.log('PRESSED test button');
+            dispatch(deleteProject({id: projectId}));
+          }}
+        />
+      );
+    };
+
+    console.log("1")
+    const screen = render(
+        <PaperProvider>
+        <Portal.Host>
+          <TestButton />
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+      {route: 'PROJECT_VIEW', initialState},
+    );
+    console.log("2")
+
+    const snackbar = screen.queryByTestId(snackbarTestId);
+    expect(snackbar).toBeOnTheScreen();
+ 
+    // Dismiss snackbar
+    fireEvent(snackbar, 'onDismiss');
+    jest.runAllTimers();
+    console.log("3")
+
+    // Confirm snackbar is gone
+    // This fails the entire test suite, though the snackbar was rendering with visible=false
+    // Question 1: Why would an expect call cause the entire suite to fail, not just the single test?
+    //             expect(undefined).toBeTruthy();    also fails the entire suite 
+    // Question 2: Why this would fail if I don't explicitly call rerender? 
+    //             Shouldn't rerenders be automatically triggered?
+    // Tried: calling rerender with the same components as the first render. This passed, but I think
+    //        it was just because it created a new OfflineSnackbar with visible initialized to false
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
+
+
+    // Fire the test button event to make a server request. The request is mocked to fail, 
+    // which should add a message to the notificationsSlice and trigger the snackbar
+    fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
+    console.log("4")
+
+    // This passes if the failing expect is removed, but it may only be because we never actually
+    // remove the snackbar, so it's still on the screen from the first render
+    expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
+  });
+
   // test('is not shown when thunk fails online', () => {});
   // test('is not shown when thunk succeeds online', () => {});
   // test('is not shown when thunk succeeds offline', () => {});

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -341,7 +341,6 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
 
-    // Fire the test button event
     await act(async () => {
       fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     });

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -204,55 +204,51 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
   const deleteProjectMock = jest.mocked(projectService.deleteProject);
 
   const snackbarTestId = 'offline-snackbar';
+  const projectId = '1';
+  const initialAppState = {
+    project: {
+      projects: {
+        [projectId]: {
+          id: projectId,
+          name: projectId,
+          privacy: 'PRIVATE',
+          archived: false,
+          updatedAt: '',
+          measurementUnits: 'METRIC',
+          description: 'desc',
+          memberships: {},
+          sites: {},
+        },
+      },
+    },
+  } as Partial<AppState>;
+
+  // Button component that simulates dispatching something to server
+  const TestButton = () => {
+    const dispatch = useDispatch();
+    return (
+      <Button
+        title="dispatch"
+        testID="test-delete-project-btn"
+        onPress={() => {
+          dispatch(deleteProject({id: projectId}));
+        }}
+      />
+    );
+  };
 
   beforeEach(() => {
     useIsOfflineMock.mockReset().mockReturnValue(false);
     deleteProjectMock.mockReset();
   });
 
-  const makeAppStateWithProject = (projectId: string) => {
-    return {
-      project: {
-        projects: {
-          [projectId]: {
-            id: projectId,
-            name: '1',
-            privacy: 'PRIVATE',
-            archived: false,
-            updatedAt: '',
-            measurementUnits: 'METRIC',
-            description: 'desc',
-            memberships: {},
-            sites: {},
-          },
-        },
-      },
-    } as Partial<AppState>;
-  };
-
   test('can be dismissed, and is shown when thunk fails offline', async () => {
     useIsOfflineMock.mockReturnValue(true);
 
-    const projectId = '1';
-    const initialState = makeAppStateWithProject(projectId);
-
-    // Button that simulates dispatching something to server
     // FYI: Need to mockImplementation, not just mockReturn for async reasons
     deleteProjectMock.mockImplementation(async () =>
       Promise.reject(['rejected']),
     );
-    const TestButton = () => {
-      const dispatch = useDispatch();
-      return (
-        <Button
-          title="dispatch"
-          testID="test-delete-project-btn"
-          onPress={() => {
-            dispatch(deleteProject({id: projectId}));
-          }}
-        />
-      );
-    };
 
     const screen = render(
       <PaperProvider>
@@ -262,7 +258,7 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
           <ProjectViewScreen projectId={projectId} />
         </Portal.Host>
       </PaperProvider>,
-      {route: 'PROJECT_VIEW', initialState},
+      {route: 'PROJECT_VIEW', initialState: initialAppState},
     );
 
     const snackbar = screen.queryByTestId(snackbarTestId);
@@ -290,25 +286,9 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
 
   test('is not shown when thunk fails online', async () => {
     useIsOfflineMock.mockReturnValue(false);
-
-    const projectId = '1';
-    const initialState = makeAppStateWithProject(projectId);
-
     deleteProjectMock.mockImplementation(async () =>
       Promise.reject(['rejected']),
     );
-    const TestButton = () => {
-      const dispatch = useDispatch();
-      return (
-        <Button
-          title="dispatch"
-          testID="test-delete-project-btn"
-          onPress={() => {
-            dispatch(deleteProject({id: projectId}));
-          }}
-        />
-      );
-    };
 
     const screen = render(
       <PaperProvider>
@@ -318,7 +298,7 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
           <ProjectViewScreen projectId={projectId} />
         </Portal.Host>
       </PaperProvider>,
-      {route: 'PROJECT_VIEW', initialState},
+      {route: 'PROJECT_VIEW', initialState: initialAppState},
     );
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
@@ -332,27 +312,9 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
 
   test('is not shown when thunk succeeds offline', async () => {
     useIsOfflineMock.mockReturnValue(true);
-
-    const projectId = '1';
-    const initialState = makeAppStateWithProject(projectId);
-
-    // Button that simulates dispatching something to server
-    // FYI: Need to mockImplementation, not just mockReturn for async reasons
     deleteProjectMock.mockImplementation(async () =>
       Promise.resolve('unused test success message'),
     );
-    const TestButton = () => {
-      const dispatch = useDispatch();
-      return (
-        <Button
-          title="dispatch"
-          testID="test-delete-project-btn"
-          onPress={() => {
-            dispatch(deleteProject({id: projectId}));
-          }}
-        />
-      );
-    };
 
     const screen = render(
       <PaperProvider>
@@ -362,7 +324,7 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
           <ProjectViewScreen projectId={projectId} />
         </Portal.Host>
       </PaperProvider>,
-      {route: 'PROJECT_VIEW', initialState},
+      {route: 'PROJECT_VIEW', initialState: initialAppState},
     );
 
     const snackbar = screen.queryByTestId(snackbarTestId);
@@ -379,13 +341,11 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
 
-    // Fire the test button event to make a server request.
+    // Fire the test button event
     await act(async () => {
       fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     });
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
-
-  // test('is not shown when thunk succeeds online', async () => {});
 });

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -271,25 +271,25 @@ describe('Offline snackbar (with mocked backend call)', () => {
     // Dismiss snackbar
     // TODO-cknipe: Should we be using userEvent instead?
 
-    // Option 1 - Good, test passes
+    // A: Option 1 - Good, test passes
     // fireEvent(snackbar, 'onDismiss');
     // act(() => {
     //   jest.runAllTimers();
     // });
 
-    // Option 2 - Good, test passes
+    // A: Option 2 - Good, test passes
     // fireEvent(snackbar, 'onDismiss');
     // await act(async () => {
     //   jest.runAllTimers();
     // });
 
-    // Option 3 - Bad, test fails with snackbar still found on the screen
+    // A: Option 3 - Bad, test fails with snackbar still found on the screen
     // await act(async () => {
     //   fireEvent(snackbar, 'onDismiss');
     //   jest.runAllTimers();
     // });
 
-    // Option 4 - Good, test passes
+    // A: Option 4 - Good, test passes
     await act(async () => {
       fireEvent(snackbar, 'onDismiss');
     });
@@ -298,7 +298,7 @@ describe('Offline snackbar (with mocked backend call)', () => {
       jest.runAllTimers();
     });
 
-    // Option 5 - Bad, test fails with snackbar still found on the screen
+    // A: Option 5 - Bad, test fails with snackbar still found on the screen
     // await act(async () => {
     //   fireEvent(snackbar, 'onDismiss');
     //   await jest.runAllTimersAsync();
@@ -309,22 +309,25 @@ describe('Offline snackbar (with mocked backend call)', () => {
     // Fire the test button event to make a server request. The request is mocked to fail,
     // which should add a message to the notificationsSlice and trigger the snackbar.
 
-    // Option 1 - Bad, test fails with snackbar not on the screen
+    // B: Option 1 - Bad, test fails with snackbar not on the screen
     // fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     // act(() => {
     //   jest.runAllTimers();
     // });
 
-    // Option 2 - Good, test passes
+    // B: Option 2 - Good, test passes
     // fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     // await act(async () => {
     //   jest.runAllTimers();
     // });
 
-    // Option 3 - Good, test passes
+    // B: Option 3 - Good, test passes
     await act(async () => {
       fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     });
+
+    // B: Option 4 - Bad, test fails with snackbar not on the screen
+    // fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
 
     expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
   });

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -18,22 +18,22 @@
 import 'terraso-mobile-client/translations';
 import 'terraso-mobile-client/config';
 
-import { Button } from 'react-native';
-import { PaperProvider, Portal } from 'react-native-paper';
+import {Button} from 'react-native';
+import {PaperProvider, Portal} from 'react-native-paper';
 
-import { act, fireEvent } from '@testing-library/react-native';
-import { testState } from '@testing/integration/data';
-import { render } from '@testing/integration/utils';
+import {act, fireEvent} from '@testing-library/react-native';
+import {testState} from '@testing/integration/data';
+import {render} from '@testing/integration/utils';
 
 import * as projectService from 'terraso-client-shared/project/projectService';
 
-import { OfflineSnackbar } from 'terraso-mobile-client/components/messages/OfflineSnackbar';
-import { FeatureFlagName } from 'terraso-mobile-client/config/featureFlags';
+import {OfflineSnackbar} from 'terraso-mobile-client/components/messages/OfflineSnackbar';
+import {FeatureFlagName} from 'terraso-mobile-client/config/featureFlags';
 import * as connectivityHooks from 'terraso-mobile-client/hooks/connectivityHooks';
-import { deleteProject } from 'terraso-mobile-client/model/project/projectSlice';
-import { ProjectListScreen } from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
-import { ProjectViewScreen } from 'terraso-mobile-client/screens/ProjectViewScreen/ProjectViewScreen';
-import { AppState, useDispatch } from 'terraso-mobile-client/store';
+import {deleteProject} from 'terraso-mobile-client/model/project/projectSlice';
+import {ProjectListScreen} from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
+import {ProjectViewScreen} from 'terraso-mobile-client/screens/ProjectViewScreen/ProjectViewScreen';
+import {AppState, useDispatch} from 'terraso-mobile-client/store';
 
 jest.mock('terraso-mobile-client/config/featureFlags', () => {
   const actual = jest.requireActual(
@@ -189,20 +189,19 @@ describe('Offline snackbar', () => {
     );
 
     // FYI: Because the snackbar has an animation transition before hiding and returning null,
-    // Need to run the jest timers, and  wrap it in act() to make sureresulting state updates 
+    // Need to run the jest timers, and  wrap it in act() to make sureresulting state updates
     // are fully applied
     act(() => {
       jest.runAllTimers();
-    })
+    });
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
 
-
   test('can be dismissed, and is shown when thunk fails offline', async () => {
     console.log('------ TEST: dismiss + shown when thunk fails offline ------');
     useIsOfflineMock.mockReturnValue(true);
-    
+
     const projectId = '1';
     const initialState = {
       project: {
@@ -221,7 +220,7 @@ describe('Offline snackbar', () => {
         },
       },
     } as Partial<AppState>;
-    
+
     // Button that simulates dispatching something to server
     deleteProjectMock.mockReturnValue(Promise.reject(['rejected']));
     const TestButton = () => {
@@ -239,7 +238,7 @@ describe('Offline snackbar', () => {
     };
 
     const screen = render(
-        <PaperProvider>
+      <PaperProvider>
         <Portal.Host>
           <TestButton />
           <OfflineSnackbar />
@@ -248,45 +247,45 @@ describe('Offline snackbar', () => {
       </PaperProvider>,
       {route: 'PROJECT_VIEW', initialState},
     );
-    console.log("2")
+    console.log('2');
 
     const snackbar = screen.queryByTestId(snackbarTestId);
     expect(snackbar).toBeOnTheScreen();
- 
+
     // Dismiss snackbar
     fireEvent(snackbar, 'onDismiss');
 
-    // Question 0: If we await act, the entire suite fails in the same way as in Question 1 below. 
+    // Question 0: If we await act, the entire suite fails in the same way as in Question 1 below.
     // Why would that make a difference?
     act(() => {
-      jest.runAllTimers()
-    })
-    console.log("3")
+      jest.runAllTimers();
+    });
+    console.log('3');
 
     // Question 1: Why would `expect(undefined).toBeTruthy();` here cause the entire suite to fail, not just the single test?
-    //   If put further up in the test, or in other tests, it only fails the single test, not the entire suite. 
+    //   If put further up in the test, or in other tests, it only fails the single test, not the entire suite.
     //
-    // Output from `npm run test OfflineSnackbar`: 
+    // Output from `npm run test OfflineSnackbar`:
     //   Test suite failed to run
     //   TypeError: Cannot set properties of undefined (setting 'message')
     //     at node_modules/jest-circus/build/formatNodeAssertErrors.js:47:25
     //         at Array.map (<anonymous>)
     //   Test Suites: 1 failed, 1 total
     //   Tests:       0 total
-    // I suspect this is the erroring line in the test library: 
+    // I suspect this is the erroring line in the test library:
     // https://github.com/jestjs/jest/blob/main/packages/jest-circus/src/formatNodeAssertErrors.ts#L58
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
 
-
-    // Fire the test button event to make a server request. The request is mocked to fail, 
+    // Fire the test button event to make a server request. The request is mocked to fail,
     // which should add a message to the notificationsSlice and trigger the snackbar
     fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     await act(() => {
       jest.runAllTimers();
     });
-    console.log("4")
 
-    // Question 2: When should an act call be awaited or not? 
+    console.log('4');
+
+    // Question 2: When should an act call be awaited or not?
     // The expect below fails if we do not await the act above -- even though the IDE says `await` has
     // no effect on the expression. I had thought you'd only need to await if the function passed in
     // is async, but perhaps I'm wrong. Why would this make a difference at all, and what is special about
@@ -296,7 +295,7 @@ describe('Offline snackbar', () => {
     //   received value must be a host element.
     //   Received has value: null
     expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
-});
+  });
 
   // test('is not shown when thunk fails online', () => {});
   // test('is not shown when thunk succeeds online', () => {});

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import 'terraso-mobile-client/translations';
+import 'terraso-mobile-client/config';
+
+import {PaperProvider, Portal} from 'react-native-paper';
+
+import {testState} from '@testing/integration/data';
+import {render} from '@testing/integration/utils';
+
+import {OfflineSnackbar} from 'terraso-mobile-client/components/messages/OfflineSnackbar';
+import {FeatureFlagName} from 'terraso-mobile-client/config/featureFlags';
+import * as connectivityHooks from 'terraso-mobile-client/hooks/connectivityHooks';
+import {ProjectListScreen} from 'terraso-mobile-client/screens/ProjectListScreen/ProjectListScreen';
+import {ProjectViewScreen} from 'terraso-mobile-client/screens/ProjectViewScreen/ProjectViewScreen';
+
+jest.mock('terraso-mobile-client/config/featureFlags', () => {
+  const actual = jest.requireActual(
+    'terraso-mobile-client/config/featureFlags',
+  );
+  return {
+    ...actual,
+    isFlagEnabled: (flag: FeatureFlagName) => {
+      if (flag === 'FF_offline') return true;
+    },
+  };
+});
+
+jest.mock('terraso-mobile-client/hooks/connectivityHooks', () => {
+  return {
+    useIsOffline: jest.fn(),
+  };
+});
+
+jest.mock('terraso-client-shared/terrasoApi/api', () => {
+  const actual = jest.requireActual('terraso-client-shared/terrasoApi/api');
+  return {
+    ...actual,
+    requestGraphQL: jest.fn(),
+  };
+});
+
+describe('Offline snackbar', () => {
+  const useIsOfflineMock = jest.mocked(connectivityHooks.useIsOffline);
+  const snackbarText = "You are offline. Projects can't be edited.";
+
+  beforeEach(() => {
+    useIsOfflineMock.mockReset().mockReturnValue(false);
+  });
+
+  test('appears when offline and first rendering project screen', () => {
+    useIsOfflineMock.mockReturnValue(true);
+
+    const screen = render(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+      {
+        route: 'PROJECT_VIEW',
+        initialState: testState,
+      },
+    );
+
+    expect(screen.getByText(snackbarText)).toBeTruthy();
+  });
+
+  test('does not appear when online and first rendering project screen', () => {
+    useIsOfflineMock.mockReturnValue(false);
+
+    const screen = render(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+      {
+        route: 'PROJECT_VIEW',
+        initialState: testState,
+      },
+    );
+
+    expect(screen.queryByText(snackbarText)).toBeFalsy();
+  });
+
+  test('does not appear when offline on non-project-specific screen', () => {
+    useIsOfflineMock.mockReturnValue(true);
+
+    const screen = render(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectListScreen />
+        </Portal.Host>
+      </PaperProvider>,
+      {
+        route: 'BOTTOM_TABS',
+        initialState: testState,
+      },
+    );
+
+    expect(screen.queryByText(snackbarText)).toBeFalsy();
+  });
+
+  test('appears when going offline', () => {
+    useIsOfflineMock.mockReturnValue(false);
+
+    const screen = render(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+      {
+        route: 'PROJECT_VIEW',
+        initialState: testState,
+      },
+    );
+
+    useIsOfflineMock.mockReset().mockReturnValue(true);
+    screen.rerender(
+      <PaperProvider>
+        <Portal.Host>
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId="1" />
+        </Portal.Host>
+      </PaperProvider>,
+    );
+
+    expect(screen.getByText(snackbarText)).toBeTruthy();
+  });
+
+  // test('disappears when returning online', () => {});
+  // test('is shown when thunk fails offline', () => {});
+  // test('is not shown when thunk fails online', () => {});
+  // test('is not shown when thunk succeeds online', () => {});
+  // test('is not shown when thunk succeeds offline', () => {});
+});

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -21,7 +21,7 @@ import 'terraso-mobile-client/config';
 import { Button } from 'react-native';
 import { PaperProvider, Portal } from 'react-native-paper';
 
-import { fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/react-native';
+import { act, fireEvent } from '@testing-library/react-native';
 import { testState } from '@testing/integration/data';
 import { render } from '@testing/integration/utils';
 
@@ -210,13 +210,18 @@ describe('Offline snackbar', () => {
       </PaperProvider>,
     );
 
-    await waitForElementToBeRemoved(screen.queryByTestId(snackbarTestId))
-      .then(() => {
-        console.log('Yup'); // This does not happen
-      })
-      .catch(() => {
-        console.log('Nope'); // This happens
-      });
+    // await waitForElementToBeRemoved(screen.queryByTestId(snackbarTestId))
+    //   .then(() => {
+    //     console.log('Yup'); // This does not happen
+    //   })
+    //   .catch(() => {
+    //     console.log('Nope'); // This happens
+    //   });
+
+    act(() => {
+      // jest.advanceTimersByTime(1500);
+      jest.runAllTimers();
+    })
 
     // These all fail
     expect(screen.queryByText(snackbarText)).toBeFalsy();
@@ -286,7 +291,11 @@ describe('Offline snackbar', () => {
  
     // Dismiss snackbar
     fireEvent(snackbar, 'onDismiss');
-    jest.runAllTimers();
+    // jest.runAllTimers();
+    act(() => {
+      // jest.advanceTimersByTime(1500)
+      jest.runAllTimers()
+    })
     console.log("3")
 
     // Confirm snackbar is gone
@@ -297,21 +306,24 @@ describe('Offline snackbar', () => {
     //             Shouldn't rerenders be automatically triggered?
     // Tried: calling rerender with the same components as the first render. This passed, but I think
     //        it was just because it created a new OfflineSnackbar with visible initialized to false
-    //expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
 
 
     // Fire the test button event to make a server request. The request is mocked to fail, 
     // which should add a message to the notificationsSlice and trigger the snackbar
     fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
+    await act(() => {
+      // jest.advanceTimersByTime(1500)
+      jest.runAllTimers();
+    });
     console.log("4")
 
     // This passes if the failing expect is removed, but it may only be because we never actually
     // remove the snackbar, so it's still on the screen from the first render? 
     // But also the last console.log reports the snackbar with visible=false, so I'm 
     // just confused
-    await waitFor(() => {
-      expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
-    });  
+    expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
+    
 });
 
   // test('is not shown when thunk fails online', () => {});

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -63,6 +63,15 @@ jest.mock('terraso-client-shared/project/projectService', () => {
   };
 });
 
+const createJSXWithSnackbar = (ui: React.ReactNode) => (
+  <PaperProvider>
+    <Portal.Host>
+      <OfflineSnackbar />
+      {ui}
+    </Portal.Host>
+  </PaperProvider>
+);
+
 describe('Offline snackbar', () => {
   const useIsOfflineMock = jest.mocked(connectivityHooks.useIsOffline);
   const deleteProjectMock = jest.mocked(projectService.deleteProject);
@@ -78,12 +87,7 @@ describe('Offline snackbar', () => {
     useIsOfflineMock.mockReturnValue(true);
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectViewScreen projectId="1" />
-        </Portal.Host>
-      </PaperProvider>,
+      createJSXWithSnackbar(<ProjectViewScreen projectId="1" />),
       {
         route: 'PROJECT_VIEW',
         initialState: testState,
@@ -97,12 +101,7 @@ describe('Offline snackbar', () => {
     useIsOfflineMock.mockReturnValue(false);
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectViewScreen projectId="1" />
-        </Portal.Host>
-      </PaperProvider>,
+      createJSXWithSnackbar(<ProjectViewScreen projectId="1" />),
       {
         route: 'PROJECT_VIEW',
         initialState: testState,
@@ -115,18 +114,10 @@ describe('Offline snackbar', () => {
   test('does not appear when offline on non-project-specific screen', () => {
     useIsOfflineMock.mockReturnValue(true);
 
-    const screen = render(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectListScreen />
-        </Portal.Host>
-      </PaperProvider>,
-      {
-        route: 'BOTTOM_TABS',
-        initialState: testState,
-      },
-    );
+    const screen = render(createJSXWithSnackbar(<ProjectListScreen />), {
+      route: 'BOTTOM_TABS',
+      initialState: testState,
+    });
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
@@ -135,12 +126,7 @@ describe('Offline snackbar', () => {
     useIsOfflineMock.mockReturnValue(false);
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectViewScreen projectId="1" />
-        </Portal.Host>
-      </PaperProvider>,
+      createJSXWithSnackbar(<ProjectViewScreen projectId="1" />),
       {
         route: 'PROJECT_VIEW',
         initialState: testState,
@@ -148,14 +134,7 @@ describe('Offline snackbar', () => {
     );
 
     useIsOfflineMock.mockReset().mockReturnValue(true);
-    screen.rerender(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectViewScreen projectId="1" />
-        </Portal.Host>
-      </PaperProvider>,
-    );
+    screen.rerender(createJSXWithSnackbar(<ProjectViewScreen projectId="1" />));
 
     expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
   });
@@ -164,12 +143,7 @@ describe('Offline snackbar', () => {
     useIsOfflineMock.mockReturnValue(true);
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectViewScreen projectId="1" />
-        </Portal.Host>
-      </PaperProvider>,
+      createJSXWithSnackbar(<ProjectViewScreen projectId="1" />),
       {
         route: 'PROJECT_VIEW',
         initialState: testState,
@@ -179,14 +153,7 @@ describe('Offline snackbar', () => {
     expect(screen.queryByTestId(snackbarTestId)).toBeTruthy();
 
     useIsOfflineMock.mockReturnValue(false);
-    screen.rerender(
-      <PaperProvider>
-        <Portal.Host>
-          <OfflineSnackbar />
-          <ProjectViewScreen projectId="1" />
-        </Portal.Host>
-      </PaperProvider>,
-    );
+    screen.rerender(createJSXWithSnackbar(<ProjectViewScreen projectId="1" />));
 
     // FYI: Because the snackbar has an animation transition before hiding and returning null,
     // Need to run the jest timers, and  wrap it in act() to make sure resulting state updates
@@ -251,13 +218,12 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
     );
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
+      createJSXWithSnackbar(
+        <>
           <TestButton />
-          <OfflineSnackbar />
           <ProjectViewScreen projectId={projectId} />
-        </Portal.Host>
-      </PaperProvider>,
+        </>,
+      ),
       {route: 'PROJECT_VIEW', initialState: initialAppState},
     );
 
@@ -291,13 +257,12 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
     );
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
+      createJSXWithSnackbar(
+        <>
           <TestButton />
-          <OfflineSnackbar />
           <ProjectViewScreen projectId={projectId} />
-        </Portal.Host>
-      </PaperProvider>,
+        </>,
+      ),
       {route: 'PROJECT_VIEW', initialState: initialAppState},
     );
 
@@ -317,13 +282,12 @@ describe('Offline snackbar (with mocked async thunk call)', () => {
     );
 
     const screen = render(
-      <PaperProvider>
-        <Portal.Host>
+      createJSXWithSnackbar(
+        <>
           <TestButton />
-          <OfflineSnackbar />
           <ProjectViewScreen projectId={projectId} />
-        </Portal.Host>
-      </PaperProvider>,
+        </>,
+      ),
       {route: 'PROJECT_VIEW', initialState: initialAppState},
     );
 

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -53,14 +53,6 @@ jest.mock('terraso-mobile-client/hooks/connectivityHooks', () => {
   };
 });
 
-jest.mock('terraso-client-shared/terrasoApi/api', () => {
-  const actual = jest.requireActual('terraso-client-shared/terrasoApi/api');
-  return {
-    ...actual,
-    requestGraphQL: jest.fn(),
-  };
-});
-
 jest.mock('terraso-client-shared/project/projectService', () => {
   const actual = jest.requireActual(
     'terraso-client-shared/project/projectService',
@@ -73,15 +65,6 @@ jest.mock('terraso-client-shared/project/projectService', () => {
 
 describe('Offline snackbar', () => {
   const useIsOfflineMock = jest.mocked(connectivityHooks.useIsOffline);
-
-  // TODO-cknipe: Uhh maybe remove this? Or look at the debugger to find what to retun
-  // const requestGraphQLMock = jest.mocked(api.requestGraphQL);
-  // type GraphQLResponseType = ReturnType<typeof api.requestGraphQL>;
-  // const graphQLError = Promise.reject([
-  //   'terraso_api.error_unexpected',
-  // ]) as GraphQLResponseType;
-  // const graphQLSuccess = Promise.resolve() as GraphQLResponseType;
-
   const deleteProjectMock = jest.mocked(projectService.deleteProject);
 
   // TODO-cknipe: Use only one of these
@@ -90,7 +73,6 @@ describe('Offline snackbar', () => {
 
   beforeEach(() => {
     useIsOfflineMock.mockReset().mockReturnValue(false);
-    // requestGraphQLMock.mockReset();
     deleteProjectMock.mockReset();
   });
 

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -21,7 +21,7 @@ import 'terraso-mobile-client/config';
 import { Button } from 'react-native';
 import { PaperProvider, Portal } from 'react-native-paper';
 
-import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react-native';
+import { fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/react-native';
 import { testState } from '@testing/integration/data';
 import { render } from '@testing/integration/utils';
 
@@ -244,9 +244,10 @@ describe('Offline snackbar', () => {
   });
 
   // TODO-cknipe: Issues: 
-  // All the console.logs in OfflineSnackbar make sense, but the 
-  test('is shown when thunk fails offline', async () => {
-    console.log('------ TEST: shown when thunk fails offline ------');
+  // 1. I can't figure out a way to dismiss the snackbar (this may be the same issue as the previous test)
+  // 2. I suspect there may also be issues with the snackbar showing again
+  test('can be dismissed, and is shown when thunk fails offline', async () => {
+    console.log('------ TEST: dismiss + shown when thunk fails offline ------');
     // Mock being Offline
     useIsOfflineMock.mockReturnValue(true);
     deleteProjectMock.mockReturnValue(Promise.reject(['rejected']));
@@ -314,7 +315,7 @@ describe('Offline snackbar', () => {
     //             Shouldn't rerenders be automatically triggered?
     // Tried: calling rerender with the same components as the first render. This passed, but I think
     //        it was just because it created a new OfflineSnackbar with visible initialized to false
-    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
+    //expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
 
 
     // Fire the test button event to make a server request. The request is mocked to fail, 
@@ -323,9 +324,13 @@ describe('Offline snackbar', () => {
     console.log("4")
 
     // This passes if the failing expect is removed, but it may only be because we never actually
-    // remove the snackbar, so it's still on the screen from the first render
-    expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
-  });
+    // remove the snackbar, so it's still on the screen from the first render? 
+    // But also the last console.log reports the snackbar with visible=false, so I'm 
+    // just confused
+    await waitFor(() => {
+      expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
+    });  
+});
 
   // test('is not shown when thunk fails online', () => {});
   // test('is not shown when thunk succeeds online', () => {});

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -332,7 +332,48 @@ describe('Offline snackbar (with mocked backend call)', () => {
     expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
   });
 
-  // test('is not shown when thunk fails online', async () => {});
+  test('is not shown when thunk fails online', async () => {
+    useIsOfflineMock.mockReturnValue(false);
+
+    const projectId = '1';
+    const initialState = makeAppStateWithProject(projectId);
+
+    deleteProjectMock.mockImplementation(async () =>
+      Promise.reject(['rejected']),
+    );
+    const TestButton = () => {
+      const dispatch = useDispatch();
+      return (
+        <Button
+          title="dispatch"
+          testID="test-delete-project-btn"
+          onPress={() => {
+            dispatch(deleteProject({id: projectId}));
+          }}
+        />
+      );
+    };
+
+    const screen = render(
+      <PaperProvider>
+        <Portal.Host>
+          <TestButton />
+          <OfflineSnackbar />
+          <ProjectViewScreen projectId={projectId} />
+        </Portal.Host>
+      </PaperProvider>,
+      {route: 'PROJECT_VIEW', initialState},
+    );
+
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
+
+    await act(async () => {
+      fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
+    });
+
+    expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
+  });
+
   // test('is not shown when thunk succeeds online', async () => {});
   // test('is not shown when thunk succeeds offline', async () => {});
 });

--- a/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
+++ b/dev-client/__tests__/integration/OfflineSnackbar.test.tsx
@@ -269,65 +269,21 @@ describe('Offline snackbar (with mocked backend call)', () => {
     expect(snackbar).toBeOnTheScreen();
 
     // Dismiss snackbar
-    // TODO-cknipe: Should we be using userEvent instead?
-
-    // A: Option 1 - Good, test passes
-    // fireEvent(snackbar, 'onDismiss');
-    // act(() => {
-    //   jest.runAllTimers();
-    // });
-
-    // A: Option 2 - Good, test passes
-    // fireEvent(snackbar, 'onDismiss');
-    // await act(async () => {
-    //   jest.runAllTimers();
-    // });
-
-    // A: Option 3 - Bad, test fails with snackbar still found on the screen
-    // await act(async () => {
-    //   fireEvent(snackbar, 'onDismiss');
-    //   jest.runAllTimers();
-    // });
-
-    // A: Option 4 - Good, test passes
+    // FYI: run timers so snackbar's dismissal animation completes
     await act(async () => {
       fireEvent(snackbar, 'onDismiss');
     });
     await act(async () => {
-      // Need snackbar's dismissal animation to complete
       jest.runAllTimers();
     });
-
-    // A: Option 5 - Bad, test fails with snackbar still found on the screen
-    // await act(async () => {
-    //   fireEvent(snackbar, 'onDismiss');
-    //   await jest.runAllTimersAsync();
-    // });
 
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
 
     // Fire the test button event to make a server request. The request is mocked to fail,
     // which should add a message to the notificationsSlice and trigger the snackbar.
-
-    // B: Option 1 - Bad, test fails with snackbar not on the screen
-    // fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
-    // act(() => {
-    //   jest.runAllTimers();
-    // });
-
-    // B: Option 2 - Good, test passes
-    // fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
-    // await act(async () => {
-    //   jest.runAllTimers();
-    // });
-
-    // B: Option 3 - Good, test passes
     await act(async () => {
       fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
     });
-
-    // B: Option 4 - Bad, test fails with snackbar not on the screen
-    // fireEvent.press(screen.queryByTestId('test-delete-project-btn'));
 
     expect(screen.queryByTestId(snackbarTestId)).toBeOnTheScreen();
   });
@@ -374,6 +330,7 @@ describe('Offline snackbar (with mocked backend call)', () => {
     expect(screen.queryByTestId(snackbarTestId)).not.toBeOnTheScreen();
   });
 
+  test('is not shown when thunk succeeds offline', async () => {});
+
   // test('is not shown when thunk succeeds online', async () => {});
-  // test('is not shown when thunk succeeds offline', async () => {});
 });

--- a/dev-client/__tests__/integration/depthIntervalHelpers.test.ts
+++ b/dev-client/__tests__/integration/depthIntervalHelpers.test.ts
@@ -16,159 +16,160 @@
  */
 
 import {
-    createProjectSettings, generateProject,
-    generateSite
+  createProjectSettings,
+  generateProject,
+  generateSite,
 } from '@testing/integration/modelUtils';
 
-import { SoilData } from 'terraso-mobile-client/model/soilData/soilDataSlice';
-import { getVisibleDepthIntervals } from 'terraso-mobile-client/store/depthIntervalHelpers';
+import {SoilData} from 'terraso-mobile-client/model/soilData/soilDataSlice';
+import {getVisibleDepthIntervals} from 'terraso-mobile-client/store/depthIntervalHelpers';
 
 describe('getVisibleDepthIntervals', () => {
-    test('should return custom site intervals', () => {
-      const site = generateSite();
-      const siteDepthIntervals = [
-        {depthInterval: {start: 1, end: 2}, label: 'first'},
-        {depthInterval: {start: 3, end: 4}, label: 'second'},
-      ];
-  
-      const siteSoilData = {
-        depthIntervals: siteDepthIntervals,
-        depthDependentData: [],
-        depthIntervalPreset: 'CUSTOM',
-      } as SoilData;
-  
-      const result = getVisibleDepthIntervals(
-        site.id,
-        {[site.id]: site},
-        {[site.id]: siteSoilData},
-        {},
-      );
-  
-      expect(result).toHaveLength(2);
-      expect(result[0].interval.depthInterval.start).toEqual(1);
-      expect(result[0].interval.depthInterval.end).toEqual(2);
-      expect(result[1].interval.depthInterval.start).toEqual(3);
-      expect(result[1].interval.depthInterval.end).toEqual(4);
-    });
-  
-    test('should return preset site intervals', () => {
-      const site = generateSite();
-  
-      const siteSoilData = {
-        depthIntervals: [],
-        depthDependentData: [],
-        depthIntervalPreset: 'NRCS',
-      } as SoilData;
-  
-      const result = getVisibleDepthIntervals(
-        site.id,
-        {[site.id]: site},
-        {[site.id]: siteSoilData},
-        {},
-      );
-  
-      expect(result).toHaveLength(6);
-      expect(result[0].interval.depthInterval.start).toEqual(0);
-      expect(result[0].interval.depthInterval.end).toEqual(5);
-      expect(result[1].interval.depthInterval.start).toEqual(5);
-      expect(result[1].interval.depthInterval.end).toEqual(15);
-    });
-  
-    test('should return custom project intervals', () => {
-      const project = generateProject();
-      const site = generateSite({project: project});
-  
-      const projectDepthIntervals = [
-        {depthInterval: {start: 1, end: 2}, label: 'first'},
-        {depthInterval: {start: 5, end: 6}, label: 'second'},
-      ];
-  
-      const projectSettings = createProjectSettings(project, {
-        depthIntervals: projectDepthIntervals,
-        depthIntervalPreset: 'CUSTOM',
-      });
-  
-      const siteSoilData = {
-        depthIntervals: [],
-        depthDependentData: [],
-        depthIntervalPreset: 'CUSTOM',
-      } as SoilData;
-  
-      const result = getVisibleDepthIntervals(
-        site.id,
-        {[site.id]: site},
-        {[site.id]: siteSoilData},
-        projectSettings,
-      );
-  
-      expect(result).toHaveLength(2);
-      expect(result[0].interval.depthInterval.start).toEqual(1);
-      expect(result[0].interval.depthInterval.end).toEqual(2);
-      expect(result[1].interval.depthInterval.start).toEqual(5);
-      expect(result[1].interval.depthInterval.end).toEqual(6);
-    });
-  
-    test('should return preset project intervals', () => {
-      const project = generateProject();
-      const site = generateSite({project: project});
-  
-      const projectSettings = createProjectSettings(project, {
-        depthIntervals: [],
-        depthIntervalPreset: 'NRCS',
-      });
-  
-      const siteSoilData = {
-        depthIntervals: [],
-        depthDependentData: [],
-        // FYI sites in projects may have an inaccurate preset
-        depthIntervalPreset: 'CUSTOM',
-      } as SoilData;
-  
-      const result = getVisibleDepthIntervals(
-        site.id,
-        {[site.id]: site},
-        {[site.id]: siteSoilData},
-        projectSettings,
-      );
-  
-      expect(result).toHaveLength(6);
-      expect(result[0].interval.depthInterval.start).toEqual(0);
-      expect(result[0].interval.depthInterval.end).toEqual(5);
-      expect(result[1].interval.depthInterval.start).toEqual(5);
-      expect(result[1].interval.depthInterval.end).toEqual(15);
-    });
-  
-    test('should return project + additional site intervals', () => {
-      const project = generateProject();
-      const site = generateSite({project: project});
-      const projectDepthIntervals = [
-        {depthInterval: {start: 1, end: 2}, label: 'first'},
-      ];
-      const projectSettings = createProjectSettings(project, {
-        depthIntervals: projectDepthIntervals,
-        depthIntervalPreset: 'CUSTOM',
-      });
-  
-      const siteDepthIntervals = [{depthInterval: {start: 3, end: 4}, label: ''}];
-  
-      const siteSoilData = {
-        depthIntervals: siteDepthIntervals,
-        depthDependentData: [],
-        // FYI sites in projects may have an inaccurate preset
-        depthIntervalPreset: 'NRCS',
-      } as SoilData;
-  
-      const result = getVisibleDepthIntervals(
-        site.id,
-        {[site.id]: site},
-        {[site.id]: siteSoilData},
-        projectSettings,
-      );
-  
-      expect(result).toHaveLength(2);
-      expect(result[0].interval.depthInterval.start).toEqual(1);
-      expect(result[0].interval.depthInterval.end).toEqual(2);
-      expect(result[1].interval.depthInterval.start).toEqual(3);
-      expect(result[1].interval.depthInterval.end).toEqual(4);
-    });
+  test('should return custom site intervals', () => {
+    const site = generateSite();
+    const siteDepthIntervals = [
+      {depthInterval: {start: 1, end: 2}, label: 'first'},
+      {depthInterval: {start: 3, end: 4}, label: 'second'},
+    ];
+
+    const siteSoilData = {
+      depthIntervals: siteDepthIntervals,
+      depthDependentData: [],
+      depthIntervalPreset: 'CUSTOM',
+    } as SoilData;
+
+    const result = getVisibleDepthIntervals(
+      site.id,
+      {[site.id]: site},
+      {[site.id]: siteSoilData},
+      {},
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].interval.depthInterval.start).toEqual(1);
+    expect(result[0].interval.depthInterval.end).toEqual(2);
+    expect(result[1].interval.depthInterval.start).toEqual(3);
+    expect(result[1].interval.depthInterval.end).toEqual(4);
   });
+
+  test('should return preset site intervals', () => {
+    const site = generateSite();
+
+    const siteSoilData = {
+      depthIntervals: [],
+      depthDependentData: [],
+      depthIntervalPreset: 'NRCS',
+    } as SoilData;
+
+    const result = getVisibleDepthIntervals(
+      site.id,
+      {[site.id]: site},
+      {[site.id]: siteSoilData},
+      {},
+    );
+
+    expect(result).toHaveLength(6);
+    expect(result[0].interval.depthInterval.start).toEqual(0);
+    expect(result[0].interval.depthInterval.end).toEqual(5);
+    expect(result[1].interval.depthInterval.start).toEqual(5);
+    expect(result[1].interval.depthInterval.end).toEqual(15);
+  });
+
+  test('should return custom project intervals', () => {
+    const project = generateProject();
+    const site = generateSite({project: project});
+
+    const projectDepthIntervals = [
+      {depthInterval: {start: 1, end: 2}, label: 'first'},
+      {depthInterval: {start: 5, end: 6}, label: 'second'},
+    ];
+
+    const projectSettings = createProjectSettings(project, {
+      depthIntervals: projectDepthIntervals,
+      depthIntervalPreset: 'CUSTOM',
+    });
+
+    const siteSoilData = {
+      depthIntervals: [],
+      depthDependentData: [],
+      depthIntervalPreset: 'CUSTOM',
+    } as SoilData;
+
+    const result = getVisibleDepthIntervals(
+      site.id,
+      {[site.id]: site},
+      {[site.id]: siteSoilData},
+      projectSettings,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].interval.depthInterval.start).toEqual(1);
+    expect(result[0].interval.depthInterval.end).toEqual(2);
+    expect(result[1].interval.depthInterval.start).toEqual(5);
+    expect(result[1].interval.depthInterval.end).toEqual(6);
+  });
+
+  test('should return preset project intervals', () => {
+    const project = generateProject();
+    const site = generateSite({project: project});
+
+    const projectSettings = createProjectSettings(project, {
+      depthIntervals: [],
+      depthIntervalPreset: 'NRCS',
+    });
+
+    const siteSoilData = {
+      depthIntervals: [],
+      depthDependentData: [],
+      // FYI sites in projects may have an inaccurate preset
+      depthIntervalPreset: 'CUSTOM',
+    } as SoilData;
+
+    const result = getVisibleDepthIntervals(
+      site.id,
+      {[site.id]: site},
+      {[site.id]: siteSoilData},
+      projectSettings,
+    );
+
+    expect(result).toHaveLength(6);
+    expect(result[0].interval.depthInterval.start).toEqual(0);
+    expect(result[0].interval.depthInterval.end).toEqual(5);
+    expect(result[1].interval.depthInterval.start).toEqual(5);
+    expect(result[1].interval.depthInterval.end).toEqual(15);
+  });
+
+  test('should return project + additional site intervals', () => {
+    const project = generateProject();
+    const site = generateSite({project: project});
+    const projectDepthIntervals = [
+      {depthInterval: {start: 1, end: 2}, label: 'first'},
+    ];
+    const projectSettings = createProjectSettings(project, {
+      depthIntervals: projectDepthIntervals,
+      depthIntervalPreset: 'CUSTOM',
+    });
+
+    const siteDepthIntervals = [{depthInterval: {start: 3, end: 4}, label: ''}];
+
+    const siteSoilData = {
+      depthIntervals: siteDepthIntervals,
+      depthDependentData: [],
+      // FYI sites in projects may have an inaccurate preset
+      depthIntervalPreset: 'NRCS',
+    } as SoilData;
+
+    const result = getVisibleDepthIntervals(
+      site.id,
+      {[site.id]: site},
+      {[site.id]: siteSoilData},
+      projectSettings,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].interval.depthInterval.start).toEqual(1);
+    expect(result[0].interval.depthInterval.end).toEqual(2);
+    expect(result[1].interval.depthInterval.start).toEqual(3);
+    expect(result[1].interval.depthInterval.end).toEqual(4);
+  });
+});

--- a/dev-client/jest/integration/setup.ts
+++ b/dev-client/jest/integration/setup.ts
@@ -39,6 +39,8 @@ jest.mock('react-native-reanimated', () => {
 });
 jest.useFakeTimers();
 jest.mock('react-native/src/private/animated/NativeAnimatedHelper');
+jest.mock('expo-font');
+jest.mock('expo-asset');
 
 // nanoid is a randomness source used by react navigation, here we are
 // setting it to a stable value to get stable snapshot tests

--- a/dev-client/jest/integration/setup.ts
+++ b/dev-client/jest/integration/setup.ts
@@ -39,8 +39,6 @@ jest.mock('react-native-reanimated', () => {
 });
 jest.useFakeTimers();
 jest.mock('react-native/src/private/animated/NativeAnimatedHelper');
-jest.mock('expo-font');
-jest.mock('expo-asset');
 
 // nanoid is a randomness source used by react navigation, here we are
 // setting it to a stable value to get stable snapshot tests
@@ -52,6 +50,8 @@ jest.mock('@gorhom/bottom-sheet', () => ({
   __esModule: true,
   ...require('@gorhom/bottom-sheet/mock'),
 }));
+
+jest.mock('expo-asset');
 
 jest.mock('@expo/vector-icons/MaterialIcons', () => 'Icon');
 
@@ -65,6 +65,7 @@ jest.mock('expo-font', () => {
 
   return module;
 });
+
 
 jest.mock('terraso-mobile-client/config', () => ({
   APP_CONFIG: {},

--- a/dev-client/src/components/messages/OfflineSnackbar.tsx
+++ b/dev-client/src/components/messages/OfflineSnackbar.tsx
@@ -42,9 +42,7 @@ export const OfflineSnackbar = () => {
   // Only supports 1 snackbar at a time; will not queue up snackbars
   const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
 
-  const onDismiss = () => {
-    setShowSnackbar(false);
-  };
+  const onDismiss = () => setShowSnackbar(false);
 
   useEffect(() => {
     // Get error messages

--- a/dev-client/src/components/messages/OfflineSnackbar.tsx
+++ b/dev-client/src/components/messages/OfflineSnackbar.tsx
@@ -41,7 +41,12 @@ export const OfflineSnackbar = () => {
 
   // Only supports 1 snackbar at a time; will not queue up snackbars
   const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
-  const onDismiss = () => setShowSnackbar(false);
+  console.log('Snackbar showing? ', showSnackbar);
+
+  const onDismiss = () => {
+    console.log('dismiss snackbar');
+    setShowSnackbar(false);
+  };
 
   useEffect(() => {
     // Get error messages
@@ -55,13 +60,16 @@ export const OfflineSnackbar = () => {
     );
 
     if (isOffline && errorMessages.length > 0) {
+      console.log('Show snackbar because error message happened offline');
       setShowSnackbar(true);
     }
     if (!isOffline) {
+      console.log('not offline, so snackbar should not be showing');
       setShowSnackbar(false);
     }
 
     errorMessages.forEach(messageKey => {
+      console.log('Removing message:', messages[messageKey]);
       dispatch(removeMessage(messageKey));
     });
   }, [messages, isOffline, dispatch, t]);
@@ -72,7 +80,8 @@ export const OfflineSnackbar = () => {
         visible={showSnackbar}
         onDismiss={onDismiss}
         onIconPress={onDismiss}
-        duration={Infinity}>
+        duration={Infinity}
+        testID="offline-snackbar">
         {t('projects.offline_cant_edit')}
       </Snackbar>
     </Portal>

--- a/dev-client/src/components/messages/OfflineSnackbar.tsx
+++ b/dev-client/src/components/messages/OfflineSnackbar.tsx
@@ -41,10 +41,8 @@ export const OfflineSnackbar = () => {
 
   // Only supports 1 snackbar at a time; will not queue up snackbars
   const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
-  console.log('Snackbar showing? ', showSnackbar);
 
   const onDismiss = () => {
-    console.log('dismiss snackbar');
     setShowSnackbar(false);
   };
 
@@ -60,16 +58,13 @@ export const OfflineSnackbar = () => {
     );
 
     if (isOffline && errorMessages.length > 0) {
-      console.log('Show snackbar because error message happened offline');
       setShowSnackbar(true);
     }
     if (!isOffline) {
-      console.log('not offline, so snackbar should not be showing');
       setShowSnackbar(false);
     }
 
     errorMessages.forEach(messageKey => {
-      console.log('Removing message:', messages[messageKey]);
       dispatch(removeMessage(messageKey));
     });
   }, [messages, isOffline, dispatch, t]);


### PR DESCRIPTION
## Description
Write tests for when the OfflineSnackbar component appears and disappears.

Also, allow files in `__tests__` and `__mocks__` to be affected by prettier

Thanks to @wseveraldojunior for the tips for getting this to work!

### Related Issues
Addresses [#1233](https://github.com/techmatters/terraso-product/issues/1233)

