### PR TITLE
fix: test non-determinism

### DIFF
--- a/dev-client/src/model/sync/records.test.ts
+++ b/dev-client/src/model/sync/records.test.ts
@@ -454,12 +454,7 @@ describe('record', () => {
 
     test('records error state', () => {
       const at = Date.now();
-      markEntityError(
-        records,
-        'a',
-        {value: 'error', revisionId: 123},
-        Date.now(),
-      );
+      markEntityError(records, 'a', {value: 'error', revisionId: 123}, at);
       expect(records.a.lastSyncedError).toEqual('error');
       expect(records.a.lastSyncedRevisionId).toEqual(123);
       expect(records.a.lastSyncedAt).toEqual(at);


### PR DESCRIPTION
## Description
Same issue as https://github.com/techmatters/terraso-mobile-client/pull/2862, here is the new failing run: https://github.com/techmatters/terraso-mobile-client/actions/runs/13533135909/attempts/1?pr=2913. I looked over the file more carefully this time to make sure there aren't any others skulking around.

### Verification steps
Tests should pass (can't really verify because there's no reliable way to trigger it).
