### PR TITLE
fix: update husky scripts for v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -24,7 +24,7 @@
     "localization-to-po": "node scripts/localization/transform-to.mjs po",
     "localization-to-json": "node scripts/localization/transform-to.mjs json",
     "localization-check-missing": "node scripts/localization/missing-check.mjs",
-    "prepare": "cd .. && husky install"
+    "prepare": "cd .. && husky"
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",


### PR DESCRIPTION
## Description
update husky scripts for v9.

See "how to migrate" on https://github.com/typicode/husky/releases/tag/v9.0.1