### PR TITLE
fix: update macos to 15 and xcode to 16.2

### DIFF
--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -4,15 +4,15 @@ on:
       STRICT:
         required: false
         type: string
-        default: 'true'
+        default: "true"
       upload:
         required: false
         type: string
-        default: 'false'
+        default: "false"
       APP_BUILD:
         required: false
         type: string
-        default: 'v1'
+        default: "v1"
     secrets:
       MAPBOX_DOWNLOADS_TOKEN:
         required: true
@@ -38,7 +38,7 @@ on:
 jobs:
   ios-build:
     name: iOS Build
-    runs-on: macos-14
+    runs-on: macos-15
     environment: ${{ ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'beta')) && 'production') || (startsWith(github.ref, 'refs/tags/v') && 'staging') }}
     env:
       STRICT: ${{ inputs.STRICT }}
@@ -70,8 +70,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.tool-versions'
-          cache: 'npm'
+          node-version-file: ".tool-versions"
+          cache: "npm"
           cache-dependency-path: dev-client/package-lock.json
 
       - name: Install Node dependencies
@@ -91,7 +91,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '^15.4'
+          xcode-version: "^16.2"
 
       - name: Build iOS App
         uses: yukiarrr/ios-build-action@v1.12.0
@@ -99,7 +99,7 @@ jobs:
           project-path: dev-client/ios/LandPKSSoilID.xcodeproj
           p12-base64: ${{ secrets.APPLE_P12_BASE64 }}
           mobileprovision-base64: ${{ secrets.APPLE_MOBILE_PROVISION_BASE64 }}
-          code-signing-identity: 'iPhone Distribution'
+          code-signing-identity: "iPhone Distribution"
           team-id: ${{ vars.APPLE_TEAM_ID }}
           certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           workspace-path: dev-client/ios/LandPKSSoilID.xcworkspace
@@ -109,7 +109,7 @@ jobs:
         uses: apple-actions/upload-testflight-build@v1
         if: ${{ inputs.upload == 'true' }}
         with:
-          app-path: 'output.ipa'
+          app-path: "output.ipa"
           issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPLE_KEY_ID }}
           api-private-key: ${{ secrets.APPLE_APP_STORE_CONNECT_PRIVATE_KEY }}


### PR DESCRIPTION
## Description
update macos to 15 and xcode to 16.2

Should fix:
>ITMS-90725: SDK version issue - This app was built with the iOS 17.5 SDK. Starting April 24, 2025, all iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution.
