### PR TITLE
fix: Fix the iOS build workflow xcode version to 16.2

### DIFF
--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "^16.2"
+          xcode-version: "16.2"
 
       - name: Build iOS App
         uses: yukiarrr/ios-build-action@v1.12.0


### PR DESCRIPTION
## Description
The iOS build is broken on main. Will this fix it? Let's see... (Update: yes!)

### Related Issues
Addresses #2940

Filed https://github.com/techmatters/terraso-mobile-client/issues/2943 to follow up in a couple months to see if we can change it back to using the latest Xcode version

### Verification steps
If the build associated with this PR succeeds, that's a very positive sign
