### PR TITLE
fix: revert Xcode 16.2 hard-coding

### DIFF
--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: "^16.2"
 
       - name: Build iOS App
         uses: yukiarrr/ios-build-action@v1.12.0


### PR DESCRIPTION
## Description
revert Xcode 16.2 hard-coding now that we can build cleanly with 16.3.