### PR TITLE
fix: Try to bump uuid to version 11.1.0

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,9 +62,9 @@
         "react-native-svg": "^15.11.2",
         "react-native-tab-view": "^4.0.12",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#a4df832",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#9c6941f",
         "use-debounce": "^10.0.4",
-        "uuid": "^10.0.0",
+        "uuid": "^11.1.0",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -86,7 +86,6 @@
         "@types/lodash": "^4.17.16",
         "@types/quantize": "^1.0.2",
         "@types/react": "^18.3.12",
-        "@types/uuid": "^10.0.0",
         "babel-jest": "^29.7.0",
         "babel-plugin-root-import": "^6.6.0",
         "depcheck": "^1.4.7",
@@ -9099,11 +9098,6 @@
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -24674,15 +24668,15 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#a4df832353e467fe32a3e56452e48cf796d0871e",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#9c6941fd0adaa40227c663edb3445018eb0ce682",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#fac222b",
-        "uuid": "^10.0.0"
+        "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
+        "uuid": "^11.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -25454,14 +25448,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,9 +81,9 @@
     "react-native-svg": "^15.11.2",
     "react-native-tab-view": "^4.0.12",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#a4df832",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#9c6941f",
     "use-debounce": "^10.0.4",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.0",
     "yup": "^1.6.1"
   },
   "devDependencies": {
@@ -105,7 +105,6 @@
     "@types/lodash": "^4.17.16",
     "@types/quantize": "^1.0.2",
     "@types/react": "^18.3.12",
-    "@types/uuid": "^10.0.0",
     "babel-jest": "^29.7.0",
     "babel-plugin-root-import": "^6.6.0",
     "depcheck": "^1.4.7",


### PR DESCRIPTION
## Description
Following the note about uuid@11 at https://www.npmjs.com/package/uuid 
If this works, switch client-shared back to 11.1.0

### Related Issues
N/A but we were running into it when trying to bump the client-shared hash in [PR 2939](https://github.com/techmatters/terraso-mobile-client/pull/2939).

### Verification steps
- Confirm test workflow run passes
