### PR TITLE
Revert "build: update @rnmapbox/maps to 10.1.38 (#2959)"

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/material-top-tabs": "^7.1.0",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.2.0",
-        "@rnmapbox/maps": "^10.1.38",
+        "@rnmapbox/maps": "^10.1.33",
         "@sentry/core": "^8.55.0",
         "@sentry/react-native": "^6.13.1",
         "base-64": "^1.0.0",
@@ -7636,9 +7636,7 @@
       }
     },
     "node_modules/@rnmapbox/maps": {
-      "version": "10.1.38",
-      "resolved": "https://registry.npmjs.org/@rnmapbox/maps/-/maps-10.1.38.tgz",
-      "integrity": "sha512-TMKaVwh5C5Z+nqUx87mZlDfPB1zmsdJqU6jAjmM8OrZWpuxpaBo3r0AgijmLEhoXIcJ2ptREk/RRcVnNgwNxgQ==",
+      "version": "10.1.33",
       "license": "MIT",
       "dependencies": {
         "@turf/along": "6.5.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -36,7 +36,7 @@
     "@react-navigation/material-top-tabs": "^7.1.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
-    "@rnmapbox/maps": "^10.1.38",
+    "@rnmapbox/maps": "^10.1.33",
     "@sentry/core": "^8.55.0",
     "@sentry/react-native": "^6.13.1",
     "base-64": "^1.0.0",


### PR DESCRIPTION
## Description
This reverts commit 7d233f32ffe365db9d4ace0109bbce3b49f577a1 and keeps the dependency on 10.1.33, because after bumping @rnmapbox/maps to 10.1.38, the app would crash on Android with
“Warning: TypeError: MapboxGLLocationManager.onLocationUpdate is not a function (it is undefined)”

I believe this is related to https://github.com/rnmapbox/maps/issues/3796 


### Verification steps
Open app, make sure does not crash on Android or iOS