### PR TITLE
fix: bump terraso-client-shared commit hash without bumping uuid version

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,7 +62,7 @@
         "react-native-svg": "^15.11.2",
         "react-native-tab-view": "^4.0.12",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#a4df832",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#75bef62",
         "use-debounce": "^10.0.4",
         "uuid": "^10.0.0",
         "yup": "^1.6.1"
@@ -24670,18 +24670,18 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#fac222bd10eeac0176a2040e9b09449e84d0a693"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#43c94f46514501d8d4ed853b0d11e00f74418411"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#a4df832353e467fe32a3e56452e48cf796d0871e",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#75bef62e8479ffd9526a0a9c624b96543425f397",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#fac222b",
+        "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,9 +62,9 @@
         "react-native-svg": "^15.11.2",
         "react-native-tab-view": "^4.0.12",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#acd2844",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#a4df832",
         "use-debounce": "^10.0.4",
-        "uuid": "^11.1.0",
+        "uuid": "^10.0.0",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -86,6 +86,7 @@
         "@types/lodash": "^4.17.16",
         "@types/quantize": "^1.0.2",
         "@types/react": "^18.3.12",
+        "@types/uuid": "^10.0.0",
         "babel-jest": "^29.7.0",
         "babel-plugin-root-import": "^6.6.0",
         "depcheck": "^1.4.7",
@@ -9098,6 +9099,11 @@
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -24664,19 +24670,19 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#43c94f46514501d8d4ed853b0d11e00f74418411"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#fac222bd10eeac0176a2040e9b09449e84d0a693"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#acd2844ab0d4a2de129b9b71031cb0c84983cd2d",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#a4df832353e467fe32a3e56452e48cf796d0871e",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
-        "uuid": "^11.1.0"
+        "terraso-backend": "github:techmatters/terraso-backend#fac222b",
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -25448,16 +25454,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "10.0.0",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,7 +81,7 @@
     "react-native-svg": "^15.11.2",
     "react-native-tab-view": "^4.0.12",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#a4df832",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#75bef62",
     "use-debounce": "^10.0.4",
     "uuid": "^10.0.0",
     "yup": "^1.6.1"

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,9 +81,9 @@
     "react-native-svg": "^15.11.2",
     "react-native-tab-view": "^4.0.12",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#acd2844",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#a4df832",
     "use-debounce": "^10.0.4",
-    "uuid": "^11.1.0",
+    "uuid": "^10.0.0",
     "yup": "^1.6.1"
   },
   "devDependencies": {
@@ -105,6 +105,7 @@
     "@types/lodash": "^4.17.16",
     "@types/quantize": "^1.0.2",
     "@types/react": "^18.3.12",
+    "@types/uuid": "^10.0.0",
     "babel-jest": "^29.7.0",
     "babel-plugin-root-import": "^6.6.0",
     "depcheck": "^1.4.7",


### PR DESCRIPTION
## Description
Alas! I thought it was ok to bump the uuid package version from 10 to 11, but it seems it causes the app to crash. So, sadly, taking client-shared back to a commit hash that uses uuid 10.0.0, and use uuid 10.0.0 in mobile-client as well.

Opening https://github.com/techmatters/terraso-mobile-client/issues/2968 to follow up on this.


### Related Issues
A tangential follow-up to a change for https://github.com/techmatters/terraso-backend/issues/1618 

### Verification steps
- App does not crash after login
- Tests pass
