### PR TITLE
fix: Remove the caret to precisely fix @rnmapbox/maps version

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/material-top-tabs": "^7.1.0",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.2.0",
-        "@rnmapbox/maps": "^10.1.33",
+        "@rnmapbox/maps": "10.1.33",
         "@sentry/core": "^8.55.0",
         "@sentry/react-native": "^6.13.1",
         "base-64": "^1.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -36,7 +36,7 @@
     "@react-navigation/material-top-tabs": "^7.1.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
-    "@rnmapbox/maps": "^10.1.33",
+    "@rnmapbox/maps": "10.1.33",
     "@sentry/core": "^8.55.0",
     "@sentry/react-native": "^6.13.1",
     "base-64": "^1.0.0",


### PR DESCRIPTION
## Description
Follow-on to https://github.com/techmatters/terraso-mobile-client/pull/2966 because some @rnmapbox/maps version between 10.1.34 and 10.1.38 would cause a crash.
TODO: Do we need a task to try to update it in a couple months? Will dependabot do it automatically, or does fixing it to an exact version prevent dependabot from trying?