### PR TITLE
fix: check-ts should run on pre-commit

### DIFF
--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -148,7 +148,7 @@
   ],
   "lint-staged": {
     "dev-client/**/*.{ts,tsx}": [
-      "sh -c 'cd dev-client && npm run eslint'"
+      "sh -c 'cd dev-client && npm run eslint && npm run check-ts'"
     ],
     "dev-client/**/*.{json,ts,tsx,html}": [
       "sh -c 'cd dev-client && npm run prettier'"


### PR DESCRIPTION
## Description
When we had changed the pre-commit to use husky, we didn't carry over the check-ts step. Add it back.


### Verification steps
- Introduce a typescript problem in the code (like misspelling a variable)
- Try to commit it 
- It should fail on the lint-staged 
