### PR TITLE
fix: Only hide SiteSlopeDataSection when dataRegion is global

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilId/SiteDataSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SiteDataSection.tsx
@@ -37,7 +37,7 @@ export const SiteDataSection = ({siteId}: Props) => {
   return (
     <ScreenContentSection title={t('site.soil_id.site_data.title')}>
       <Text variant="body1">{t('site.soil_id.site_data.description')}</Text>
-      {dataRegion === 'US' && <SiteSlopeDataSection siteId={siteId} />}
+      {dataRegion !== 'GLOBAL' && <SiteSlopeDataSection siteId={siteId} />}
       <SiteSoilCracksSection siteId={siteId} />
       <SiteSoilPropertiesDataSection siteId={siteId} />
     </ScreenContentSection>


### PR DESCRIPTION
## Description
Still show the section for slope when you have a site where the region is unknown

![image](https://github.com/user-attachments/assets/b06b4983-aa03-421d-ac48-eecb091de270)


### Related Issues
Addresses Derek's comment on https://github.com/techmatters/terraso-mobile-client/issues/2927

### Verification steps
Make a site and while it's still figuring out Soil ID, quickly go to the "explore the data" button and see if the slope data section exists