### PR TITLE
fix: Remove elevation if unknown and outside the US

### DIFF
--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -38,6 +38,7 @@ import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {StaticMapView} from 'terraso-mobile-client/components/StaticMapView';
 import {renderElevation} from 'terraso-mobile-client/components/util/site';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
+import {useSoilIdOutput} from 'terraso-mobile-client/hooks/soilIdHooks';
 import {updateSite} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {LocationSoilIdCard} from 'terraso-mobile-client/screens/LocationScreens/components/LocationSoilIdCard';
@@ -71,6 +72,10 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigation = useNavigation();
+  const soilIdOutput = useSoilIdOutput(
+    site?.id ? {siteId: site.id} : {coords: coords},
+  );
+  const dataRegion = soilIdOutput.dataRegion;
 
   const project = useSelector(state =>
     site?.projectId === undefined
@@ -109,10 +114,13 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
           label={t('geo.longitude.title')}
           value={formatCoordinate(coords?.longitude)}
         />
-        <LocationDetail
-          label={t('geo.elevation.title')}
-          value={renderElevation(t, elevation)}
-        />
+        {(elevation || dataRegion === 'US') && (
+          // TODO: Remove the conditional once mobile-client bug 2664 is done
+          <LocationDetail
+            label={t('geo.elevation.title')}
+            value={renderElevation(t, elevation)}
+          />
+        )}
         {!site && (
           <Box>
             <Box paddingVertical="20px" alignItems="center">

--- a/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
@@ -110,12 +110,17 @@ export const TemporaryLocationCallout = ({
               />
             </>
           )}
-          <Divider />
         </>
-        <CalloutDetail
-          label={t('site.elevation_label')}
-          value={<ElevationDisplay elevation={elevation} t={t} />}
-        />
+        {(elevation.value || soilIdOutput.dataRegion === 'US') && (
+          // TODO: Remove the conditional once mobile-client bug 2664 is done
+          <>
+            <Divider />
+            <CalloutDetail
+              label={t('site.elevation_label')}
+              value={<ElevationDisplay elevation={elevation} t={t} />}
+            />
+          </>
+        )}
         <Divider />
         <Row justifyContent="flex-end">
           <CreateSiteButton


### PR DESCRIPTION
## Description
Don't display elevation on map popover or location dashboard, if unknown and outside the US

### Related Issues
Addresses https://github.com/techmatters/terraso-product/issues/1308 
And should be undone with https://github.com/techmatters/terraso-mobile-client/issues/2664

[Here's a video of what it looks like now](https://tech-matters.slack.com/archives/C0376RCCXD2/p1751996709665269?thread_ts=1751996041.572489&cid=C0376RCCXD2)