### PR TITLE
refactor: Rename 'DataBasedSoilMatch' type to 'SoilMatch'

### DIFF
--- a/dev-client/__tests__/integration/hooks/soilIdHooks.test.tsx
+++ b/dev-client/__tests__/integration/hooks/soilIdHooks.test.tsx
@@ -17,7 +17,7 @@
 
 import {renderHook} from '@testing-library/react-native';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import * as SoilIdMatchContext from 'terraso-mobile-client/context/SoilIdMatchContext';
 import {
@@ -45,7 +45,7 @@ const renderSoilIdHook = (input: SoilIdLocationInput) => {
   });
 };
 
-const dataBasedMatchWithName = (name: string): DataBasedSoilMatch => {
+const dataBasedMatchWithName = (name: string): SoilMatch => {
   return {
     ...locationBasedMatchWithName(name),
     combinedMatch: {
@@ -63,7 +63,7 @@ const dataBasedMatchWithName = (name: string): DataBasedSoilMatch => {
   };
 };
 
-const locationBasedMatchWithName = (name: string): DataBasedSoilMatch => {
+const locationBasedMatchWithName = (name: string): SoilMatch => {
   return {
     soilInfo: {
       landCapabilityClass: {capabilityClass: '', subClass: ''},

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,7 +62,7 @@
         "react-native-svg": "^15.11.2",
         "react-native-tab-view": "^4.0.12",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#c4b54533f5089e327f9ba70bebeee29cbb125eed",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#138c8e4770b00006f024f7e3f4a1e387f889f920",
         "use-debounce": "^10.0.4",
         "uuid": "^10.0.0",
         "yup": "^1.6.1"
@@ -24687,8 +24687,8 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#c4b54533f5089e327f9ba70bebeee29cbb125eed",
-      "integrity": "sha512-Arje6VTs/VOF+lOeR9tF5xKrHhDInypN4kLPTceQBMPcX509h2cHwHtiCEIIe1b2f5NFKNAi3ypHD9af/phdRA==",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#138c8e4770b00006f024f7e3f4a1e387f889f920",
+      "integrity": "sha512-8yTMRXma1C3uySHcRiUkViRMS58pWvZ0Y7eBDaJtle7thLt+hXRQUKdTVit6neV0aY3BlzFE0nzsD07SyJaWgw==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,7 +81,7 @@
     "react-native-svg": "^15.11.2",
     "react-native-tab-view": "^4.0.12",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#c4b54533f5089e327f9ba70bebeee29cbb125eed",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#138c8e4770b00006f024f7e3f4a1e387f889f920",
     "use-debounce": "^10.0.4",
     "uuid": "^10.0.0",
     "yup": "^1.6.1"

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {
   coordsKey,
@@ -71,7 +71,7 @@ describe('locationEntryForMatches', () => {
     expect(
       tempLocationEntryForMatches(
         {latitude: 1, longitude: 2},
-        inputMatches as DataBasedSoilMatch[],
+        inputMatches as SoilMatch[],
         'GLOBAL',
       ),
     ).toEqual({

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.ts
@@ -16,11 +16,13 @@
  */
 
 import {
-  DataBasedSoilMatch,
   SoilIdDataRegionChoices,
   SoilIdInputData,
 } from 'terraso-client-shared/graphqlSchema/graphql';
-import {SoilIdStatus} from 'terraso-client-shared/soilId/soilIdTypes';
+import {
+  SoilIdStatus,
+  SoilMatch,
+} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import {COORDINATE_PRECISION} from 'terraso-mobile-client/constants';
@@ -32,7 +34,7 @@ export type DataRegion = SoilIdDataRegionChoices | undefined;
 export type SoilIdEntry = {
   dataRegion: DataRegion;
   input: SoilIdInputData | Coords;
-  matches: DataBasedSoilMatch[];
+  matches: SoilMatch[];
   status: SoilIdStatus;
 };
 
@@ -58,7 +60,7 @@ export const tempLocationEntryForStatus = (
 
 export const tempLocationEntryForMatches = (
   input: Coords,
-  matches: DataBasedSoilMatch[],
+  matches: SoilMatch[],
   dataRegion: SoilIdDataRegionChoices,
 ): SoilIdEntry => {
   return {
@@ -83,7 +85,7 @@ export const siteEntryForStatus = (
 
 export const siteEntryForMatches = (
   input: SoilIdInputData,
-  matches: DataBasedSoilMatch[],
+  matches: SoilMatch[],
   dataRegion: SoilIdDataRegionChoices,
 ): SoilIdEntry => {
   return {

--- a/dev-client/src/model/soilIdMatch/soilIdRanking.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdRanking.test.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {
   getSortedMatches,
@@ -163,12 +163,12 @@ describe('data based matches', () => {
 
 describe('empty matches', () => {
   test('top match is undefined', () => {
-    const soilIdOutputMatches: DataBasedSoilMatch[] = [];
+    const soilIdOutputMatches: SoilMatch[] = [];
     expect(getTopMatch(soilIdOutputMatches)).toBeUndefined();
   });
 
   test('sorting returns empty list', () => {
-    const soilIdOutputMatches: DataBasedSoilMatch[] = [];
+    const soilIdOutputMatches: SoilMatch[] = [];
     expect(getSortedMatches(soilIdOutputMatches)).toEqual([]);
   });
 });

--- a/dev-client/src/model/soilIdMatch/soilIdRanking.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdRanking.ts
@@ -15,11 +15,9 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
-export const getTopMatch = (
-  matches: DataBasedSoilMatch[],
-): DataBasedSoilMatch | undefined => {
+export const getTopMatch = (matches: SoilMatch[]): SoilMatch | undefined => {
   if (matches.length > 0) {
     return matches.reduce((a, b) => getBetterMatch(a, b));
   } else {
@@ -27,10 +25,7 @@ export const getTopMatch = (
   }
 };
 
-const getBetterMatch = (
-  a: DataBasedSoilMatch,
-  b: DataBasedSoilMatch,
-): DataBasedSoilMatch => {
+const getBetterMatch = (a: SoilMatch, b: SoilMatch): SoilMatch => {
   if (a.combinedMatch && b.combinedMatch) {
     return a.combinedMatch.rank < b.combinedMatch.rank ? a : b;
   } else {
@@ -38,7 +33,7 @@ const getBetterMatch = (
   }
 };
 
-export const getSortedMatches = (matches: DataBasedSoilMatch[]) => {
+export const getSortedMatches = (matches: SoilMatch[]) => {
   return [...matches].sort((a, b) => {
     if (a.combinedMatch && b.combinedMatch) {
       return a.combinedMatch.rank - b.combinedMatch.rank;

--- a/dev-client/src/model/soilMetadata/soilMetadataFunctions.ts
+++ b/dev-client/src/model/soilMetadata/soilMetadataFunctions.ts
@@ -15,16 +15,16 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
-export const getMatchSelectionId = (match: DataBasedSoilMatch) => {
+export const getMatchSelectionId = (match: SoilMatch) => {
   return match.soilInfo.soilSeries.name;
 };
 
 export const findSelectedMatch = (
-  matches: DataBasedSoilMatch[],
+  matches: SoilMatch[],
   selectedSoilId: string | undefined | null,
-): DataBasedSoilMatch | undefined => {
+): SoilMatch | undefined => {
   if (!selectedSoilId) {
     return undefined;
   }

--- a/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
+++ b/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
@@ -18,7 +18,7 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import StackedBarChart from 'terraso-mobile-client/assets/stacked-bar.svg';
@@ -128,7 +128,7 @@ const SiteMatchContent = ({siteId}: SiteMatchDisplayProps) => {
 type MatchContentProps = {
   status: SoilIdStatus;
   dataRegion: DataRegion;
-  match: DataBasedSoilMatch | undefined;
+  match: SoilMatch | undefined;
   isSelected?: boolean;
 };
 

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/LocationScoreDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/LocationScoreDisplay.tsx
@@ -18,10 +18,8 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {
-  DataBasedSoilMatch,
-  SoilMatchInfo,
-} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatchInfo} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
@@ -42,7 +40,7 @@ import {getSoilWebUrl} from 'terraso-mobile-client/util';
 type LocationScoreDisplayProps = {
   isSite: boolean;
   dataRegion: DataRegion;
-  match: DataBasedSoilMatch;
+  match: SoilMatch;
   matchInfo: SoilMatchInfo;
   coords: Coords;
 };

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
@@ -18,7 +18,7 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {
   Column,
@@ -28,7 +28,7 @@ import {rowsFromSoilIdData} from 'terraso-mobile-client/components/tables/soilPr
 import {SoilPropertiesDataTable} from 'terraso-mobile-client/components/tables/soilProperties/SoilPropertiesDataTable';
 
 type PropertiesDisplayProps = {
-  match: DataBasedSoilMatch;
+  match: SoilMatch;
 };
 
 export function PropertiesDisplay({match}: PropertiesDisplayProps) {

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
@@ -18,10 +18,8 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {
-  DataBasedSoilMatch,
-  SoilMatchInfo,
-} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatchInfo} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';
@@ -39,7 +37,7 @@ import {ScoreTile} from 'terraso-mobile-client/screens/LocationScreens/component
 import {SoilPropertiesScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilPropertiesScoreInfoContent';
 
 type PropertiesScoreDisplayProps = {
-  match: DataBasedSoilMatch;
+  match: SoilMatch;
   matchInfo: SoilMatchInfo;
 };
 

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
@@ -17,7 +17,7 @@
 
 import {Divider} from 'react-native-paper';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
@@ -32,7 +32,7 @@ type SiteScoreInfoContentProps = {
   siteId: string;
   coords: Coords;
   dataRegion: DataRegion;
-  siteMatch: DataBasedSoilMatch;
+  siteMatch: SoilMatch;
 };
 
 export function SiteScoreInfoContent({

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilIdMatchSelector.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilIdMatchSelector.tsx
@@ -19,7 +19,7 @@ import {StyleSheet, View} from 'react-native';
 
 import CheckBox from '@react-native-community/checkbox';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {DisableableText} from 'terraso-mobile-client/components/content/typography/DisableableText';
 import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
@@ -30,7 +30,7 @@ import {getMatchSelectionId} from 'terraso-mobile-client/model/soilMetadata/soil
 import {useSoilIdSelection} from 'terraso-mobile-client/model/soilMetadata/soilMetadataHooks';
 
 type SoilIdMatchSelectorProps = {
-  match: DataBasedSoilMatch;
+  match: SoilMatch;
   siteId: string;
 };
 

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
@@ -17,7 +17,7 @@
 
 import {Divider} from 'react-native-paper';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
@@ -29,7 +29,7 @@ import {SoilInfoDisplay} from 'terraso-mobile-client/screens/LocationScreens/com
 type TempScoreInfoContentProps = {
   coords: Coords;
   dataRegion: DataRegion;
-  tempLocationMatch: DataBasedSoilMatch;
+  tempLocationMatch: SoilMatch;
 };
 
 export function TempScoreInfoContent({

--- a/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
@@ -21,7 +21,7 @@ import {ActivityIndicator, Divider} from 'react-native-paper';
 
 import {TFunction} from 'i18next';
 
-import {DataBasedSoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
@@ -162,7 +162,7 @@ const ElevationDisplay = ({elevation, t}: ElevationDisplayProps) => {
 
 type SoilIdStatusDisplayTopMatchProps = {
   status: SoilIdStatus;
-  topSoilMatch: DataBasedSoilMatch | undefined;
+  topSoilMatch: SoilMatch | undefined;
 };
 type TopSoilMatchDisplayProps = SoilIdStatusDisplayTopMatchProps & {
   dataRegion: DataRegion;


### PR DESCRIPTION
## Description
The client-shared still exports the `DataBasedSoilMatch` type via the generated graphql file, but we make an equivalent type with a new name `SoilMatch`. The intent is to use it in the mobile-client to be more accurate that it is a generic soil match, not a type specific to DataBased or LocationBased situations.

### Related Issues
Follow-on refactoring I wanted to do, tracked by https://github.com/techmatters/terraso-product/issues/1280
Corresponding client-shared commit: https://github.com/techmatters/terraso-client-shared/pull/1438

### Verification steps
No behavior should change