### PR TITLE
fix: correct spelling of Kastanozems in Spanish

### DIFF
--- a/dev-client/locales/po/es.po
+++ b/dev-client/locales/po/es.po
@@ -3880,7 +3880,7 @@ msgstr "Son suelos productivos, con acumulaciones de arcilla y carbonatos. La pr
 
 #: 
 msgid "soil##match_info##haplic_kastanozems##name"
-msgstr "kKastanozems Háplicos"
+msgstr "Kastanozems Háplicos"
 
 #: 
 msgid "soil##match_info##haplic_kastanozems##description"

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -1256,7 +1256,7 @@
                 "management": "Son suelos productivos, con acumulaciones de arcilla y carbonatos. La productividad mejorará con la fertilización (especialmente el fósforo) y el riego."
             },
             "haplic_kastanozems": {
-                "name": "kKastanozems Háplicos",
+                "name": "Kastanozems Háplicos",
                 "description": "Los suelos de pastizales de kastanozems háplicos se encuentran en climas relativamente secos con un alto contenido de materia orgánica en los horizontes superficiales y a menudo subsuelos calcáreos. Los horizontes superficiales son más finos que los de los Chernozems.",
                 "management": "Son suelos productivos, con acumulaciones de arcilla y carbonato. La productividad mejorará con la fertilización (especialmente el fósforo) y el riego."
             },


### PR DESCRIPTION
## Description
Looks like the translation in POEditor accidentally got an extra `k`.
I edited the files in-place to fix it (didn't go through POEditor), but Derek also fixed this string in POEditor, so it should be fine for the future.

We don't expect this fix to make it into the 1.3 release, but it will go into the publicized release (1.3.1, I imagine)