### PR TITLE
fix: Update client code to use new soilMatches endpoint for 1.3

### DIFF
--- a/dev-client/__tests__/integration/hooks/soilIdHooks.test.tsx
+++ b/dev-client/__tests__/integration/hooks/soilIdHooks.test.tsx
@@ -17,7 +17,7 @@
 
 import {renderHook} from '@testing-library/react-native';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import * as SoilIdMatchContext from 'terraso-mobile-client/context/SoilIdMatchContext';
 import {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,7 +62,7 @@
         "react-native-svg": "^15.11.2",
         "react-native-tab-view": "^4.0.12",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#93f44f4bde8ba666f24994e33a3301b64b24250e",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#157f6e85323d96f346c02ce9552fe0c3210957e3",
         "use-debounce": "^10.0.4",
         "uuid": "^10.0.0",
         "yup": "^1.6.1"
@@ -24682,20 +24682,20 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#68ca9ace09caced2cb31cfa7d1988d1675561c4c",
-      "integrity": "sha512-Q2dtTnuI7UGOHXOJvKj4YdlqJY6qypMtEwlD0yj7jmstWsCa3nSKSXHVdfVE5KBDoEnN7dFoF1KKfJf2yjfqRw=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#05bacc65da4c16e0c13688449d066789f96b0c54",
+      "integrity": "sha512-3VWR97FTSQnnOPa3GD8HtY2sQcFsmO1Vu8Ay95OJwr3wzCpnjLGzckfqejotPjrrczDEhFPru3Lk/XFRU04Zhg=="
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#93f44f4bde8ba666f24994e33a3301b64b24250e",
-      "integrity": "sha512-jB/KXbnWu7z7VQbqHWWOgeYekv5tSlKclG5+QzlsD3kC+NYLQeJp3HQWahxUclfXx6Nf2qWR2LVfhjBsYOIXbQ==",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#157f6e85323d96f346c02ce9552fe0c3210957e3",
+      "integrity": "sha512-g4b40bi9QrgESGehwBF87at0yNLtQ+f8hlRVVyYVR0z0jwrio0fzZlV1bbU1XdQC3MPr9d8LiX3UPxeSrYzsBQ==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#68ca9ace09caced2cb31cfa7d1988d1675561c4c",
+        "terraso-backend": "github:techmatters/terraso-backend#05bacc65da4c16e0c13688449d066789f96b0c54",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -62,7 +62,7 @@
         "react-native-svg": "^15.11.2",
         "react-native-tab-view": "^4.0.12",
         "reduce-reducers": "^1.0.4",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#157f6e85323d96f346c02ce9552fe0c3210957e3",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#ac601e6cf937c5c55fba36e7e0bd308054037d46",
         "use-debounce": "^10.0.4",
         "uuid": "^10.0.0",
         "yup": "^1.6.1"
@@ -24687,8 +24687,8 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#157f6e85323d96f346c02ce9552fe0c3210957e3",
-      "integrity": "sha512-g4b40bi9QrgESGehwBF87at0yNLtQ+f8hlRVVyYVR0z0jwrio0fzZlV1bbU1XdQC3MPr9d8LiX3UPxeSrYzsBQ==",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#ac601e6cf937c5c55fba36e7e0bd308054037d46",
+      "integrity": "sha512-SdrdANcUApFZdnmU+XLYrrEYONybtkKzS0MyxX7uZskRMhuPSxoNWh8BbWuHESRXFxXJYk0DFXUpcy+uQ57mxw==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,7 +81,7 @@
     "react-native-svg": "^15.11.2",
     "react-native-tab-view": "^4.0.12",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#93f44f4bde8ba666f24994e33a3301b64b24250e",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#157f6e85323d96f346c02ce9552fe0c3210957e3",
     "use-debounce": "^10.0.4",
     "uuid": "^10.0.0",
     "yup": "^1.6.1"

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,7 +81,7 @@
     "react-native-svg": "^15.11.2",
     "react-native-tab-view": "^4.0.12",
     "reduce-reducers": "^1.0.4",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#157f6e85323d96f346c02ce9552fe0c3210957e3",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#ac601e6cf937c5c55fba36e7e0bd308054037d46",
     "use-debounce": "^10.0.4",
     "uuid": "^10.0.0",
     "yup": "^1.6.1"

--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchActions.ts
@@ -37,10 +37,7 @@ export const fetchTempLocationBasedSoilMatchesThunk = async (
 ) => fetchTempLocationBasedSoilMatches(coords);
 
 export const fetchTempLocationBasedSoilMatches = async (coords: Coords) => {
-  // NOTE: we call the dataBasedSoilMatches endpoint here to make the
-  //       pre and post site creation soil lists consistent.
-  //       Upstream bug: https://github.com/techmatters/soil-id-algorithm/issues/126
-  const result = await soilIdService.fetchDataBasedSoilMatches(coords, {
+  const result = await soilIdService.fetchSoilMatches(coords, {
     depthDependentData: [],
   });
 
@@ -79,7 +76,7 @@ export const fetchSiteBasedSoilMatches = async (
   }
 
   const coords = {latitude: site.latitude, longitude: site.longitude};
-  const result = await soilIdService.fetchDataBasedSoilMatches(coords, input);
+  const result = await soilIdService.fetchSoilMatches(coords, input);
 
   if (result.__typename === 'SoilIdFailure') {
     return siteEntryForStatus(input, result.reason);

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.test.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {
   coordsKey,

--- a/dev-client/src/model/soilIdMatch/soilIdMatches.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdMatches.ts
@@ -18,11 +18,9 @@
 import {
   SoilIdDataRegionChoices,
   SoilIdInputData,
-} from 'terraso-client-shared/graphqlSchema/graphql';
-import {
-  SoilIdStatus,
   SoilMatch,
-} from 'terraso-client-shared/soilId/soilIdTypes';
+} from 'terraso-client-shared/graphqlSchema/graphql';
+import {SoilIdStatus} from 'terraso-client-shared/soilId/soilIdTypes';
 import {Coords} from 'terraso-client-shared/types';
 
 import {COORDINATE_PRECISION} from 'terraso-mobile-client/constants';

--- a/dev-client/src/model/soilIdMatch/soilIdRanking.test.tsx
+++ b/dev-client/src/model/soilIdMatch/soilIdRanking.test.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {
   getSortedMatches,

--- a/dev-client/src/model/soilIdMatch/soilIdRanking.ts
+++ b/dev-client/src/model/soilIdMatch/soilIdRanking.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 export const getTopMatch = (matches: SoilMatch[]): SoilMatch | undefined => {
   if (matches.length > 0) {

--- a/dev-client/src/model/soilMetadata/soilMetadataFunctions.ts
+++ b/dev-client/src/model/soilMetadata/soilMetadataFunctions.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 export const getMatchSelectionId = (match: SoilMatch) => {
   return match.soilInfo.soilSeries.name;

--- a/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
+++ b/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
@@ -18,7 +18,7 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import StackedBarChart from 'terraso-mobile-client/assets/stacked-bar.svg';

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/LocationScoreDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/LocationScoreDisplay.tsx
@@ -18,8 +18,10 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {SoilMatchInfo} from 'terraso-client-shared/graphqlSchema/graphql';
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {
+  SoilMatch,
+  SoilMatchInfo,
+} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesDisplay.tsx
@@ -18,7 +18,7 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {
   Column,

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/PropertiesScoreDisplay.tsx
@@ -18,8 +18,10 @@
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 
-import {SoilMatchInfo} from 'terraso-client-shared/graphqlSchema/graphql';
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {
+  SoilMatch,
+  SoilMatchInfo,
+} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
 import {HelpContentSpacer} from 'terraso-mobile-client/components/content/HelpContentSpacer';

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
@@ -17,7 +17,7 @@
 
 import {Divider} from 'react-native-paper';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilIdMatchSelector.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilIdMatchSelector.tsx
@@ -19,7 +19,7 @@ import {StyleSheet, View} from 'react-native';
 
 import CheckBox from '@react-native-community/checkbox';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 
 import {DisableableText} from 'terraso-mobile-client/components/content/typography/DisableableText';
 import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/TempScoreInfoContent.tsx
@@ -17,7 +17,7 @@
 
 import {Divider} from 'react-native-paper';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';

--- a/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
@@ -21,7 +21,7 @@ import {ActivityIndicator, Divider} from 'react-native-paper';
 
 import {TFunction} from 'i18next';
 
-import {SoilMatch} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';


### PR DESCRIPTION
## Description
Previously it was fetchDataBasedSoilMatches, now that is being used to support 1.2. And for 1.3 it's just fetchSoilMatches. 

To fix the issue where the new backend is incompatible with both 1.2 and 1.3 clients simultaneously (details [in slack here](https://tech-matters.slack.com/archives/C0376RCCXD2/p1752170651976809))
