### PR TITLE
fix: soil cracks should be included as soil id input

### DIFF
--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchInputs.ts
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchInputs.ts
@@ -98,6 +98,7 @@ export const soilDataToIdInput = (data: SoilData): SoilIdInputData => {
       soilDepthDependentDataToIdInput,
     ),
     slope: soilDataSlopePercent(data),
+    surfaceCracks: data.surfaceCracksSelect,
   };
 };
 


### PR DESCRIPTION
## Description
Looks like we just forgot to send along surfaceCracks in the SoilIdInput

### Related Issues
Part of https://github.com/techmatters/terraso-product/issues/1279

### Verification
Can now see it as part of the data sent to the backend with tcpdump
