### PR TITLE
fix: get elevation for all locations, not just US locations

### DIFF
--- a/dev-client/__tests__/snapshot/__snapshots__/SiteTabsScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/SiteTabsScreen-test.tsx.snap
@@ -1396,7 +1396,7 @@ exports[`renders correctly 1`] = `
                                             }
                                           }
                                         >
-                                          1.00 m
+                                          1 m
                                         </Text>
                                       </View>
                                       <View

--- a/dev-client/src/components/util/site.ts
+++ b/dev-client/src/components/util/site.ts
@@ -19,5 +19,5 @@ import {TFunction} from 'i18next';
 
 export const renderElevation = (t: TFunction, elevation: number | undefined) =>
   elevation
-    ? t('site.elevation_value', {value: elevation.toFixed(2), units: 'm'})
+    ? t('site.elevation_value', {value: elevation.toFixed(0), units: 'm'})
     : t('site.elevation_unknown');

--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -21,8 +21,8 @@ export const getElevation = async (
   lat: number,
   lng: number,
 ): Promise<number | undefined> => {
-  // 1. TypeScript requires values passed to URLSearchParams strings,
-  //    which is why we convert the floats to strings.
+  // TypeScript requires values passed to URLSearchParams to be strings,
+  // which is why we convert the floats to strings.
   const queryString = new URLSearchParams({
     longitude: formatCoordinate(lng),
     latitude: formatCoordinate(lat),

--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -17,47 +17,27 @@
 
 import {formatCoordinate} from 'terraso-mobile-client/util';
 
-const isErrorResult = (result: string) => {
-  const OUT_OF_RANGE_MESSAGE = 'Invalid or missing input parameters.';
-  const UNABLE_TO_PROCESS_MESSAGE = 'Unable to complete operation.';
-
-  // Call failed.  [Failed cloud operation: Open, Path: /vsimem/_0000096E.aux.xml]
-  const CALL_FAILED_MESSAGE = 'Call failed.';
-
-  if ([OUT_OF_RANGE_MESSAGE, UNABLE_TO_PROCESS_MESSAGE].includes(result)) {
-    return true;
-  }
-
-  if (result.startsWith(CALL_FAILED_MESSAGE)) {
-    return true;
-  }
-
-  return false;
-};
-
 export const getElevation = async (
   lat: number,
   lng: number,
 ): Promise<number | undefined> => {
   // 1. TypeScript requires values passed to URLSearchParams strings,
   //    which is why we convert the floats to strings.
-  // 2. This API uses X for longitude and Y for latitude. That's not a typo.
   const queryString = new URLSearchParams({
-    x: formatCoordinate(lng),
-    y: formatCoordinate(lat),
-    units: 'Meters', // TODO: switch based on user preference
+    longitude: formatCoordinate(lng),
+    latitude: formatCoordinate(lat),
   });
   let elevation;
 
   try {
     const response = await fetch(
-      `https://epqs.nationalmap.gov/v1/json/?${queryString}`,
+      `https://api.open-meteo.com/v1/elevation/?${queryString}`,
     );
-    const result = await response.text();
-    if (isErrorResult(result)) {
+    if (response.status !== 200) {
       elevation = undefined;
     } else {
-      elevation = parseFloat(JSON.parse(result).value);
+      const result = await response.text();
+      elevation = parseInt(JSON.parse(result).elevation[0], 10);
     }
   } catch (error) {
     console.error(error);

--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -33,11 +33,9 @@ export const getElevation = async (
     const response = await fetch(
       `https://api.open-meteo.com/v1/elevation/?${queryString}`,
     );
-    if (response.status !== 200) {
-      elevation = undefined;
-    } else {
-      const result = await response.text();
-      elevation = parseInt(JSON.parse(result).elevation[0], 10);
+    if (response.status === 200) {
+      const result = await response.json();
+      elevation = parseInt(result.elevation[0], 10);
     }
   } catch (error) {
     console.error(error);

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -38,7 +38,6 @@ import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
 import {StaticMapView} from 'terraso-mobile-client/components/StaticMapView';
 import {renderElevation} from 'terraso-mobile-client/components/util/site';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
-import {useSoilIdOutput} from 'terraso-mobile-client/hooks/soilIdHooks';
 import {updateSite} from 'terraso-mobile-client/model/site/siteGlobalReducer';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {LocationSoilIdCard} from 'terraso-mobile-client/screens/LocationScreens/components/LocationSoilIdCard';
@@ -72,10 +71,6 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigation = useNavigation();
-  const soilIdOutput = useSoilIdOutput(
-    site?.id ? {siteId: site.id} : {coords: coords},
-  );
-  const dataRegion = soilIdOutput.dataRegion;
 
   const project = useSelector(state =>
     site?.projectId === undefined
@@ -114,8 +109,7 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
           label={t('geo.longitude.title')}
           value={formatCoordinate(coords?.longitude)}
         />
-        {(elevation || dataRegion === 'US') && (
-          // TODO: Remove the conditional once mobile-client bug 2664 is done
+        {elevation && (
           <LocationDetail
             label={t('geo.elevation.title')}
             value={renderElevation(t, elevation)}

--- a/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
+++ b/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
@@ -153,7 +153,8 @@ const MatchContent = ({
     <>
       <Text variant="body1" color="primary.contrast" mb="5px">
         <Text bold>
-          {t(isSelected ? 'site.soil_id.matches.selected' : 'soil.top_match')}:{' '}
+          {t(isSelected ? 'site.soil_id.matches.selected' : 'soil.top_match')}
+          :{' '}
         </Text>
         <SoilIdStatusDisplay
           status={status}

--- a/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
+++ b/dev-client/src/screens/LocationScreens/components/LocationSoilIdCard.tsx
@@ -153,8 +153,7 @@ const MatchContent = ({
     <>
       <Text variant="body1" color="primary.contrast" mb="5px">
         <Text bold>
-          {t(isSelected ? 'site.soil_id.matches.selected' : 'soil.top_match')}
-          :{' '}
+          {t(isSelected ? 'site.soil_id.matches.selected' : 'soil.top_match')}:{' '}
         </Text>
         <SoilIdStatusDisplay
           status={status}

--- a/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
@@ -112,7 +112,7 @@ export const TemporaryLocationCallout = ({
             </>
           )}
         </>
-        {elevation.value && (
+        {elevation && (
           <>
             <Divider />
             <CalloutDetail

--- a/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
@@ -112,8 +112,7 @@ export const TemporaryLocationCallout = ({
             </>
           )}
         </>
-        {(elevation.value || soilIdOutput.dataRegion === 'US') && (
-          // TODO: Remove the conditional once mobile-client bug 2664 is done
+        {elevation.value && (
           <>
             <Divider />
             <CalloutDetail


### PR DESCRIPTION
## Description
Use open-meteo elevation API instead of the nationalmap.gov API. This allows for global elevation data.

### Related Issues
Fixes #2664.
Removes workaround from https://github.com/techmatters/terraso-mobile-client/pull/2991