### PR TITLE
fix: Add watchman shutdown-server to clean-watchman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ setup-git-hooks:
 	@echo "git hooks installed"
 
 clean-watchman:
-	cd dev-client && npm run clean-watchman && watchman shutdown-server
+	cd dev-client && npm run clean-watchman
 
 clean-simulators:
 	{ type -p xcrun && xcrun simctl shutdown all && xcrun simctl erase all; }

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ setup-git-hooks:
 	@echo "git hooks installed"
 
 clean-watchman:
-	cd dev-client && npm run clean-watchman
+	cd dev-client && npm run clean-watchman && watchman shutdown-server
 
 clean-simulators:
 	{ type -p xcrun && xcrun simctl shutdown all && xcrun simctl erase all; }

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -20,7 +20,7 @@
     "check-ts": "tsc --noEmit",
     "check-modules": "depcheck",
     "prebuild": "expo prebuild",
-    "clean-watchman": "watchman watch-del-all",
+    "clean-watchman": "watchman watch-del-all && watchman shutdown-server",
     "localization-to-po": "node scripts/localization/transform-to.mjs po",
     "localization-to-json": "node scripts/localization/transform-to.mjs json",
     "localization-check-missing": "node scripts/localization/missing-check.mjs",


### PR DESCRIPTION
## Description
I found that running 
```
watchman watch-del-all
watchman shutdown-server
```
fixed a watchman error in my local environment, that `make clean-watchman` alone did not fix.
Because `npm run clean-watchman` already does the watch-del-all part, I only added the shutdown-server part.
Source: https://stackoverflow.com/questions/49443341/watchman-crawl-failed-retrying-once-with-node-crawler 

However, I'm not sure if/how this will affect watchman in other repos -- like if you have a backend, mobile-client, and web-client running at the same time and run this in mobile-client, I'm not sure if you'd need to do something extra to make backend and web-client continue to hot reload?
[[TODO: test that if reviewers aren't sure]] 