### PR TITLE
chore: bump version to 1.4

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -81,7 +81,7 @@ if (typeof APP_BUILD === 'string') {
 const defaultConfig: ExpoConfig = {
   name: 'LandPKS Soil ID',
   slug: 'landpks',
-  version: '1.3',
+  version: '1.4',
   orientation: 'portrait',
   splash: {
     image: 'src/assets/splash.png',

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LandPKS Soil ID",
-  "version": "1.3",
+  "version": "1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LandPKS Soil ID",
-      "version": "1.3",
+      "version": "1.4",
       "dependencies": {
         "@craftzdog/react-native-buffer": "^6.0.5",
         "@expo/vector-icons": "^14.1.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LandPKS Soil ID",
-  "version": "1.3",
+  "version": "1.4",
   "private": true,
   "scripts": {
     "android": "expo run:android",


### PR DESCRIPTION
## Description
Bumps the mobile client app version number to 1.4
Same edits as the bump to 1.3 in https://github.com/techmatters/terraso-mobile-client/pull/2882 

### Related Issues
Addresses #3004 
