### PR TITLE
fix: Show 'Error' instead of 'No matches' on algorithm failure

### DIFF
--- a/dev-client/src/components/SoilIdStatusDisplay.tsx
+++ b/dev-client/src/components/SoilIdStatusDisplay.tsx
@@ -45,7 +45,7 @@ export const SoilIdStatusDisplay = ({
      * which are Ok to display to the user even in offline mode.
      */
     return isOffline ? offline : loading;
-  } else if (status === 'error') {
+  } else if (status === 'error' || status === 'ALGORITHM_FAILURE') {
     return error;
   } else if (status === 'DATA_UNAVAILABLE') {
     return noData;


### PR DESCRIPTION
### Related Issues
Addresses #2751 

### Verification steps
Look at the temporary location callout at a location that has an algorithm error (currently 43.04364, -92.30141 does). Make sure the callout says "ERROR" and there is a red alert on the soil id matches screen that says "Can't fetch soil map"
