### PR TITLE
docs: remove outdated setup information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,10 @@ All users:
 $ cd dev-client
 ```
 
-Install NPM and Ruby packages:
+Install NPM packages:
 
 ```sh
 $ npm install
-$ bundle install
-$ cd ios
 ```
 
 If you get this error:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Install NPM and Ruby packages:
 $ npm install
 $ bundle install
 $ cd ios
-$ bundle exec pod install
 ```
 
 If you get this error:
@@ -101,53 +100,6 @@ The below commands implicitly call `npm run start` when they are finished, so yo
 1. Run `npm run ios` to load the app in the simulator.
 2. Run `npm run ios -- --configuration release` to load a release build of the app in the simulator.
 3. Run `npm run ios -- --device "Jane iPhone"` to load the app on a specific device. (Use `xcrun simctl list devices available` to get a list of available simulators.)
-
-# Releases
-
-## Android
-
-### Initial setup
-
-#### Generate a keystore:
-
-```
-keytool -genkey -v -keystore terraso-lpks-key.keystore -alias terraso-lpks -keyalg RSA -keysize 2048 -validity 10000
-```
-
-#### Define confguration variables
-
-Add this to `~/.gradle/gradle.properties`. Use the password you created in “generate a keystore.”
-
-```
-cat << EOF >> ~/.gradle/gradle.properties
-LPKS_UPLOAD_STORE_FILE=terraso-lpks-key.keystore
-LPKS_UPLOAD_KEY_ALIAS=terraso-lpks
-LPKS_UPLOAD_STORE_PASSWORD=XXXXX
-LPKS_UPLOAD_KEY_PASSWORD=XXXXXX
-EOF
-```
-
-#### Move the keystore in to your development folder
-
-```
-mv terraso-lpks-key.keystore mobile-client/dev-client/android/app
-```
-
-### Releasing a build
-
-From `mobile-client/dev-client/android`:
-
-Build the app bundle:
-
-```
-./gradlew bundleRelease
-```
-
-Sign the app bundle:
-
-```
-jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256  -keystore ~/terraso-lpks-key.keystore -signedjar app/build/outputs/bundle/release/terraso-landpks.aab  app/build/outputs/bundle/release/app-release.aab terraso-lpks
-```
 
 # Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -44,18 +44,6 @@ Install NPM packages:
 $ npm install
 ```
 
-If you get this error:
-
-```
-xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
-```
-
-Then run this:
-
-```sh
-$ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-```
-
 ## Development Tools
 
 Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) from the App Store. Install the iOS SDK and Simulator.
@@ -102,6 +90,18 @@ Before building for iOS or Android, run `npm run prebuild` to generate the neces
 1. Run `npm run ios` to load the app in the simulator.
 2. Run `npm run ios -- --configuration release` to load a release build of the app in the simulator.
 3. Run `npm run ios -- --device "Jane iPhone"` to load the app on a specific device. (Use `xcrun simctl list devices available` to get a list of available simulators.)
+
+If you get this error:
+
+```
+xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
+```
+
+Then run this:
+
+```sh
+$ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
 
 # Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ $ sudo apt install node watchman openjdk-17-jdk
 Do **not** use the `a` or `i` subcommands in `npm run start`, they don't work with our workflow.
 The below commands implicitly call `npm run start` when they are finished, so you shouldn't ordinarily need to call it manually.
 
+## Prebuild
+
+Before building for iOS or Android, run `npm run prebuild` to generate the necessary files for Xcode and gradle.
+
 ## Android
 
 1. Run `npm run android` to load the app on an emulator or connnected physical device.


### PR DESCRIPTION
## Description
In the README, removed outdated information on android signing and iOS CocoaPods.

Releases are handled by GitHub actions and CocoaPods by npm run prebuild.