### PR TITLE
fix: make git ignore watchman cookie files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ buildcache/
 sentry.properties
 .sentry
 
+# Sometimes watchman creates cookie files
+.watchman-cookie-*


### PR DESCRIPTION
## Description
Watchman sometimes creates cookie files that I think git should ignore: 
<img width="490" height="213" alt="Screenshot 2025-08-07 at 9 49 40 AM" src="https://github.com/user-attachments/assets/b80e5a1b-f439-439f-b6c6-35b9f2d98aa2" />

However, I'm not sure why it's creating the cookies in the dev-client directory. From the Watchman docs:
> The cookie is created in a directory that is expected not to go away. The obvious location is the root itself, but we'd like cookies not to show up in VCS operations. So if a VCS directory (.git, .hg or .svn) is found, that's where cookies are created instead.
