### PR TITLE
fix: repaired missing privacy_policy_label

### DIFF
--- a/dev-client/find-i18n-keys.mjs
+++ b/dev-client/find-i18n-keys.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// find-i18n-keys.mjs
+// Usage: node find-i18n-keys.mjs [path1] [path2] ... [--catalog path/to/catalog.json] [--json]
+
+// easiest way to run: 'npm run check-i18n'
+// todo: run with other linters automatically; maybe add github action too.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const exts = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const IGNORE_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  'out',
+  'coverage',
+]);
+
+const args = process.argv.slice(2);
+const jsonOutput = args.includes('--json');
+
+function popFlagWithValue(flag, arr) {
+  const i = arr.indexOf(flag);
+  if (i === -1) return null;
+  const v = arr[i + 1];
+  if (!v || v.startsWith('--')) throw new Error(`Missing value for ${flag}`);
+  arr.splice(i, 2);
+  return v;
+}
+const catalogPath = popFlagWithValue('--catalog', args);
+const roots = args.length ? args : ['.'];
+
+// ---------- FS walk ----------
+function* walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, {withFileTypes: true});
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (!IGNORE_DIRS.has(e.name)) yield* walk(path.join(dir, e.name));
+    } else if (e.isFile() && exts.has(path.extname(e.name))) {
+      yield path.join(dir, e.name);
+    }
+  }
+}
+
+// ---------- Regex extractors ----------
+const RE_KEY = /i18nKey\s*=\s*(['"])([^'"]+?)\1/g;
+const RE_LABEL = /labelI18nKey\s*=\s*(['"])([^'"]+?)\1/g;
+const RE_URLKEY = /urlI18nKey\s*=\s*(['"])([^'"]+?)\1/g;
+const RE_T_FIRST_ARG = /\bt\s*\(\s*(['"])([^'"]+?)\1/g;
+const RE_I18NKEYS_BLOCK = /i18nKeys\s*=\s*\{\s*\[\s*([\s\S]*?)\s*\]\s*\}/g;
+const RE_STRING_IN_BLOCK = /(['"])([^'"]+?)\1/g;
+
+function lineNumberFromIndex(text, index) {
+  let line = 1;
+  for (let i = 0; i < index; i++) if (text.charCodeAt(i) === 10) line++;
+  return line;
+}
+
+function collectFromRegex(re, text, file, pushFn) {
+  re.lastIndex = 0;
+  let m;
+  while ((m = re.exec(text))) {
+    const key = m[2];
+    if (key) pushFn(key, file, lineNumberFromIndex(text, m.index));
+    if (re.lastIndex === m.index) re.lastIndex++;
+  }
+}
+
+function collectFromI18nKeysBlock(text, file, pushFn) {
+  RE_I18NKEYS_BLOCK.lastIndex = 0;
+  let m;
+  while ((m = RE_I18NKEYS_BLOCK.exec(text))) {
+    const blockStart = m.index;
+    const arrayContent = m[1] ?? '';
+    RE_STRING_IN_BLOCK.lastIndex = 0;
+    let sm;
+    while ((sm = RE_STRING_IN_BLOCK.exec(arrayContent))) {
+      const key = sm[2];
+      const absoluteIdx = blockStart + sm.index;
+      pushFn(key, file, lineNumberFromIndex(text, absoluteIdx));
+      if (RE_STRING_IN_BLOCK.lastIndex === sm.index)
+        RE_STRING_IN_BLOCK.lastIndex++;
+    }
+    if (RE_I18NKEYS_BLOCK.lastIndex === m.index) RE_I18NKEYS_BLOCK.lastIndex++;
+  }
+}
+
+// ---------- Scan codebase ----------
+const scanKeys = new Set();
+const occurrences = new Map(); // key -> [{file,line}]
+
+function addOccurrence(key, file, line) {
+  scanKeys.add(key);
+  if (!occurrences.has(key)) occurrences.set(key, []);
+  occurrences.get(key).push({file, line});
+}
+
+function processFile(filePath) {
+  let text;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return;
+  }
+  collectFromRegex(RE_KEY, text, filePath, addOccurrence);
+  collectFromRegex(RE_LABEL, text, filePath, addOccurrence);
+  collectFromRegex(RE_URLKEY, text, filePath, addOccurrence);
+  collectFromRegex(RE_T_FIRST_ARG, text, filePath, addOccurrence);
+  collectFromI18nKeysBlock(text, filePath, addOccurrence);
+}
+
+for (const root of roots) {
+  try {
+    const st = fs.statSync(root);
+    if (st.isDirectory()) for (const f of walk(root)) processFile(f);
+    else if (st.isFile()) processFile(root);
+  } catch {
+    /* ignore */
+  }
+}
+
+const sortedScanKeys = Array.from(scanKeys).sort((a, b) => a.localeCompare(b));
+
+// ---------- Catalog JSON extraction ----------
+// Rule: collect LEAF keys that have at least one parent (depth >= 2), joined with dots.
+// e.g. {abc:{def:"x", xyz:"y"}, help:"hi"} -> abc.def, abc.xyz   (skip "help")
+function collectCatalogKeysFromObject(obj, parentPath = []) {
+  const result = [];
+  if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+    for (const [k, v] of Object.entries(obj)) {
+      const pathArr = [...parentPath, k];
+      const depth = pathArr.length;
+      const isLeaf = !(v && typeof v === 'object');
+      if (isLeaf && depth >= 2) {
+        const joined = pathArr.join('.');
+        result.push(joined);
+      }
+      // Recurse into objects for deeper leaves
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        result.push(...collectCatalogKeysFromObject(v, pathArr));
+      }
+    }
+  }
+  return result;
+}
+
+let catalogKeys = new Set();
+if (catalogPath) {
+  try {
+    const raw = fs.readFileSync(catalogPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    catalogKeys = new Set(
+      collectCatalogKeysFromObject(parsed).sort((a, b) => a.localeCompare(b)),
+    );
+  } catch (e) {
+    console.error(
+      `Failed to read/parse catalog JSON at ${catalogPath}: ${e.message}`,
+    );
+    process.exit(2);
+  }
+}
+
+// ---------- Diff ----------
+function setDiff(a, b) {
+  const out = [];
+  for (const x of a) if (!b.has(x)) out.push(x);
+  out.sort((x, y) => x.localeCompare(y));
+  return out;
+}
+
+const inCatalogNotScan = setDiff(catalogKeys, scanKeys);
+const inScanNotCatalog = setDiff(scanKeys, catalogKeys);
+
+// ---------- Output ----------
+if (jsonOutput) {
+  const out = {
+    scan: {
+      count: sortedScanKeys.length,
+      keys: sortedScanKeys,
+      occurrences: Object.fromEntries(
+        sortedScanKeys.map(k => [k, occurrences.get(k) ?? []]),
+      ),
+    },
+    catalog: catalogPath
+      ? {
+          path: catalogPath,
+          count: catalogKeys.size,
+          keys: Array.from(catalogKeys).sort(),
+        }
+      : null,
+    diff: catalogPath
+      ? {
+          inCatalogNotScan: inCatalogNotScan,
+          inScanNotCatalog: inScanNotCatalog,
+        }
+      : null,
+  };
+  console.log(JSON.stringify(out, null, 2));
+} else {
+  console.log(`Found ${sortedScanKeys.length} unique key(s) in scan.`);
+  if (catalogPath) {
+    // console.log(
+    //   `Catalog: ${catalogPath} (${catalogKeys.size} key(s) after rules)`
+    // );
+    // console.log(
+    //   `\n=== In catalog but NOT in scan (${inCatalogNotScan.length})===`
+    // );
+    // if (inCatalogNotScan.length === 0) console.log("(none)");
+    // else inCatalogNotScan.forEach((k) => console.log(k));
+    console.log(
+      `\n=== In scan but NOT in catalog (${inScanNotCatalog.length})===`,
+    );
+    if (inScanNotCatalog.length === 0) console.log('(none)');
+    else inScanNotCatalog.forEach(k => console.log(k));
+  } else {
+    console.log(
+      '(Tip: pass --catalog path/to/en.json to compare with a catalog)',
+    );
+  }
+
+  // Also print occurrences at the end for convenience
+  // console.log("\nOccurrences:");
+  // for (const k of sortedScanKeys) {
+  //   const occ = occurrences.get(k) ?? [];
+  //   for (const { file, line } of occ) console.log(`${k}\t${file}:${line}`);
+  // }
+}

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -25,7 +25,7 @@
     "localization-to-json": "node scripts/localization/transform-to.mjs json",
     "localization-check-missing": "node scripts/localization/missing-check.mjs",
     "prepare": "cd .. && husky",
-    "check-i18n": "echo '---- English ----' && node find-i18n-keys.mjs . --catalog src/translations/en.json && echo '\n---- Spanish ----' && node find-i18n-keys.mjs . --catalog src/translations/es.json"
+    "check-i18n": "node scripts/localization/find-i18n-keys.mjs . --catalog src/translations/en.json ; node scripts/localization/find-i18n-keys.mjs . --catalog src/translations/es.json"
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -24,7 +24,8 @@
     "localization-to-po": "node scripts/localization/transform-to.mjs po",
     "localization-to-json": "node scripts/localization/transform-to.mjs json",
     "localization-check-missing": "node scripts/localization/missing-check.mjs",
-    "prepare": "cd .. && husky"
+    "prepare": "cd .. && husky",
+    "check-i18n": "echo '---- English ----' && node find-i18n-keys.mjs . --catalog src/translations/en.json && echo '\n---- Spanish ----' && node find-i18n-keys.mjs . --catalog src/translations/es.json"
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",

--- a/dev-client/src/components/content/info/privacy/DataPrivacyContent.tsx
+++ b/dev-client/src/components/content/info/privacy/DataPrivacyContent.tsx
@@ -35,12 +35,12 @@ export const DataPrivacyContent = () => {
       <TranslatedParagraph i18nKey="general.info.privacy_item3" />
       <TranslatedParagraph i18nKey="general.info.privacy_item4" />
       <ExternalLink
-        label={t('general.info.privacy_policy_link_text')}
-        url={t('general.info.privacy_policy_link_url')}
+        label={t('general.privacy_policy_link_text')}
+        url={t('general.privacy_policy_link_url')}
       />
       <ExternalLink
-        label={t('general.info.terms_of_service_link_text')}
-        url={t('general.info.terms_of_service_link_url')}
+        label={t('general.terms_of_service_link_text')}
+        url={t('general.terms_of_service_link_url')}
       />
     </Column>
   );

--- a/dev-client/src/screens/ProjectSitesScreen.tsx
+++ b/dev-client/src/screens/ProjectSitesScreen.tsx
@@ -204,6 +204,12 @@ export function ProjectSitesScreen({
     sortNames.push('distanceAsc');
   }
 
+  /*
+      these strings can help automatic detection
+      t("projects.sites.sort.distanceAsc")
+      t("projects.sites.sort.nameAsc")
+      t("projects.sites.sort.updatedAtAsc")
+  */
   const sortingOptions = Object.fromEntries(
     sortNames.map(label => [label, t('projects.sites.sort.' + label)]),
   );

--- a/dev-client/src/screens/UserSettingsScreen/components/menu/PrivacyItem.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/menu/PrivacyItem.tsx
@@ -20,8 +20,8 @@ import {LinkItem} from 'terraso-mobile-client/screens/UserSettingsScreen/compone
 export const PrivacyItem = () => {
   return (
     <LinkItem
-      labelI18nKey="general.info.privacy_policy_label"
-      urlI18nKey="general.info.privacy_policy_link_url"
+      labelI18nKey="general.privacy_policy_link_text"
+      urlI18nKey="general.privacy_policy_link_url"
     />
   );
 };

--- a/dev-client/src/screens/WelcomeScreen.tsx
+++ b/dev-client/src/screens/WelcomeScreen.tsx
@@ -88,12 +88,12 @@ export const WelcomeScreen = () => {
           <TranslatedParagraph i18nKey="welcome.terms" />
 
           <ExternalLink
-            label={t('welcome.privacy_policy_link_text')}
-            url={t('welcome.privacy_policy_link_url')}
+            label={t('general.privacy_policy_link_text')}
+            url={t('general.privacy_policy_link_url')}
           />
           <ExternalLink
-            label={t('welcome.terms_of_service_link_text')}
-            url={t('welcome.terms_of_service_link_url')}
+            label={t('general.terms_of_service_link_text')}
+            url={t('general.terms_of_service_link_url')}
           />
 
           {/* To leave room for the FAB */}

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -19,10 +19,6 @@
         "link_text": "LandPKS from Terraso",
         "link_url": "https://landpks.terraso.org/",
         "terms": "By using LandPKS you accept our privacy policy and terms of service.",
-        "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
-        "privacy_policy_link_text": "Privacy Policy",
-        "terms_of_service_link_url": "https://terraso.org/terms-of-service/",
-        "terms_of_service_link_text": "Terms of Service",
         "get_started": "Get started"
     },
     "info": {
@@ -456,11 +452,7 @@
             "privacy_item3": "<bold>A private site</bold> not affiliated with a project is only visible to the person who created it. That person can change the privacy at any time. ",
             "privacy_item4": "<bold>A project’s privacy setting determines the privacy of its affiliated sites.</bold> Sites that belong to a private project are visible to project team members. A project manager can change the privacy at any time. ",
             "data_portal_link_url": "https://landpks.terraso.org/portal",
-            "data_portal_link_text": "LandPKS Data Portal",
-            "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
-            "privacy_policy_link_text": "Privacy Policy",
-            "terms_of_service_link_url": "https://terraso.org/terms-of-service/",
-            "terms_of_service_link_text": "Terms of Service"
+            "data_portal_link_text": "LandPKS Data Portal"
         },
         "required": "Required",
         "character_limit": "{{current}} / {{limit}} characters",
@@ -479,6 +471,10 @@
             "label": "Terms of service",
             "url": "https://terraso.org/terms-of-service/"
         },
+        "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
+        "privacy_policy_link_text": "Privacy Policy",
+        "terms_of_service_link_url": "https://terraso.org/terms-of-service/",
+        "terms_of_service_link_text": "Terms of Service",
         "not_available_offine": "Not available offline",
         "offline_sign_in_title": "Sign in not available offline",
         "offline_sign_in_body": "To use LandPKS Soil ID offline, you must first sign in while online.",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -19,10 +19,6 @@
         "link_text": "LandPKS de Terraso",
         "link_url": "https://landpks.terraso.org/",
         "terms": "TK By using LandPKS you accept our privacy policy and terms of service.",
-        "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
-        "privacy_policy_link_text": "Política de privacidad",
-        "terms_of_service_link_url": "https://terraso.org/terms-of-service/",
-        "terms_of_service_link_text": "Condiciones de servicio",
         "get_started": "Comenzar"
     },
     "search": {
@@ -450,11 +446,7 @@
             "privacy_item3": "<bold>Un sitio privado</bold> no afiliado a un proyecto es visible sólo para la persona quien lo creó. Esa persona puede cambiar la privacidad en cualquier momento.",
             "privacy_item4": "<bold>La configuración de privacidad de un proyecto determina la privacidad de sus sitios afiliados.</bold> Los sitios que pertenecen a un proyecto privado son visibles para los miembros del equipo del proyecto. Un administrador de proyectos puede cambiar la privacidad en cualquier momento.",
             "data_portal_link_url": "https://landpks.terraso.org/portal",
-            "data_portal_link_text": "Portal de datos LandPKS",
-            "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
-            "privacy_policy_link_text": "Política de privacidad",
-            "terms_of_service_link_url": "https://terraso.org/terms-of-service/",
-            "terms_of_service_link_text": "Términos de Servicio"
+            "data_portal_link_text": "Portal de datos LandPKS"
         },
         "character_limit": "{{current}} / {{limit}} caracteres",
         "open_settings": "Ir a configuraciones",
@@ -476,7 +468,11 @@
         "offline_sign_in_title": "Inicio de sesión no disponible sin conexión",
         "offline_sign_in_body": "Para utilizar LandPKS Soil ID sin conexión, primero debes iniciar sesión en línea.",
         "not_available": "No disponible",
-        "learn_more": "Aprender más"
+        "learn_more": "Aprender más",
+        "privacy_policy_link_url": "https://techmatters.org/privacy-policy/",
+        "privacy_policy_link_text": "Política de privacidad",
+        "terms_of_service_link_url": "https://terraso.org/terms-of-service/",
+        "terms_of_service_link_text": "Condiciones de servicio"
     },
     "errors": {
         "generic": "Error al guardar la informacion de la identificación del suelo.",


### PR DESCRIPTION
also added command "npm run check-i18n" which will find most missing translation strings. this should probably run automatically at some point.

also moved a few strings into general section to avoid duplication (privacy_policy_link..., and terms_of_service_link...).

conformed the check script found the missing value and now all the values are good.
(it falsely reports projects.sites.sort., but not an actual problem).
