### PR TITLE
fix: remove a bullet point from the interstitial

### DIFF
--- a/dev-client/src/screens/WelcomeScreen.tsx
+++ b/dev-client/src/screens/WelcomeScreen.tsx
@@ -60,7 +60,8 @@ export const WelcomeScreen = () => {
           <TranslatedBulletList
             i18nKeys={[
               'welcome.version_includes.bullet_1',
-              'welcome.version_includes.bullet_2',
+              // This ended up not getting into 1.3.1, but we expect to use the string for the next release
+              // 'welcome.version_includes.bullet_2',
               'welcome.version_includes.bullet_3',
             ]}
           />


### PR DESCRIPTION
## Description
Welcome interstitial now looks like
<img width="352" height="691" alt="Screenshot 2025-08-27 at 11 09 35 AM" src="https://github.com/user-attachments/assets/36a2e6bd-e375-4150-a878-d369e23ca3b1" />


### Related Issues
Addresses #1305

