### PR TITLE
fix: don't promote global soil id in interstitial yet

### DIFF
--- a/dev-client/src/screens/WelcomeScreen.tsx
+++ b/dev-client/src/screens/WelcomeScreen.tsx
@@ -59,9 +59,7 @@ export const WelcomeScreen = () => {
           </Text>
           <TranslatedBulletList
             i18nKeys={[
-              // We're not promoting global soil id yet, but we expect to use the string for the next release
-              // 'welcome.version_includes.bullet_1',
-              // These both ended up not getting into 1.3.1, but we expect to use the string for the next release
+              // This ended up not getting into 1.3.1, but we expect to use the string for the next release
               // 'welcome.version_includes.bullet_2',
               'welcome.version_includes.bullet_3',
             ]}
@@ -73,6 +71,8 @@ export const WelcomeScreen = () => {
           </Text>
           <TranslatedBulletList
             i18nKeys={[
+              // We're not promoting global soil id yet, figured it was easier to just move this here than to re-do the translations in POEditor
+              'welcome.version_includes.bullet_1',
               'welcome.next.bullet_1',
               'welcome.next.bullet_2',
               'welcome.next.bullet_3',


### PR DESCRIPTION
## Description
Oops, we forgot to remove the global soil id part of the interstitial as well. Promotion is slated for 1.3.2.
Remove it from the "This version includes:" section and add it to the "What's next?" section. Kind of silly that there's now only one bullet point in this version, but it's fine.

### Related Issues
Follow-up to https://github.com/techmatters/terraso-product/issues/1305
