### PR TITLE
fix: elevation 0 shows on temp location callout and on location dashboard

### DIFF
--- a/dev-client/src/components/util/site.ts
+++ b/dev-client/src/components/util/site.ts
@@ -18,6 +18,6 @@
 import {TFunction} from 'i18next';
 
 export const renderElevation = (t: TFunction, elevation: number | undefined) =>
-  elevation
+  elevation !== undefined
     ? t('site.elevation_value', {value: elevation.toFixed(0), units: 'm'})
     : t('site.elevation_unknown');

--- a/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
+++ b/dev-client/src/screens/LocationScreens/LocationDashboardContent.tsx
@@ -111,12 +111,10 @@ export const LocationDashboardContent = ({site, coords, elevation}: Props) => {
           label={t('geo.longitude.title')}
           value={formatCoordinate(coords?.longitude)}
         />
-        {elevation && (
-          <LocationDetail
-            label={t('geo.elevation.title')}
-            value={renderElevation(t, elevation)}
-          />
-        )}
+        <LocationDetail
+          label={t('geo.elevation.title')}
+          value={renderElevation(t, elevation)}
+        />
         {!site && (
           <Box>
             <Box paddingVertical="20px" alignItems="center">

--- a/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
+++ b/dev-client/src/screens/SitesScreen/components/TemporaryLocationCallout.tsx
@@ -114,15 +114,11 @@ export const TemporaryLocationCallout = ({
             </>
           )}
         </>
-        {elevation && (
-          <>
-            <Divider />
-            <CalloutDetail
-              label={t('site.elevation_label')}
-              value={<ElevationDisplay elevation={elevation} t={t} />}
-            />
-          </>
-        )}
+        <Divider />
+        <CalloutDetail
+          label={t('site.elevation_label')}
+          value={<ElevationDisplay elevation={elevation} t={t} />}
+        />
         <Divider />
         <Row justifyContent="flex-end">
           <CreateSiteButton


### PR DESCRIPTION
## Description
No longer crashes when viewing location dashboard for elevation 0 (for example, in the ocean). 
Negative elevations continue to work fine.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/3025
