### PR TITLE
feat: implement SoilMatchCard per component library

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -40,7 +40,7 @@ import {getSortedMatches} from 'terraso-mobile-client/model/soilIdMatch/soilIdRa
 import {NoMapDataWarningAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/NoMapDataWarningAlert';
 import {OfflineAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/OfflineAlert';
 import {SoilMatchesErrorAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/SoilMatchesErrorAlert';
-import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
+import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
 import {TempScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/TempScoreInfoContent';
@@ -101,7 +101,7 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
               />
             }
             trigger={onOpen => (
-              <SoilMatchTile
+              <SoilMatchCard
                 soilName={siteMatch.soilInfo.soilSeries.name}
                 dataRegion={dataRegion}
                 score={
@@ -132,7 +132,7 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
               />
             }
             trigger={onOpen => (
-              <SoilMatchTile
+              <SoilMatchCard
                 soilName={locationMatch.soilInfo.soilSeries.name}
                 dataRegion={dataRegion}
                 score={locationMatch.locationMatch.score}

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
@@ -56,13 +56,13 @@ export const SoilIdSelectionSection = ({
         }
         trigger={onOpen => (
           <SoilMatchCard
+            variant="Selected"
             soilName={selectedSoilMatch.soilInfo.soilSeries.name}
             dataRegion={dataRegion}
             score={
               selectedSoilMatch.combinedMatch?.score ??
               selectedSoilMatch.locationMatch.score
             }
-            isSelected={true}
             onPress={onOpen}
           />
         )}>

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
@@ -23,7 +23,7 @@ import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleCon
 import {useSoilIdOutput} from 'terraso-mobile-client/hooks/soilIdHooks';
 import {findSelectedMatch} from 'terraso-mobile-client/model/soilMetadata/soilMetadataFunctions';
 import {useSoilIdSelection} from 'terraso-mobile-client/model/soilMetadata/soilMetadataHooks';
-import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
+import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
 
@@ -55,7 +55,7 @@ export const SoilIdSelectionSection = ({
           />
         }
         trigger={onOpen => (
-          <SoilMatchTile
+          <SoilMatchCard
             soilName={selectedSoilMatch.soilInfo.soilSeries.name}
             dataRegion={dataRegion}
             score={

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchCard.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchCard.tsx
@@ -33,7 +33,7 @@ type Props = {
   onPress: () => void;
 };
 
-export const SoilMatchTile = ({
+export const SoilMatchCard = ({
   soilName,
   dataRegion,
   score,

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchCard.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchCard.tsx
@@ -25,71 +25,104 @@ import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches'
 import {getSoilNameDisplayText} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/globalSoilI18nFunctions';
 import {formatPercent} from 'terraso-mobile-client/util';
 
+export type SoilMatchCardVariant = 'Default' | 'Rejected' | 'Selected';
+
 type Props = {
+  variant?: SoilMatchCardVariant;
   soilName: string;
   dataRegion: DataRegion;
   score: number;
-  isSelected?: boolean;
   onPress: () => void;
 };
 
 export const SoilMatchCard = ({
+  variant = 'Default',
   soilName,
   dataRegion,
   score,
-  isSelected,
   onPress,
 }: Props) => {
   const {t, i18n} = useTranslation();
-
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityState={{disabled: !onPress}}
       onPress={onPress}>
       <Box
-        variant="tile"
+        variant={variant === 'Rejected' ? 'rejectedTile' : 'tile'}
         alignItems="center"
         flexDirection="row"
         justifyContent="space-between"
         my="4px"
         py="6px">
         <Box marginHorizontal="16px" width="84px" justifyContent="center">
-          {isSelected ? (
-            <Text
-              variant="match-tile-selected"
-              color="primary.lighter"
-              textAlign="center">
-              <TranslatedContent i18nKey="site.soil_id.matches.selected" />
-            </Text>
-          ) : (
-            <>
-              <Text
-                variant="match-tile-score"
-                color="primary.lighter"
-                textAlign="center">
-                <TranslatedContent
-                  i18nKey="site.soil_id.matches.match_score"
-                  values={{score: formatPercent(score)}}
-                />
-              </Text>
-              <Text
-                variant="body2"
-                color="primary.lighter"
-                textAlign="center"
-                mb="6px">
-                <TranslatedContent i18nKey="site.soil_id.matches.match" />
-              </Text>
-            </>
-          )}
+          <MatchAppraisalDisplayText variant={variant} score={score} />
         </Box>
         <Box flex={1} mr="12px" my="8px" flexDirection="row">
-          <Text variant="match-tile-name" color="primary.contrast">
+          <Text
+            variant="match-tile-name"
+            color={
+              variant === 'Rejected' ? 'text.primary' : 'primary.contrast'
+            }>
             {getSoilNameDisplayText(soilName, dataRegion, t, i18n)}
           </Text>
         </Box>
-        <Icon name="chevron-right" color="primary.contrast" mr="12px" />
+        <Chevron variant={variant} />
       </Box>
     </Pressable>
+  );
+};
+
+type MatchPercentDisplayProps = {
+  variant: SoilMatchCardVariant;
+  score: number;
+};
+
+const MatchAppraisalDisplayText = ({
+  variant,
+  score,
+}: MatchPercentDisplayProps) => {
+  if (variant === 'Selected') return <SelectedSoilDisplayText />;
+  else return <MatchPercentDisplayText variant={variant} score={score} />;
+};
+
+const Chevron = ({variant}: {variant: SoilMatchCardVariant}) => {
+  return (
+    <Icon
+      name="chevron-right"
+      color={variant === 'Rejected' ? 'text.primary' : 'primary.contrast'}
+      mr="12px"
+    />
+  );
+};
+
+const MatchPercentDisplayText = ({
+  variant,
+  score,
+}: MatchPercentDisplayProps) => {
+  const textColor = variant === 'Rejected' ? 'text.primary' : 'primary.lighter';
+  return (
+    <>
+      <Text variant="match-tile-score" color={textColor} textAlign="center">
+        <TranslatedContent
+          i18nKey="site.soil_id.matches.match_score"
+          values={{score: formatPercent(score)}}
+        />
+      </Text>
+      <Text variant="body2" color={textColor} textAlign="center" mb="6px">
+        <TranslatedContent i18nKey="site.soil_id.matches.match" />
+      </Text>
+    </>
+  );
+};
+
+const SelectedSoilDisplayText = () => {
+  return (
+    <Text
+      variant="match-tile-selected"
+      color="primary.lighter"
+      textAlign="center">
+      <TranslatedContent i18nKey="site.soil_id.matches.selected" />
+    </Text>
   );
 };

--- a/dev-client/src/theme.ts
+++ b/dev-client/src/theme.ts
@@ -47,6 +47,7 @@ export const theme = extendTheme({
       default: '#FFFFFF',
       secondary: '#00344D',
       tertiary: '#E0E0E0',
+      rejected: '#9AAFB9',
     },
     secondary: {
       main: '#C05621',
@@ -120,6 +121,10 @@ export const theme = extendTheme({
         tile: {
           borderRadius: '4px',
           backgroundColor: 'background.secondary',
+        },
+        rejectedTile: {
+          borderRadius: '4px',
+          backgroundColor: 'background.rejected',
         },
       },
     },


### PR DESCRIPTION
## Description
- Rename to SoilMatchCard
- Implement the Default, Rejected, and Selected variants of the SoilMatchCard per [design in Figma](https://www.figma.com/design/KMJbhjVyrrLFHj6jGcX9lN/LandPKS-Design-Prototype-working-file?node-id=7327-9259&t=lgutBmkw7JpsUXym-0)
- Most of the code changes are refactoring with extracting components

### Related Issues
Implements https://github.com/techmatters/terraso-mobile-client/issues/3048 

## Screenshots 
Default:
<img width="403" height="398" alt="Screenshot 2025-09-10 at 1 08 38 PM" src="https://github.com/user-attachments/assets/acb7b057-a6be-44a8-b37c-417d75a0fb79" />

Rejected:
<img width="405" height="392" alt="Screenshot 2025-09-10 at 1 08 55 PM" src="https://github.com/user-attachments/assets/94717b02-9d18-4bc9-96ab-cadfad958f94" />

Selected:
<img width="412" height="86" alt="Screenshot 2025-09-10 at 1 09 14 PM" src="https://github.com/user-attachments/assets/3b17eb6e-c2f7-4f7a-ab23-fc9b6cc4b933" />

