### PR TITLE
feat: bump client version to 1.3.2

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -83,7 +83,7 @@ if (typeof APP_BUILD === 'string') {
 const defaultConfig: ExpoConfig = {
   name: 'LandPKS Soil ID',
   slug: 'landpks',
-  version: '1.3.1',
+  version: '1.3.2',
   orientation: 'portrait',
   splash: {
     image: 'src/assets/splash.png',

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LandPKS Soil ID",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LandPKS Soil ID",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@craftzdog/react-native-buffer": "^6.0.5",
         "@expo/vector-icons": "^14.1.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LandPKS Soil ID",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "android": "expo run:android",


### PR DESCRIPTION
## Description
The [iOS release build for v257beta failed ](https://github.com/techmatters/terraso-mobile-client/actions/runs/17772608093/job/50512353334#step:9:94) because the version had not yet been bumped from the last publicly approved version (1.3.1). So bump to 1.3.2.