### PR TITLE
fix: send English coodinates to elevation API

### DIFF
--- a/dev-client/src/model/elevation/elevationService.ts
+++ b/dev-client/src/model/elevation/elevationService.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {formatCoordinate} from 'terraso-mobile-client/util';
+import {formatCoordinateInEnglish} from 'terraso-mobile-client/util';
 
 export const getElevation = async (
   lat: number,
@@ -24,8 +24,8 @@ export const getElevation = async (
   // TypeScript requires values passed to URLSearchParams to be strings,
   // which is why we convert the floats to strings.
   const queryString = new URLSearchParams({
-    longitude: formatCoordinate(lng),
-    latitude: formatCoordinate(lat),
+    longitude: formatCoordinateInEnglish(lng),
+    latitude: formatCoordinateInEnglish(lat),
   });
   let elevation;
 

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -56,6 +56,12 @@ export const formatCoordinate = (value: number) => {
   });
 };
 
+export const formatCoordinateInEnglish = (value: number) => {
+  return value.toLocaleString('en-US', {
+    maximumFractionDigits: COORDINATE_PRECISION,
+  });
+};
+
 export const formatName = (firstName: string, lastName?: string) => {
   return [lastName, firstName].filter(Boolean).join(', ');
 };


### PR DESCRIPTION
Using Ukrainian localization, decimal separators are commas. So when our language was set to Ukrainian, instead of 
`https://api.open-meteo.com/v1/elevation/?longitude=103.9&latitude=43`
we'd send
`https://api.open-meteo.com/v1/elevation/?longitude=103%2C9&latitude=43`
to the elevation API, and it would return `undefined` instead of the actual elevation. 

Fix this by always sending the coordinates to the API with English localization (but still display everything to the user with proper localization). 


### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/3061 



