### PR TITLE
feat: new UI for enhanced soil select experience

### DIFF
--- a/dev-client/src/components/FeatureFlagControl.tsx
+++ b/dev-client/src/components/FeatureFlagControl.tsx
@@ -54,6 +54,8 @@ export const FeatureFlagControlPanel = () => {
                   <FeatureFlagControl flag="FF_offline" />
                   <View style={styles.spacer} />
                   <FeatureFlagControl flag="FF_testing" />
+                  <View style={styles.spacer} />
+                  <FeatureFlagControl flag="FF_select_soil" />
                   <Divider />
                 </ScreenContentSection>
               </ScrollView>

--- a/dev-client/src/components/buttons/Fab.tsx
+++ b/dev-client/src/components/buttons/Fab.tsx
@@ -21,32 +21,54 @@ import {Surface} from 'react-native-paper';
 import {ContainedButton} from 'terraso-mobile-client/components/buttons/ContainedButton';
 import {IconName} from 'terraso-mobile-client/components/icons/Icon';
 
+type Positioning = 'BottomRight' | 'BottomCenter';
+
 export type FabProps = {
   label: string;
   leftIcon?: IconName;
   disabled?: boolean;
   onPress?: PressableProps['onPress'];
+  poisitioning?: Positioning;
 };
 
-export const Fab = ({label, leftIcon, disabled, onPress}: FabProps) => (
-  <Surface style={styles.surface} elevation={2}>
-    <ContainedButton
-      label={label}
-      leftIcon={leftIcon}
-      disabled={disabled}
-      size="lg"
-      onPress={onPress}
-    />
-  </Surface>
-);
+export const Fab = ({
+  label,
+  leftIcon,
+  disabled,
+  onPress,
+  poisitioning = 'BottomRight',
+}: FabProps) => {
+  const surfacePositionStyle =
+    poisitioning === 'BottomCenter'
+      ? styles.surfaceBottomCenter
+      : styles.surfaceBottomRight;
+
+  return (
+    <Surface style={[styles.surface, surfacePositionStyle]} elevation={2}>
+      <ContainedButton
+        label={label}
+        leftIcon={leftIcon}
+        disabled={disabled}
+        size="lg"
+        onPress={onPress}
+      />
+    </Surface>
+  );
+};
 
 const styles = StyleSheet.create({
   surface: {
     position: 'absolute',
     margin: 16,
-    right: 0,
-    bottom: 0,
     backgroundColor: 'transparent',
     borderRadius: 4,
+  },
+  surfaceBottomRight: {
+    bottom: 0,
+    right: 0,
+  },
+  surfaceBottomCenter: {
+    bottom: 0,
+    alignSelf: 'center',
   },
 });

--- a/dev-client/src/config/featureFlags.ts
+++ b/dev-client/src/config/featureFlags.ts
@@ -32,6 +32,11 @@ export const featureFlags = {
     defaultIsEnabledInDevelopment: true,
     description: 'Enables testing-support controls',
   },
+  FF_select_soil: {
+    defaultIsEnabled: false,
+    defaultIsEnabledInDevelopment: true,
+    description: 'Enhanced soil selection (terraso-product#658)',
+  },
 };
 
 export type FeatureFlagName = keyof typeof featureFlags;

--- a/dev-client/src/navigation/screenDefinitions.tsx
+++ b/dev-client/src/navigation/screenDefinitions.tsx
@@ -28,6 +28,7 @@ import {CreateProjectScreen} from 'terraso-mobile-client/screens/CreateProjectSc
 import {CreateSiteScreen} from 'terraso-mobile-client/screens/CreateSiteScreen/CreateSiteScreen';
 import {DeleteAccountScreen} from 'terraso-mobile-client/screens/DeleteAccountScreen/DeleteAccountScreen';
 import {EditPinnedNoteScreen} from 'terraso-mobile-client/screens/EditPinnedNoteScreen';
+import {SoilMatchInfoScreen} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen';
 import {SiteLocationSoilIdScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteLocationSoilIdScreen';
 import {SiteTabsScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteTabsScreen';
 import {TemporaryLocationScreen} from 'terraso-mobile-client/screens/LocationScreens/TemporaryLocationScreen';
@@ -80,6 +81,7 @@ export const screenDefinitions = {
   SITE_TABS: SiteTabsScreen,
   SITE_LOCATION_SOIL_ID: SiteLocationSoilIdScreen,
   TEMPORARY_LOCATION_SOIL_ID: TemporaryLocationSoilIdScreen,
+  SOIL_MATCH_INFO: SoilMatchInfoScreen,
   SITE_SETTINGS: SiteSettingsScreen,
   SITE_TEAM_SETTINGS: SiteTeamSettingsScreen,
   ADD_USER_PROJECT: AddUserToProjectScreen,

--- a/dev-client/src/navigation/screenDefinitions.tsx
+++ b/dev-client/src/navigation/screenDefinitions.tsx
@@ -28,7 +28,10 @@ import {CreateProjectScreen} from 'terraso-mobile-client/screens/CreateProjectSc
 import {CreateSiteScreen} from 'terraso-mobile-client/screens/CreateSiteScreen/CreateSiteScreen';
 import {DeleteAccountScreen} from 'terraso-mobile-client/screens/DeleteAccountScreen/DeleteAccountScreen';
 import {EditPinnedNoteScreen} from 'terraso-mobile-client/screens/EditPinnedNoteScreen';
-import {SoilMatchInfoScreen} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen';
+import {
+  SiteSoilMatchInfoScreen,
+  TemporaryLocationSoilMatchInfoScreen,
+} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen';
 import {SiteLocationSoilIdScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteLocationSoilIdScreen';
 import {SiteTabsScreen} from 'terraso-mobile-client/screens/LocationScreens/SiteTabsScreen';
 import {TemporaryLocationScreen} from 'terraso-mobile-client/screens/LocationScreens/TemporaryLocationScreen';
@@ -81,7 +84,8 @@ export const screenDefinitions = {
   SITE_TABS: SiteTabsScreen,
   SITE_LOCATION_SOIL_ID: SiteLocationSoilIdScreen,
   TEMPORARY_LOCATION_SOIL_ID: TemporaryLocationSoilIdScreen,
-  SOIL_MATCH_INFO: SoilMatchInfoScreen,
+  TEMP_LOCATION_SOIL_MATCH_INFO: TemporaryLocationSoilMatchInfoScreen,
+  SITE_SOIL_MATCH_INFO: SiteSoilMatchInfoScreen,
   SITE_SETTINGS: SiteSettingsScreen,
   SITE_TEAM_SETTINGS: SiteTeamSettingsScreen,
   ADD_USER_PROJECT: AddUserToProjectScreen,

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -88,14 +88,18 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
   const onMatchCardPress = useCallback(
     (soilMatch: SoilMatch) => {
       if (isSite) {
-        navigation.navigate('SOIL_MATCH_INFO', {
+        navigation.navigate('SITE_SOIL_MATCH_INFO', {
           siteId,
           coords,
           soilMatch,
           dataRegion,
         });
       } else {
-        // TODO-cknipe
+        navigation.navigate('TEMP_LOCATION_SOIL_MATCH_INFO', {
+          coords,
+          soilMatch,
+          dataRegion,
+        });
       }
     },
     [siteId, isSite, coords, dataRegion, navigation],

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -41,6 +41,7 @@ import {NoMapDataWarningAlert} from 'terraso-mobile-client/screens/LocationScree
 import {OfflineAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/OfflineAlert';
 import {SoilMatchesErrorAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/SoilMatchesErrorAlert';
 import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
+import {RateSoilMatchFabWithSheet} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
 import {TempScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/TempScoreInfoContent';
@@ -119,6 +120,7 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
                 siteMatch={siteMatch}
               />
             </SiteRoleContextProvider>
+            <RateSoilMatchFabWithSheet />
           </InfoSheet>
         ));
       } else {

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -40,7 +40,7 @@ import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigatio
 import {NoMapDataWarningAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/NoMapDataWarningAlert';
 import {OfflineAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/OfflineAlert';
 import {SoilMatchesErrorAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/SoilMatchesErrorAlert';
-import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
+import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
 import {TopSoilMatchesInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/TopSoilMatchesInfoContent';
 
 type SoilIdMatchesSectionProps = {siteId?: string; coords: Coords};
@@ -85,7 +85,7 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
   const dataRegion = soilIdOutput.dataRegion;
   const isSite = !!siteId;
 
-  const onMatchCardPress = useCallback(
+  const onMatchTilePress = useCallback(
     (soilMatch: SoilMatch) => {
       if (isSite) {
         navigation.navigate('SITE_SOIL_MATCH_INFO', {
@@ -110,14 +110,14 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
       return isOffline ? <></> : <ActivityIndicator size="small" />;
     case 'ready': {
       return getSortedMatches(soilIdOutput.matches).map(soilMatch => (
-        <SoilMatchCard
+        <SoilMatchTile
           key={soilMatch.soilInfo.soilSeries.name}
           soilName={soilMatch.soilInfo.soilSeries.name}
           dataRegion={dataRegion}
           score={
             soilMatch.combinedMatch?.score ?? soilMatch.locationMatch.score
           }
-          onPress={() => onMatchCardPress(soilMatch)}
+          onPress={() => onMatchTilePress(soilMatch)}
         />
       ));
     }

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -14,10 +14,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-
+import {useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {ActivityIndicator} from 'react-native-paper';
 
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import {InfoButton} from 'terraso-mobile-client/components/buttons/icons/common/InfoButton';
@@ -29,22 +30,17 @@ import {
   Row,
 } from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {RestrictByConnectivity} from 'terraso-mobile-client/components/restrictions/RestrictByConnectivity';
-import {InfoSheet} from 'terraso-mobile-client/components/sheets/InfoSheet';
-import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 import {
   SoilIdOutput,
   useSoilIdOutput,
 } from 'terraso-mobile-client/hooks/soilIdHooks';
 import {getSortedMatches} from 'terraso-mobile-client/model/soilIdMatch/soilIdRanking';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {NoMapDataWarningAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/NoMapDataWarningAlert';
 import {OfflineAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/OfflineAlert';
 import {SoilMatchesErrorAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/SoilMatchesErrorAlert';
 import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
-import {RateSoilMatchFabWithSheet} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet';
-import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
-import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
-import {TempScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/TempScoreInfoContent';
 import {TopSoilMatchesInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/TopSoilMatchesInfoContent';
 
 type SoilIdMatchesSectionProps = {siteId?: string; coords: Coords};
@@ -54,6 +50,7 @@ export const SoilIdMatchesSection = ({
   coords,
 }: SoilIdMatchesSectionProps) => {
   const {t} = useTranslation();
+
   const soilIdInput = siteId ? {siteId} : {coords};
   const soilIdOutput = useSoilIdOutput(soilIdInput);
   const dataRegion = soilIdOutput.dataRegion;
@@ -82,73 +79,43 @@ export const SoilIdMatchesSection = ({
 type MatchTilesProps = SoilIdMatchesSectionProps & {soilIdOutput: SoilIdOutput};
 
 const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
+  const navigation = useNavigation();
   const isOffline = useIsOffline();
   const status = soilIdOutput.status;
   const dataRegion = soilIdOutput.dataRegion;
   const isSite = !!siteId;
 
+  const onMatchCardPress = useCallback(
+    (soilMatch: SoilMatch) => {
+      if (isSite) {
+        navigation.navigate('SOIL_MATCH_INFO', {
+          siteId,
+          coords,
+          soilMatch,
+          dataRegion,
+        });
+      } else {
+        // TODO-cknipe
+      }
+    },
+    [siteId, isSite, coords, dataRegion, navigation],
+  );
+
   switch (status) {
     case 'loading':
       return isOffline ? <></> : <ActivityIndicator size="small" />;
     case 'ready': {
-      if (isSite) {
-        return getSortedMatches(soilIdOutput.matches).map(siteMatch => (
-          <InfoSheet
-            key={siteMatch.soilInfo.soilSeries.name}
-            heading={
-              <SoilNameHeading
-                soilName={siteMatch.soilInfo.soilSeries.name}
-                dataRegion={dataRegion}
-              />
-            }
-            trigger={onOpen => (
-              <SoilMatchCard
-                soilName={siteMatch.soilInfo.soilSeries.name}
-                dataRegion={dataRegion}
-                score={
-                  siteMatch.combinedMatch?.score ??
-                  siteMatch.locationMatch.score
-                }
-                onPress={onOpen}
-              />
-            )}>
-            <SiteRoleContextProvider siteId={siteId}>
-              <SiteScoreInfoContent
-                siteId={siteId}
-                coords={coords}
-                dataRegion={dataRegion}
-                siteMatch={siteMatch}
-              />
-            </SiteRoleContextProvider>
-            <RateSoilMatchFabWithSheet />
-          </InfoSheet>
-        ));
-      } else {
-        return getSortedMatches(soilIdOutput.matches).map(locationMatch => (
-          <InfoSheet
-            key={locationMatch.soilInfo.soilSeries.name}
-            heading={
-              <SoilNameHeading
-                soilName={locationMatch.soilInfo.soilSeries.name}
-                dataRegion={dataRegion}
-              />
-            }
-            trigger={onOpen => (
-              <SoilMatchCard
-                soilName={locationMatch.soilInfo.soilSeries.name}
-                dataRegion={dataRegion}
-                score={locationMatch.locationMatch.score}
-                onPress={onOpen}
-              />
-            )}>
-            <TempScoreInfoContent
-              coords={coords}
-              dataRegion={dataRegion}
-              tempLocationMatch={locationMatch}
-            />
-          </InfoSheet>
-        ));
-      }
+      return getSortedMatches(soilIdOutput.matches).map(soilMatch => (
+        <SoilMatchCard
+          key={soilMatch.soilInfo.soilSeries.name}
+          soilName={soilMatch.soilInfo.soilSeries.name}
+          dataRegion={dataRegion}
+          score={
+            soilMatch.combinedMatch?.score ?? soilMatch.locationMatch.score
+          }
+          onPress={() => onMatchCardPress(soilMatch)}
+        />
+      ));
     }
     case 'DATA_UNAVAILABLE':
       return <NoMapDataWarningAlert />;

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
@@ -25,7 +25,7 @@ import {useSoilIdOutput} from 'terraso-mobile-client/hooks/soilIdHooks';
 import {findSelectedMatch} from 'terraso-mobile-client/model/soilMetadata/soilMetadataFunctions';
 import {useSoilIdSelection} from 'terraso-mobile-client/model/soilMetadata/soilMetadataHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
-import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
+import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
 
 type SoilIdSelectionSectionProps = {siteId: string; coords: Coords};
 
@@ -42,7 +42,7 @@ export const SoilIdSelectionSection = ({
   );
   const dataRegion = soilIdOutput.dataRegion;
 
-  const onMatchCardPress = useCallback(
+  const onMatchTilePress = useCallback(
     (soilMatch: SoilMatch) => {
       navigation.navigate('SITE_SOIL_MATCH_INFO', {
         siteId,
@@ -59,7 +59,7 @@ export const SoilIdSelectionSection = ({
   }
   return (
     <ScreenContentSection backgroundColor="grey.200">
-      <SoilMatchCard
+      <SoilMatchTile
         variant="Selected"
         soilName={selectedSoilMatch.soilInfo.soilSeries.name}
         dataRegion={dataRegion}
@@ -67,7 +67,7 @@ export const SoilIdSelectionSection = ({
           selectedSoilMatch.combinedMatch?.score ??
           selectedSoilMatch.locationMatch.score
         }
-        onPress={() => onMatchCardPress(selectedSoilMatch)}
+        onPress={() => onMatchTilePress(selectedSoilMatch)}
       />
     </ScreenContentSection>
   );

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
@@ -15,17 +15,17 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {useCallback} from 'react';
+
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
 import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
-import {InfoSheet} from 'terraso-mobile-client/components/sheets/InfoSheet';
-import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
 import {useSoilIdOutput} from 'terraso-mobile-client/hooks/soilIdHooks';
 import {findSelectedMatch} from 'terraso-mobile-client/model/soilMetadata/soilMetadataFunctions';
 import {useSoilIdSelection} from 'terraso-mobile-client/model/soilMetadata/soilMetadataHooks';
+import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
 import {SoilMatchCard} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchCard';
-import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
-import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
 
 type SoilIdSelectionSectionProps = {siteId: string; coords: Coords};
 
@@ -33,6 +33,7 @@ export const SoilIdSelectionSection = ({
   siteId,
   coords,
 }: SoilIdSelectionSectionProps) => {
+  const navigation = useNavigation();
   const soilIdOutput = useSoilIdOutput({siteId});
   const {selectedSoilId} = useSoilIdSelection(siteId);
   const selectedSoilMatch = findSelectedMatch(
@@ -41,40 +42,33 @@ export const SoilIdSelectionSection = ({
   );
   const dataRegion = soilIdOutput.dataRegion;
 
+  const onMatchCardPress = useCallback(
+    (soilMatch: SoilMatch) => {
+      navigation.navigate('SOIL_MATCH_INFO', {
+        siteId,
+        coords,
+        soilMatch,
+        dataRegion,
+      });
+    },
+    [siteId, coords, dataRegion, navigation],
+  );
+
   if (!selectedSoilMatch) {
     return <></>;
   }
-
   return (
     <ScreenContentSection backgroundColor="grey.200">
-      <InfoSheet
-        heading={
-          <SoilNameHeading
-            soilName={selectedSoilMatch.soilInfo.soilSeries.name}
-            dataRegion={dataRegion}
-          />
+      <SoilMatchCard
+        variant="Selected"
+        soilName={selectedSoilMatch.soilInfo.soilSeries.name}
+        dataRegion={dataRegion}
+        score={
+          selectedSoilMatch.combinedMatch?.score ??
+          selectedSoilMatch.locationMatch.score
         }
-        trigger={onOpen => (
-          <SoilMatchCard
-            variant="Selected"
-            soilName={selectedSoilMatch.soilInfo.soilSeries.name}
-            dataRegion={dataRegion}
-            score={
-              selectedSoilMatch.combinedMatch?.score ??
-              selectedSoilMatch.locationMatch.score
-            }
-            onPress={onOpen}
-          />
-        )}>
-        <SiteRoleContextProvider siteId={siteId}>
-          <SiteScoreInfoContent
-            siteId={siteId}
-            coords={coords}
-            dataRegion={soilIdOutput.dataRegion}
-            siteMatch={selectedSoilMatch}
-          />
-        </SiteRoleContextProvider>
-      </InfoSheet>
+        onPress={() => onMatchCardPress(selectedSoilMatch)}
+      />
     </ScreenContentSection>
   );
 };

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdSelectionSection.tsx
@@ -44,7 +44,7 @@ export const SoilIdSelectionSection = ({
 
   const onMatchCardPress = useCallback(
     (soilMatch: SoilMatch) => {
-      navigation.navigate('SOIL_MATCH_INFO', {
+      navigation.navigate('SITE_SOIL_MATCH_INFO', {
         siteId,
         coords,
         soilMatch,

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilMatchTile.tsx
@@ -25,17 +25,17 @@ import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches'
 import {getSoilNameDisplayText} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/globalSoilI18nFunctions';
 import {formatPercent} from 'terraso-mobile-client/util';
 
-export type SoilMatchCardVariant = 'Default' | 'Rejected' | 'Selected';
+export type SoilMatchTileVariant = 'Default' | 'Rejected' | 'Selected';
 
 type Props = {
-  variant?: SoilMatchCardVariant;
+  variant?: SoilMatchTileVariant;
   soilName: string;
   dataRegion: DataRegion;
   score: number;
   onPress: () => void;
 };
 
-export const SoilMatchCard = ({
+export const SoilMatchTile = ({
   variant = 'Default',
   soilName,
   dataRegion,
@@ -74,7 +74,7 @@ export const SoilMatchCard = ({
 };
 
 type MatchPercentDisplayProps = {
-  variant: SoilMatchCardVariant;
+  variant: SoilMatchTileVariant;
   score: number;
 };
 
@@ -86,7 +86,7 @@ const MatchAppraisalDisplayText = ({
   else return <MatchPercentDisplayText variant={variant} score={score} />;
 };
 
-const Chevron = ({variant}: {variant: SoilMatchCardVariant}) => {
+const Chevron = ({variant}: {variant: SoilMatchTileVariant}) => {
   return (
     <Icon
       name="chevron-right"

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2025 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {StyleSheet, View} from 'react-native';
+
+import {Fab} from 'terraso-mobile-client/components/buttons/Fab';
+import {TranslatedParagraph} from 'terraso-mobile-client/components/content/typography/TranslatedParagraph';
+import {TranslatedSubHeading} from 'terraso-mobile-client/components/content/typography/TranslatedSubHeading';
+import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {RadioBlock} from 'terraso-mobile-client/components/RadioBlock';
+import {FormOverlaySheet} from 'terraso-mobile-client/components/sheets/FormOverlaySheet';
+import {theme} from 'terraso-mobile-client/theme';
+
+type MatchRating = 'YES' | 'NO' | 'UNSURE';
+export const RateSoilMatchFabWithSheet = () => {
+  const {t} = useTranslation();
+  let matchRating = 'UNSURE' as MatchRating;
+
+  // TODO-cknipe: Do a real thing
+  const todo = (value: MatchRating) => {
+    console.log('swtiched to: ', value);
+  };
+  return (
+    <FormOverlaySheet
+      trigger={onOpen => (
+        // TODO-cknipe: Why doesn't it float?
+        // Compare to slope steepness, but that's not a bottomsheet
+        <View>
+          <Fab label={t('site.soil_id.matches.rate.fab')} onPress={onOpen} />
+        </View>
+      )}>
+      <View style={rateSoilStyles.contentView}>
+        <TranslatedSubHeading i18nKey="site.soil_id.matches.rate.title" />
+        <Box height="md" />
+        <TranslatedParagraph i18nKey="site.soil_id.matches.rate.description" />
+
+        <RadioBlock
+          options={{
+            YES: {text: t('site.soil_id.matches.rate.yes')},
+            NO: {text: t('site.soil_id.matches.rate.no')},
+            UNSURE: {text: t('site.soil_id.matches.rate.unsure')},
+          }}
+          groupProps={{
+            value: matchRating,
+            name: 'match-rating',
+            onChange: todo,
+          }}
+        />
+      </View>
+    </FormOverlaySheet>
+  );
+};
+
+export const rateSoilStyles = StyleSheet.create({
+  contentView: {
+    padding: theme.space.md,
+  },
+});

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
@@ -32,8 +32,8 @@ export const RateSoilMatchFabWithSheet = () => {
   let matchRating = 'UNSURE' as MatchRating;
 
   // TODO-cknipe: Do a real thing
-  const todo = (value: MatchRating) => {
-    console.log('swtiched to: ', value);
+  const onMatchRatingChanged = (value: MatchRating) => {
+    console.log('switched to: ', value);
   };
 
   return (
@@ -60,7 +60,7 @@ export const RateSoilMatchFabWithSheet = () => {
           groupProps={{
             value: matchRating,
             name: 'match-rating',
-            onChange: todo,
+            onChange: onMatchRatingChanged,
           }}
         />
       </View>

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
@@ -39,13 +39,11 @@ export const RateSoilMatchFabWithSheet = () => {
   return (
     <FormOverlaySheet
       trigger={onOpen => (
-        <View>
-          <Fab
-            label={t('site.soil_id.matches.rate.fab')}
-            onPress={onOpen}
-            poisitioning="BottomCenter"
-          />
-        </View>
+        <Fab
+          label={t('site.soil_id.matches.rate.fab')}
+          onPress={onOpen}
+          poisitioning="BottomCenter"
+        />
       )}>
       <View style={styles.contentView}>
         <TranslatedSubHeading i18nKey="site.soil_id.matches.rate.title" />

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet.tsx
@@ -35,20 +35,22 @@ export const RateSoilMatchFabWithSheet = () => {
   const todo = (value: MatchRating) => {
     console.log('swtiched to: ', value);
   };
+
   return (
     <FormOverlaySheet
       trigger={onOpen => (
-        // TODO-cknipe: Why doesn't it float?
-        // Compare to slope steepness, but that's not a bottomsheet
         <View>
-          <Fab label={t('site.soil_id.matches.rate.fab')} onPress={onOpen} />
+          <Fab
+            label={t('site.soil_id.matches.rate.fab')}
+            onPress={onOpen}
+            poisitioning="BottomCenter"
+          />
         </View>
       )}>
-      <View style={rateSoilStyles.contentView}>
+      <View style={styles.contentView}>
         <TranslatedSubHeading i18nKey="site.soil_id.matches.rate.title" />
         <Box height="md" />
         <TranslatedParagraph i18nKey="site.soil_id.matches.rate.description" />
-
         <RadioBlock
           options={{
             YES: {text: t('site.soil_id.matches.rate.yes')},
@@ -66,7 +68,7 @@ export const RateSoilMatchFabWithSheet = () => {
   );
 };
 
-export const rateSoilStyles = StyleSheet.create({
+const styles = StyleSheet.create({
   contentView: {
     padding: theme.space.md,
   },

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent.tsx
@@ -20,6 +20,8 @@ import {Divider} from 'react-native-paper';
 import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
 import {Coords} from 'terraso-client-shared/types';
 
+import {Box} from 'terraso-mobile-client/components/NativeBaseAdapters';
+import {isFlagEnabled} from 'terraso-mobile-client/config/featureFlags';
 import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
 import {LocationScoreDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/LocationScoreDisplay';
 import {PropertiesDisplay} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/PropertiesDisplay';
@@ -65,7 +67,11 @@ export function SiteScoreInfoContent({
       ) : (
         <PropertiesDisplay match={siteMatch} />
       )}
-      <SoilIdMatchSelector siteId={siteId} match={siteMatch} />
+      {isFlagEnabled('FF_select_soil') ? (
+        <Box height="16px" />
+      ) : (
+        <SoilIdMatchSelector siteId={siteId} match={siteMatch} />
+      )}
     </ScoreInfoContainer>
   );
 }

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen.tsx
@@ -34,6 +34,7 @@ import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {RateSoilMatchFabWithSheet} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet';
 import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
 import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
+import {TempScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/TempScoreInfoContent';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {useSelector} from 'terraso-mobile-client/store';
 import {selectSite} from 'terraso-mobile-client/store/selectors';
@@ -43,24 +44,41 @@ type ScreenPropsForTempLocation = {
   soilMatch: SoilMatch;
   dataRegion: DataRegion;
 };
-
 type ScreenPropsForSite = {siteId: string} & ScreenPropsForTempLocation;
 
-// TODO-cknipe: Support site + temp location
-// That might weird out the requirements? Maybe make separate components?
-// const GeneralSoilMatchInfoScreenWrapper =
-// export const SiteSoilMatchInfoScreen =
-// export const TempLocationSoilMatchInfoScreen = ({
+export const TemporaryLocationSoilMatchInfoScreen = ({
+  coords,
+  soilMatch,
+  dataRegion,
+}: ScreenPropsForTempLocation) => {
+  const {t} = useTranslation();
 
-export const SoilMatchInfoScreen = ({
+  return (
+    <ScreenScaffold
+      AppBar={<AppBar title={t('site.dashboard.default_title')} />}>
+      <ScrollView>
+        <ScreenContentSection>
+          <SoilNameHeading
+            soilName={soilMatch.soilInfo.soilSeries.name}
+            dataRegion={dataRegion}
+          />
+          <TempScoreInfoContent
+            coords={coords}
+            dataRegion={dataRegion}
+            tempLocationMatch={soilMatch}
+          />
+        </ScreenContentSection>
+      </ScrollView>
+    </ScreenScaffold>
+  );
+};
+
+export const SiteSoilMatchInfoScreen = ({
   siteId,
   coords,
   soilMatch,
   dataRegion,
 }: ScreenPropsForSite) => {
-  const {t} = useTranslation();
-
-  // TODO-cknipe: Does this work for temp loc?
   const site = useSelector(state => selectSite(siteId)(state)) ?? undefined;
 
   const handleMissingSite = useNavToBottomTabsAndShowSyncError();
@@ -71,10 +89,7 @@ export const SoilMatchInfoScreen = ({
   return (
     <ScreenDataRequirements requirements={requirements}>
       {() => (
-        <ScreenScaffold
-          AppBar={
-            <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
-          }>
+        <ScreenScaffold AppBar={<AppBar title={site.name} />}>
           <ScrollView>
             <ScreenContentSection>
               <SoilNameHeading

--- a/dev-client/src/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilInfo/SoilMatchInfoScreen.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {ScrollView} from 'react-native-gesture-handler';
+
+import {SoilMatch} from 'terraso-client-shared/graphqlSchema/graphql';
+import {Coords} from 'terraso-client-shared/types';
+
+import {ScreenContentSection} from 'terraso-mobile-client/components/content/ScreenContentSection';
+import {useNavToBottomTabsAndShowSyncError} from 'terraso-mobile-client/components/dataRequirements/handleMissingData';
+import {
+  ScreenDataRequirements,
+  useMemoizedRequirements,
+} from 'terraso-mobile-client/components/dataRequirements/ScreenDataRequirements';
+import {RestrictByFlag} from 'terraso-mobile-client/components/restrictions/RestrictByFlag';
+import {SiteRoleContextProvider} from 'terraso-mobile-client/context/SiteRoleContext';
+import {DataRegion} from 'terraso-mobile-client/model/soilIdMatch/soilIdMatches';
+import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
+import {RateSoilMatchFabWithSheet} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/RateSoilMatchFormSheet';
+import {SiteScoreInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SiteScoreInfoContent';
+import {SoilNameHeading} from 'terraso-mobile-client/screens/LocationScreens/components/soilInfo/SoilNameHeading';
+import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
+import {useSelector} from 'terraso-mobile-client/store';
+import {selectSite} from 'terraso-mobile-client/store/selectors';
+
+type ScreenPropsForTempLocation = {
+  coords: Coords;
+  soilMatch: SoilMatch;
+  dataRegion: DataRegion;
+};
+
+type ScreenPropsForSite = {siteId: string} & ScreenPropsForTempLocation;
+
+// TODO-cknipe: Support site + temp location
+// That might weird out the requirements? Maybe make separate components?
+// const GeneralSoilMatchInfoScreenWrapper =
+// export const SiteSoilMatchInfoScreen =
+// export const TempLocationSoilMatchInfoScreen = ({
+
+export const SoilMatchInfoScreen = ({
+  siteId,
+  coords,
+  soilMatch,
+  dataRegion,
+}: ScreenPropsForSite) => {
+  const {t} = useTranslation();
+
+  // TODO-cknipe: Does this work for temp loc?
+  const site = useSelector(state => selectSite(siteId)(state)) ?? undefined;
+
+  const handleMissingSite = useNavToBottomTabsAndShowSyncError();
+  const requirements = useMemoizedRequirements([
+    {data: site, doIfMissing: handleMissingSite},
+  ]);
+
+  return (
+    <ScreenDataRequirements requirements={requirements}>
+      {() => (
+        <ScreenScaffold
+          AppBar={
+            <AppBar title={site?.name ?? t('site.dashboard.default_title')} />
+          }>
+          <ScrollView>
+            <ScreenContentSection>
+              <SoilNameHeading
+                soilName={soilMatch.soilInfo.soilSeries.name}
+                dataRegion={dataRegion}
+              />
+              <SiteRoleContextProvider siteId={siteId}>
+                <SiteScoreInfoContent
+                  siteId={siteId}
+                  coords={coords}
+                  dataRegion={dataRegion}
+                  siteMatch={soilMatch}
+                />
+              </SiteRoleContextProvider>
+            </ScreenContentSection>
+          </ScrollView>
+          <RestrictByFlag flag="FF_select_soil">
+            <RateSoilMatchFabWithSheet />
+          </RestrictByFlag>
+        </ScreenScaffold>
+      )}
+    </ScreenDataRequirements>
+  );
+};

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -126,6 +126,14 @@
                 "no_map_data_title": "No soil map data",
                 "no_map_data_body": "There is no soil map data available for this location, so LandPKS cannot generate soil matches. Observations can still be entered, and if soil map data becomes available in the future, soil matches will appear here.",
                 "offline": "Soil matches will update when you are online.",
+                "rate": {
+                    "fab": "Rate match",
+                    "title": "Rate this soil match",
+                    "description": "<bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons.",
+                    "yes": "Yes, select soil for this site",
+                    "no": "No, it's different",
+                    "unsure": "Not sure yet"
+                },
                 "selector": "This is the correct soil",
                 "selected": "Selected Soil"
             },

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -143,6 +143,14 @@
                         "learn_more_url": "https://landpks.terraso.org/what-is-soil-id-and-why-does-it-matter/"
                     }
                 },
+                "rate": {
+                    "fab": "TK Rate match",
+                    "title": "TK Rate this soil match",
+                    "description": "TK <bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons.",
+                    "yes": "TK Yes, select soil for this site",
+                    "no": "TK No, it's different",
+                    "unsure": "TK Not sure yet"
+                },
                 "match": "coincidencia",
                 "error_generic_title": "No se puede obtener el mapa del suelo",
                 "error_generic_body": "LandPKS no ha podido obtener el mapa de suelos de esta ubicación. Intente detener y reiniciar la aplicación. Si el problema continúa, vuelva a intentarlo más tarde o envíe una solicitud de soporte a través del sitio web landpks.terraso.org.",

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -143,6 +143,14 @@
             "learn_more_url": "https://landpks.terraso.org/what-is-soil-id-and-why-does-it-matter/"
           }
         },
+        "rate": {
+          "fab": "TK Rate match",
+          "title": "TK Rate this soil match",
+          "description": "TK <bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons.",
+          "yes": "TK Yes, select soil for this site",
+          "no": "TK No, it's different",
+          "unsure": "TK Not sure yet"
+        },
         "match": "співпадати / відповідати чомусь",
         "error_generic_title": "Не вдається отримати ґрунтову карту",
         "error_generic_body": "LandPKS не зміг отримати карту ґрунту для цього місця. Спробуйте зупинити та перезапустити програму. Якщо проблема не зникне, спробуйте пізніше або надішліть запит на підтримку через веб-сайт landpks.terraso.org.",


### PR DESCRIPTION
## Description
- Soil match info were InfoSheets, now are their own screens
- FAB should say "Rate match" and open the form overlay sheet
- Form overlay sheet has correct text and radio buttons that do nothing yet
- All -- except the change from InfoSheet to screen -- should be behind the "FF_select_soil" feature flag

### Related Issues
Implements https://github.com/techmatters/terraso-mobile-client/issues/3063

### Screenshots
<img width="406" height="765" alt="Screenshot 2025-09-18 at 12 19 20 PM" src="https://github.com/user-attachments/assets/9b1a2406-6426-4c6a-a464-ed54c506937e" />

Upon pressing "Rate match" button --> 
<img width="407" height="776" alt="Screenshot 2025-09-18 at 12 19 31 PM" src="https://github.com/user-attachments/assets/0998fe77-8da6-432b-b6df-99bbdad6b7d4" />

