### PR TITLE
fix: typo in depths confirmation dialog (has vs have)

### DIFF
--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -667,7 +667,7 @@
             "depth_end": "depth end",
             "update_modal": {
                 "title": "Change depth?",
-                "body": "Soil pit observations that has been entered at this depth will be deleted. This action can’t be undone.",
+                "body": "Soil pit observations that have been entered at this depth will be deleted. This action can’t be undone.",
                 "action": "Change"
             },
             "delete_modal": {


### PR DESCRIPTION
Fixes simple typo , see https://github.com/techmatters/terraso-product/issues/1354
