### PR TITLE
feat: localization for 1.3.2

### DIFF
--- a/dev-client/locales/po/en.po
+++ b/dev-client/locales/po/en.po
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-08-27T20:24:56.670Z\n"
-"PO-Revision-Date: 2025-08-27T20:24:56.670Z\n"
+"POT-Creation-Date: 2025-09-24T18:44:52.112Z\n"
+"PO-Revision-Date: 2025-09-24T18:44:52.113Z\n"
 
 msgid "welcome##title"
 msgstr "Welcome to LandPKS Soil ID"
@@ -312,6 +312,24 @@ msgstr "There is no soil map data available for this location, so LandPKS cannot
 
 msgid "site##soil_id##matches##offline"
 msgstr "Soil matches will update when you are online."
+
+msgid "site##soil_id##matches##rate##fab"
+msgstr "Rate match"
+
+msgid "site##soil_id##matches##rate##title"
+msgstr "Rate this soil match"
+
+msgid "site##soil_id##matches##rate##description"
+msgstr "<bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons."
+
+msgid "site##soil_id##matches##rate##yes"
+msgstr "Yes, select soil for this site"
+
+msgid "site##soil_id##matches##rate##no"
+msgstr "No, it's different"
+
+msgid "site##soil_id##matches##rate##unsure"
+msgstr "Not sure yet"
 
 msgid "site##soil_id##matches##selector"
 msgstr "This is the correct soil"
@@ -1442,7 +1460,10 @@ msgid "soil##soil_preset##CUSTOM"
 msgstr "Custom"
 
 msgid "soil##depth##add_title"
-msgstr "Add depth"
+msgstr "Add Depth"
+
+msgid "soil##depth##edit_title"
+msgstr "Depth Options"
 
 msgid "soil##depth##data_inputs_title"
 msgstr "Show/hide soil observations"
@@ -1475,7 +1496,7 @@ msgid "soil##depth##update_modal##title"
 msgstr "Change depth?"
 
 msgid "soil##depth##update_modal##body"
-msgstr "Soil pit observations that has been entered at this depth will be deleted. This action can’t be undone."
+msgstr "Soil pit observations that have been entered at this depth will be deleted. This action can’t be undone."
 
 msgid "soil##depth##update_modal##action"
 msgstr "Change"
@@ -3543,7 +3564,7 @@ msgid "slope##steepness##manual_label"
 msgstr "Manual"
 
 msgid "slope##steepness##manual_help"
-msgstr "Enter steepness percentage or degree:"
+msgstr "Enter Steepness Percentage or Degree"
 
 msgid "slope##steepness##confirm_title"
 msgstr "Change slope?"

--- a/dev-client/locales/po/es.po
+++ b/dev-client/locales/po/es.po
@@ -1946,7 +1946,7 @@ msgstr "A medida"
 
 #: 
 msgid "soil##depth##add_title"
-msgstr "Añadir produndidad"
+msgstr "Añadir profundidad"
 
 #: 
 msgid "soil##depth##data_inputs_title"
@@ -4915,4 +4915,38 @@ msgstr "https://terraso.org/terms-of-service/"
 #: 
 msgid "general##terms_of_service_link_text"
 msgstr "Condiciones de servicio"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##fab"
+msgstr "Rate match TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##title"
+msgstr "Rate this soil match TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##description"
+msgstr "<bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons. TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##yes"
+msgstr "Yes, select soil for this site TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##no"
+msgstr "No, it's different TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##unsure"
+msgstr "Not sure yet TK"
+
+#: 
+msgid "soil##depth##edit_title"
+msgstr "Opciones de profundidad"
 

--- a/dev-client/locales/po/uk.po
+++ b/dev-client/locales/po/uk.po
@@ -202,7 +202,7 @@ msgstr "NRCS/GSP"
 
 #: 
 msgid "projects##inputs##depths##preset##BLM"
-msgstr "BLM - Bureau of Land Management - Стандарт моніторингу BLM, офіційно затверджені методики та критерії, які використовуються для Моніторингу земель"
+msgstr "Методичні документи і протоколи Бюро з управління землями США"
 
 #: 
 msgid "projects##inputs##depths##preset##CUSTOM"
@@ -242,7 +242,7 @@ msgstr "Додати ділянки"
 
 #: 
 msgid "projects##sites##transfer"
-msgstr "Ділянки, на які поширюють або переносить результати з еталонних/базових ділянок"
+msgstr "Сайти для перенесення даних"
 
 #: 
 msgid "projects##sites##create"
@@ -434,7 +434,7 @@ msgstr "висота"
 
 #: 
 msgid "geo##elevation##title"
-msgstr "Висота над рівнем моря"
+msgstr "Висота н.р.м."
 
 #: 
 msgid "soil##bedrock"
@@ -1950,6 +1950,7 @@ msgid "soil##soil_preset##CUSTOM"
 msgstr "Користувацька"
 
 #: 
+#, fuzzy
 msgid "soil##depth##add_title"
 msgstr "Додати глибину"
 
@@ -1994,6 +1995,7 @@ msgid "soil##depth##update_modal##title"
 msgstr "Змінити глибину?"
 
 #: 
+#, fuzzy
 msgid "soil##depth##update_modal##body"
 msgstr "Спостереження за ґрунтовими розрізами, введені для цієї глибини, будуть видалені. Цю дію не можна скасувати."
 
@@ -2338,6 +2340,7 @@ msgid "slope##steepness##manual_label"
 msgstr "Вручнк"
 
 #: 
+#, fuzzy
 msgid "slope##steepness##manual_help"
 msgstr "Введіть відсоток або градус крутизни:"
 
@@ -4934,4 +4937,38 @@ msgstr "https://terraso.org/terms-of-service/"
 #: 
 msgid "general##terms_of_service_link_text"
 msgstr "Умови надання послуг"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##fab"
+msgstr "Rate match TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##title"
+msgstr "Rate this soil match TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##description"
+msgstr "<bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons. TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##yes"
+msgstr "Yes, select soil for this site TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##no"
+msgstr "No, it's different TK"
+
+#: 
+#, fuzzy
+msgid "site##soil_id##matches##rate##unsure"
+msgstr "Not sure yet TK"
+
+#: 
+msgid "soil##depth##edit_title"
+msgstr "Параметри глибини"
 

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -143,14 +143,6 @@
                         "learn_more_url": "https://landpks.terraso.org/what-is-soil-id-and-why-does-it-matter/"
                     }
                 },
-                "rate": {
-                    "fab": "TK Rate match",
-                    "title": "TK Rate this soil match",
-                    "description": "TK <bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons.",
-                    "yes": "TK Yes, select soil for this site",
-                    "no": "TK No, it's different",
-                    "unsure": "TK Not sure yet"
-                },
                 "match": "coincidencia",
                 "error_generic_title": "No se puede obtener el mapa del suelo",
                 "error_generic_body": "LandPKS no ha podido obtener el mapa de suelos de esta ubicación. Intente detener y reiniciar la aplicación. Si el problema continúa, vuelva a intentarlo más tarde o envíe una solicitud de soporte a través del sitio web landpks.terraso.org.",
@@ -159,7 +151,15 @@
                 "match_score": "{{score}}",
                 "offline": "Las coincidencias de suelo se actualizarán cuando estés conectado.",
                 "selector": "Este es el suelo correcto",
-                "selected": "Suelo seleccionado"
+                "selected": "Suelo seleccionado",
+                "rate": {
+                    "fab": "Rate match TK",
+                    "title": "Rate this soil match TK",
+                    "description": "<bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons. TK",
+                    "yes": "Yes, select soil for this site TK",
+                    "no": "No, it's different TK",
+                    "unsure": "Not sure yet TK"
+                }
             },
             "site_data": {
                 "title": "Observaciones del sitio",
@@ -549,8 +549,7 @@
                 "ordering": "Error de límites de profundidad"
             },
             "bounds": "{{start}}–{{end}}{{units}}",
-            "add_title": "Añadir produndidad",
-            "edit_title": "TK Depth Options",
+            "add_title": "Añadir profundidad",
             "data_inputs_title": "Mostrar/ocultar observaciones del suelo",
             "label_help": "{{max}} caracteres máximo",
             "label_placeholder": "Etiquetar",
@@ -572,7 +571,8 @@
             },
             "bounds_labelled": "{{label}}: {{start}}–{{end}}{{units}}",
             "bounds_unitless": "{{start}}–{{end}}",
-            "delete_button": "Eliminar profundidad"
+            "delete_button": "Eliminar profundidad",
+            "edit_title": "Opciones de profundidad"
         },
         "texture": {
             "title": "Textura del suelo",

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -143,14 +143,6 @@
             "learn_more_url": "https://landpks.terraso.org/what-is-soil-id-and-why-does-it-matter/"
           }
         },
-        "rate": {
-          "fab": "TK Rate match",
-          "title": "TK Rate this soil match",
-          "description": "TK <bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons.",
-          "yes": "TK Yes, select soil for this site",
-          "no": "TK No, it's different",
-          "unsure": "TK Not sure yet"
-        },
         "match": "співпадати / відповідати чомусь",
         "error_generic_title": "Не вдається отримати ґрунтову карту",
         "error_generic_body": "LandPKS не зміг отримати карту ґрунту для цього місця. Спробуйте зупинити та перезапустити програму. Якщо проблема не зникне, спробуйте пізніше або надішліть запит на підтримку через веб-сайт landpks.terraso.org.",
@@ -159,7 +151,15 @@
         "match_score": "{{score}}",
         "offline": "Співпадіння ґрунтів оновлюватимуться, коли ви будете онлайн.",
         "selector": "Це правильно ідентифікований ґрунт",
-        "selected": "Обраний ґрунт"
+        "selected": "Обраний ґрунт",
+        "rate": {
+          "fab": "Rate match TK",
+          "title": "Rate this soil match TK",
+          "description": "<bold>Is this the right soil?</bold> Use your best judgement based on the soil description and property comparisons. TK",
+          "yes": "Yes, select soil for this site TK",
+          "no": "No, it's different TK",
+          "unsure": "Not sure yet TK"
+        }
       },
       "site_data": {
         "title": "Спостереження за ділянкою",
@@ -266,7 +266,7 @@
         "title": "Глибина ґрунтових розрізів",
         "preset": {
           "NRCS": "NRCS/GSP",
-          "BLM": "BLM - Bureau of Land Management - Стандарт моніторингу BLM, офіційно затверджені методики та критерії, які використовуються для Моніторингу земель",
+          "BLM": "Методичні документи і протоколи Бюро з управління землями США",
           "CUSTOM": "Користувацький…",
           "NONE": "Не вказано"
         },
@@ -310,7 +310,7 @@
     },
     "sites": {
       "add": "Додати ділянки",
-      "transfer": "Ділянки, на які поширюють або переносить результати з еталонних/базових ділянок",
+      "transfer": "Сайти для перенесення даних",
       "create": "Створити ділянки",
       "search": {
         "placeholder": "Пошук",
@@ -529,7 +529,7 @@
     },
     "elevation": {
       "inline": "висота",
-      "title": "Висота над рівнем моря"
+      "title": "Висота н.р.м."
     }
   },
   "soil": {
@@ -550,7 +550,6 @@
       },
       "bounds": "{{start}}–{{end}}{{units}}",
       "add_title": "Додати глибину",
-      "edit_title": "TK Depth Options",
       "data_inputs_title": "Показати/приховати ґрунтові спостереження",
       "label_help": "Максимум {{max}} символів",
       "label_placeholder": "тег",
@@ -572,7 +571,8 @@
       },
       "bounds_labelled": "{{label}}: {{start}}–{{end}}{{units}}",
       "bounds_unitless": "{{start}}–{{end}}",
-      "delete_button": "Видалити глибину"
+      "delete_button": "Видалити глибину",
+      "edit_title": "Параметри глибини"
     },
     "texture": {
       "title": "Гранулометричний склад грунту",


### PR DESCRIPTION
## Description
Update .po and .json files per instructions in the [development guide](https://docs.google.com/document/d/1IEy2LX1_ZSVYTZkAaL9P0IePm2huslViU7BC89KY_Lw/edit?tab=t.0#heading=h.f7emuqbk7q2x)

Strings for rate match are untranslated, which should be fine because they're behind a feature flag.

### Related Issues
Addresses https://github.com/techmatters/terraso-product/issues/1385

### Verification steps
Check Spanish and Ukrainian for new strings like the title of the edit depth interval sheet ("Depth Options" in English)
