### PR TITLE
fix: add pre-commit hook to prevent committing sensitive environment …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,10 +70,11 @@ dev-client/vendor/bundle/
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
 
-# You shouldn't store secrets in this file, but it can be used to manage different builds
+# .env and .env.save should never be pushed to origin because they may have secrets
+# .env.sample is ok to push, but should never have secrets
 .env
-.env.local
 .env.save
+.env.local
 
 # expo
 .expo

--- a/dev-client/.husky/pre-commit
+++ b/dev-client/.husky/pre-commit
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
 # Prevent committing sensitive environment files
-if git diff --cached --name-only | grep -qE "(^|/)\.env$|(^|/)\.env\.save$"; then
+if git diff --cached --name-only | grep -qE "(^|/)\.env$|(^|/)\.env\.local$|(^|/)\.env\.save$"; then
     echo "❌ ERROR: Attempted to commit sensitive environment files!"
     echo ""
     echo "The following files should NOT be committed:"
-    git diff --cached --name-only | grep -E "(^|/)\.env$|(^|/)\.env\.save$" | sed 's/^/  - /'
+    git diff --cached --name-only | grep -E "(^|/)\.env$|(^|/)\.env\.local$|(^|/)\.env\.save$" | sed 's/^/  - /'
     echo ""
-    echo "These files contain secrets and are in .gitignore."
+    echo "These files may contain secrets and are in .gitignore."
     echo "To fix: git restore --staged <file>"
     echo ""
     exit 1


### PR DESCRIPTION

Add validation to prevent accidental commits of .env and .env.save files which contain secrets and credentials.

## Description
Prevents checking in .env and .env.save

### Verification steps
Try to check in one of those files.  It should fail, but please only try to check in a file without any sensitive keys/tokens.