### PR TITLE
fix: replace deprecated sign-android-release action with maintained fork

### DIFF
--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -90,14 +90,16 @@ jobs:
         run: ./gradlew bundleRelease
 
       - name: Sign Android app bundle
+        id: sign_app
         if: ${{ inputs.upload == 'true' }}
-        uses: r0adkll/sign-android-release@v1.0.4
+        uses: ilharp/sign-android-release@v2
         with:
-          releaseDirectory: ./dev-client/android/app/build/outputs/bundle/release
-          signingKeyBase64: ${{ secrets.ANDROID_SIGNING_KEY }}
-          alias: ${{ vars.ANDROID_ALIAS }}
+          releaseDir: ./dev-client/android/app/build/outputs/bundle/release
+          signingKey: ${{ secrets.ANDROID_SIGNING_KEY }}
+          keyAlias: ${{ vars.ANDROID_ALIAS }}
           keyStorePassword: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          buildToolsVersion: 36.0.0
 
       - name: Upload App to Google Play
         if: ${{ inputs.upload == 'true' }}
@@ -106,7 +108,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON_TEXT }}
           releaseName: "LandPKS Soil ID"
           packageName: org.terraso.landpks
-          releaseFiles: ./dev-client/android/app/build/outputs/bundle/release/*.aab
+          releaseFiles: ${{ steps.sign_app.outputs.signedFile }}
           track: internal
           status: draft
           # changesNotSentForReview: true


### PR DESCRIPTION
Replace r0adkll/sign-android-release@v1.0.4 with ilharp/sign-android-release@v2 to fix GitHub Actions deprecation warnings about set-output commands.

The r0adkll action is unmaintained and uses deprecated set-output syntax that was disabled on May 31, 2023. The ilharp fork (v2.0.0, released April 2025) is actively maintained and uses modern GitHub Actions syntax.

I did test this (took multiple tries).
