### PR TITLE
fix: upgrade React Native to 0.81.5 to fix Android 16 camera hang

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -61,7 +61,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-i18next": "^15.7.4",
-        "react-native": "0.81.4",
+        "react-native": "^0.81.5",
         "react-native-autocomplete-input": "^5.5.6",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "^1.11.0",
@@ -6594,9 +6594,9 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
-      "integrity": "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.5.tgz",
+      "integrity": "sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.4"
@@ -6699,12 +6699,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.4.tgz",
-      "integrity": "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.5.tgz",
+      "integrity": "sha512-yWRlmEOtcyvSZ4+OvqPabt+NS36vg0K/WADTQLhrYrm9qdZSuXmq8PmdJWz/68wAqKQ+4KTILiq2kjRQwnyhQw==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.81.4",
+        "@react-native/dev-middleware": "0.81.5",
         "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "metro": "^0.83.1",
@@ -6728,6 +6728,53 @@
         }
       }
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.81.5.tgz",
+      "integrity": "sha512-bnd9FSdWKx2ncklOetCgrlwqSGhMHP2zOxObJbOWXoj7GHEmih4MKarBo5/a8gX8EfA1EwRATdfNBQ81DY+h+w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.5.tgz",
+      "integrity": "sha512-WfPfZzboYgo/TUtysuD5xyANzzfka8Ebni6RIb2wDxhb56ERi7qDrE4xGhtPsjCL4pQBXSVxyIlCy0d8I6EgGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.81.5",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^6.2.3"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -6738,6 +6785,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/debugger-frontend": {
@@ -6848,18 +6904,18 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.81.4.tgz",
-      "integrity": "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.81.5.tgz",
+      "integrity": "sha512-hORRlNBj+ReNMLo9jme3yQ6JQf4GZpVEBLxmTXGGlIL78MAezDZr5/uq9dwElSbcGmLEgeiax6e174Fie6qPLg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.81.4.tgz",
-      "integrity": "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.81.5.tgz",
+      "integrity": "sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.4"
@@ -22914,19 +22970,19 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
-      "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
+      "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.81.4",
-        "@react-native/codegen": "0.81.4",
-        "@react-native/community-cli-plugin": "0.81.4",
-        "@react-native/gradle-plugin": "0.81.4",
-        "@react-native/js-polyfills": "0.81.4",
-        "@react-native/normalize-colors": "0.81.4",
-        "@react-native/virtualized-lists": "0.81.4",
+        "@react-native/assets-registry": "0.81.5",
+        "@react-native/codegen": "0.81.5",
+        "@react-native/community-cli-plugin": "0.81.5",
+        "@react-native/gradle-plugin": "0.81.5",
+        "@react-native/js-polyfills": "0.81.5",
+        "@react-native/normalize-colors": "0.81.5",
+        "@react-native/virtualized-lists": "0.81.5",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -23233,9 +23289,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.4.tgz",
-      "integrity": "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.5.tgz",
+      "integrity": "sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -23253,10 +23309,16 @@
         "@babel/core": "*"
       }
     },
+    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
+      "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
+      "license": "MIT"
+    },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.4.tgz",
-      "integrity": "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.5.tgz",
+      "integrity": "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -81,7 +81,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-i18next": "^15.7.4",
-    "react-native": "0.81.4",
+    "react-native": "^0.81.5",
     "react-native-autocomplete-input": "^5.5.6",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "^1.11.0",


### PR DESCRIPTION
Upgrades from React Native 0.81.4 to 0.81.5 which includes a fix for the Android 16 bug where launchCameraAsync() hangs indefinitely when camera permissions are already granted.

This affects Pixel devices with September 2025 security update. The fix is at the framework level, so no code changes are needed.

Reference: https://github.com/expo/expo/issues/39480

How to test: use camera to do soil color.