### PR TITLE
fix: hide MapHeader controls when callout is open

### DIFF
--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -164,6 +164,7 @@ export const SitesScreen = memo(() => {
               zoomTo={searchFunction}
               zoomToUser={moveToUserAndShowCallout}
               toggleMapLayer={toggleMapLayer}
+              isCalloutOpen={calloutState.kind !== 'none'}
             />
             <SiteMap
               ref={mapRef}

--- a/dev-client/src/screens/SitesScreen/components/MapHeader.tsx
+++ b/dev-client/src/screens/SitesScreen/components/MapHeader.tsx
@@ -33,10 +33,20 @@ type Props = {
   zoomTo?: (coords: Coords) => void;
   zoomToUser?: () => void;
   toggleMapLayer?: () => void;
+  isCalloutOpen?: boolean;
 };
 
-export const MapHeader = ({zoomTo, zoomToUser, toggleMapLayer}: Props) => {
+export const MapHeader = ({
+  zoomTo,
+  zoomToUser,
+  toggleMapLayer,
+  isCalloutOpen,
+}: Props) => {
   const {t} = useTranslation();
+
+  if (isCalloutOpen) {
+    return null;
+  }
 
   return (
     <Box


### PR DESCRIPTION
Solves the z-ordering issue where site callout popups appeared behind map control buttons. Instead of fighting Mapbox's native rendering layers (which don't respect React Native z-index), we simply hide the MapHeader (search box and buttons) when any callout is displayed.

Here is an example:
<img width="405" height="720" alt="image" src="https://github.com/user-attachments/assets/c2c6710f-5d3a-4801-aa3e-228ec17324e5" />

After the fix, it looks like this:
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/3b399d0d-61b6-4586-9352-b4edb2bd07a9" />


