### PR TITLE
fix: change done to save on note editing screens

### DIFF
--- a/dev-client/src/components/ScreenFormWrapper.tsx
+++ b/dev-client/src/components/ScreenFormWrapper.tsx
@@ -204,7 +204,7 @@ export const ScreenFormWrapper = forwardRef(
           onPress={handlePressSubmit}
           disabled={isSubmitting}
           size="lg"
-          label={t('general.done')}
+          label={t('general.save')}
         />
       </Row>
     );


### PR DESCRIPTION
## Description
Changed "Done" to "Save" as requested.
Will affect all three note editing screens.

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/99a27bd3-3bfd-45e5-bb09-c616c36f4b5c" />

