### PR TITLE
fix: defer filter and sort application until APPLY button is clicked

### DIFF
--- a/dev-client/src/components/ListFilter.tsx
+++ b/dev-client/src/components/ListFilter.tsx
@@ -176,7 +176,7 @@ export const ListFilterProvider = <
   const itemsWithFiltersApplied = useMemo(() => {
     const res: Item[] = Object.entries<FilterFn<Item>>(filters).reduce(
       (x, [name, fn]) => {
-        const currentVal = values[name];
+        const currentVal = appliedValues[name];
         if (currentVal === undefined) {
           return x;
         }
@@ -211,7 +211,7 @@ export const ListFilterProvider = <
             return x.filter(item => fn.f(processed)(getFilterVal(item)));
 
           case 'sorting':
-            const selectedVal = values[name];
+            const selectedVal = appliedValues[name];
             if (selectedVal === undefined) {
               return x;
             }
@@ -254,7 +254,7 @@ export const ListFilterProvider = <
       items,
     );
     return res;
-  }, [items, values, filters]);
+  }, [items, appliedValues, filters]);
 
   const clearUnapplied = useCallback(() => {
     setValues(appliedValues);


### PR DESCRIPTION
Change the filtering logic to use appliedValues instead of values so that sort and filter choices are only applied to the list when the user clicks the APPLY button, not in real-time as they change the options.

This affects:
- Sites List (SiteFilterModal)
- Projects List (ListFilterModal)
- Transfer Sites screen (ListFilterModal)

Search still applies immediately as expected.

🤖 Generated with Claude Code

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
