### PR TITLE
fix: revert apple-actions/upload-testflight-build to v3

### DIFF
--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -109,7 +109,7 @@ jobs:
           scheme: LandPKSSoilID
 
       - name: Upload app to TestFlight
-        uses: apple-actions/upload-testflight-build@v4
+        uses: apple-actions/upload-testflight-build@v3
         if: ${{ inputs.upload == 'true' }}
         with:
           app-path: "output.ipa"


### PR DESCRIPTION
Dependabot upgraded to v4 today but it's causing OSStatus -10814 errors during TestFlight uploads. Reverting to v3 which was working fine.

Error: The operation couldn't be completed. (OSStatus error -10814.)

sounds like upload-testflight-build@v4 has different requirements.
I don't want to change this yet, but will ask Derek to create a backlog to switch to v4.
in the meantime, client builds are failing!