### PR TITLE
fix: disallow site bottom sheet from filling 100% of map

### DIFF
--- a/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
@@ -110,6 +110,7 @@ export const SiteListBottomSheet = memo(
         <BottomSheet
           ref={ref}
           snapPoints={snapPoints}
+          enableDynamicSizing={false}
           index={snapIndex}
           backgroundStyle={backgroundStyle}
           handleIndicatorStyle={{backgroundColor: colors.grey[800]}}>


### PR DESCRIPTION
## Description
Turn off dynamic sizing for the SiteListBottomSheet.

[Dynamic sizing](https://gorhom.dev/react-native-bottom-sheet/dynamic-sizing) is used when you want the sheet to automatically size to fit its content, but I don't think there's any need for that here.

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/2397

### Verification steps
Try to drag the Sites List up to fully cover the map. When you release, the highest it should snap to is 75% of the available height.
