### PR TITLE
fix: selected soil tile in match list should be Default variant, not Selected

### DIFF
--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.test.ts
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.test.ts
@@ -20,7 +20,7 @@ import type {
   UserRatingEntry,
 } from 'terraso-client-shared/graphqlSchema/graphql';
 
-import {getTileVariant} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/soilMatchTileVariants';
+import {getMatchListTileVariant} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/soilMatchTileVariants';
 
 // Helper to create a minimal SoilMatch object
 const createSoilMatch = (name: string): SoilMatch => {
@@ -33,18 +33,22 @@ const createSoilMatch = (name: string): SoilMatch => {
   } as SoilMatch;
 };
 
-describe('getTileVariant', () => {
+describe('getMatchListTileVariant', () => {
   describe('when a soil is selected', () => {
-    test('returns Selected for the selected soil', () => {
+    test('returns Default for the selected soil', () => {
       const soilMatch = createSoilMatch('Typic Hapludolls');
       const userRatings: UserRatingEntry[] = [
         {soilMatchId: 'Typic Hapludolls', rating: 'SELECTED'},
       ];
       const selectedSoilId = 'Typic Hapludolls';
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
-      expect(result).toBe('Selected');
+      expect(result).toBe('Default');
     });
 
     test('returns Rejected for other soils when one is selected', () => {
@@ -54,7 +58,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = 'Typic Hapludolls';
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Rejected');
     });
@@ -67,7 +75,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = 'Typic Hapludolls';
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Rejected');
     });
@@ -80,7 +92,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = 'Typic Hapludolls';
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Rejected');
     });
@@ -92,7 +108,11 @@ describe('getTileVariant', () => {
       const userRatings: UserRatingEntry[] = [];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Default');
     });
@@ -104,7 +124,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Default');
     });
@@ -116,7 +140,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Rejected');
     });
@@ -130,7 +158,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Default');
     });
@@ -142,7 +174,11 @@ describe('getTileVariant', () => {
       const userRatings: UserRatingEntry[] = [];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Default');
     });
@@ -152,7 +188,11 @@ describe('getTileVariant', () => {
       const userRatings = undefined;
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Default');
     });
@@ -165,7 +205,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Default');
     });
@@ -175,7 +219,11 @@ describe('getTileVariant', () => {
       const userRatings: UserRatingEntry[] = [];
       const selectedSoilId = '';
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       // Empty string is falsy, so should follow the "no selection" path
       expect(result).toBe('Default');
@@ -188,7 +236,11 @@ describe('getTileVariant', () => {
       ];
       const selectedSoilId = undefined;
 
-      const result = getTileVariant(soilMatch, userRatings, selectedSoilId);
+      const result = getMatchListTileVariant(
+        soilMatch,
+        userRatings,
+        selectedSoilId,
+      );
 
       expect(result).toBe('Rejected');
     });

--- a/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
+++ b/dev-client/src/screens/LocationScreens/components/soilId/SoilIdMatchesSection.tsx
@@ -45,7 +45,7 @@ import {NoMapDataWarningAlert} from 'terraso-mobile-client/screens/LocationScree
 import {OfflineAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/OfflineAlert';
 import {SoilMatchesErrorAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/SoilMatchesErrorAlert';
 import {SoilMatchTile} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/SoilMatchTile';
-import {getTileVariant} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/soilMatchTileVariants';
+import {getMatchListTileVariant} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/soilMatchTileVariants';
 import {TopSoilMatchesInfoContent} from 'terraso-mobile-client/screens/LocationScreens/components/TopSoilMatchesInfoContent';
 
 type SoilIdMatchesSectionProps = {siteId?: string; coords: Coords};
@@ -127,7 +127,11 @@ const MatchTiles = ({siteId, coords, soilIdOutput}: MatchTilesProps) => {
             soilMatch.combinedMatch?.score ?? soilMatch.locationMatch.score
           }
           onPress={() => onMatchTilePress(soilMatch)}
-          variant={getTileVariant(soilMatch, userRatings, selectedSoilId)}
+          variant={getMatchListTileVariant(
+            soilMatch,
+            userRatings,
+            selectedSoilId,
+          )}
         />
       ));
     }

--- a/dev-client/src/screens/LocationScreens/components/soilId/soilMatchTileVariants.ts
+++ b/dev-client/src/screens/LocationScreens/components/soilId/soilMatchTileVariants.ts
@@ -28,18 +28,18 @@ import {getMatchSelectionId} from 'terraso-mobile-client/model/soilMetadata/soil
  * @param thisSoilMatch - The soil match to determine the variant for
  * @param userRatings - Array of user ratings for soil matches
  * @param selectedSoilId - The ID of the currently selected soil, if any
- * @returns 'Selected' | 'Rejected' | 'Default' - The tile variant to display
+ * @returns 'Rejected' | 'Default' - The tile variant to display (note: the 'Selected' variant is only used in another section, not for the match list tiles.)
  */
-export const getTileVariant = (
+export const getMatchListTileVariant = (
   thisSoilMatch: SoilMatch,
   userRatings: UserRatingEntry[] | undefined,
   selectedSoilId: string | undefined,
-): 'Selected' | 'Rejected' | 'Default' => {
+): 'Rejected' | 'Default' => {
   // When a soil is selected, show other soil tiles as if they were "Rejected"
   // (even though in the database they're not)
   if (selectedSoilId) {
     return selectedSoilId === getMatchSelectionId(thisSoilMatch)
-      ? 'Selected'
+      ? 'Default'
       : 'Rejected';
   }
 


### PR DESCRIPTION
## Description
When a soil has been selected, it should still show its match percentage in the list of soil matches (which is the `Default` match tile variant), not show "Selected Soil" (which is the `Selected` match tile variant)

Fixes the issue in #3048 noted in [this comment](https://github.com/techmatters/terraso-mobile-client/issues/3048#issuecomment-3618423576)

