### PR TITLE
fix: sanitize filenames and URLs in data export

### DIFF
--- a/dev-client/src/screens/DataExportScreen/DataExportScreen.tsx
+++ b/dev-client/src/screens/DataExportScreen/DataExportScreen.tsx
@@ -52,7 +52,10 @@ import {ExportHelpSheet} from 'terraso-mobile-client/screens/DataExportScreen/co
 import {OfflineAlert} from 'terraso-mobile-client/screens/LocationScreens/components/soilId/alertBoxes/OfflineAlert';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {AppState, useDispatch, useSelector} from 'terraso-mobile-client/store';
-import {shareOrSaveFile} from 'terraso-mobile-client/utils/fileDownload';
+import {
+  sanitizeFilename,
+  shareOrSaveFile,
+} from 'terraso-mobile-client/utils/fileDownload';
 import {shareUrl} from 'terraso-mobile-client/utils/share';
 
 export type DataExportScreenProps = {
@@ -198,7 +201,7 @@ export function DataExportScreen({
 
         // Save file to device
         const mimeType = format === 'csv' ? 'text/csv' : 'application/json';
-        const filename = `${resourceName}.${format}`;
+        const filename = `${sanitizeFilename(resourceName)}.${format}`;
 
         const result = await shareOrSaveFile(
           content,

--- a/dev-client/src/utils/fileDownload.ts
+++ b/dev-client/src/utils/fileDownload.ts
@@ -22,6 +22,8 @@ import Share from 'react-native-share';
 import {File, Paths} from 'expo-file-system';
 import {cacheDirectory, writeAsStringAsync} from 'expo-file-system/legacy';
 
+export {sanitizeFilename} from 'terraso-mobile-client/utils/sanitize';
+
 export type SaveFileResult =
   | {success: true; filename: string}
   | {success: false; error: string; canceled?: boolean};

--- a/dev-client/src/utils/sanitize.ts
+++ b/dev-client/src/utils/sanitize.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2025 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+/**
+ * Core sanitization for names used in filenames or URL paths.
+ *
+ * Handles:
+ * - Unicode normalization (NFC)
+ * - Control characters removed
+ * - Filesystem-invalid chars (/\:*?"<>|) → hyphens
+ * - URL-problematic chars (#&=%()') removed
+ * - Multiple hyphens collapsed
+ * - Leading/trailing dots and hyphens trimmed
+ */
+const sanitizeNameCore = (name: string): string => {
+  return (
+    name
+      .normalize('NFC')
+      .trim()
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1f\x7f]/g, '') // control chars
+      .replace(/[/\\:*?"<>|]/g, '-') // filesystem-invalid → hyphen
+      .replace(/[#&=%()'']/g, '') // URL-problematic chars
+      .replace(/-+/g, '-') // collapse hyphens
+      .replace(/^[.-]+|[.-]+$/g, '')
+  ); // trim dots and hyphens
+};
+
+/**
+ * Sanitizes a string for use as a local filename.
+ * Preserves spaces for readability.
+ *
+ * @example
+ * sanitizeFilename("Project: Phase 1")     // "Project- Phase 1"
+ * sanitizeFilename("Tested 12/29/2025")    // "Tested 12-29-2025"
+ * sanitizeFilename("What's Next?")         // "Whats Next"
+ * sanitizeFilename("Файл (test)")          // "Файл test"
+ */
+export const sanitizeFilename = (name: string): string => {
+  const MAX_LENGTH = 100; // Conservative limit; reserves space for extension
+  return sanitizeNameCore(name.substring(0, MAX_LENGTH)) || 'file';
+};
+
+/**
+ * Sanitizes a string for use in a URL path segment.
+ * Converts spaces to hyphens for cleaner URLs.
+ *
+ * @example
+ * sanitizeNameForUrl("Project: Phase 1")   // "Project-Phase-1"
+ * sanitizeNameForUrl("Tested 12/29/2025")  // "Tested-12-29-2025"
+ * sanitizeNameForUrl("Київ Site")          // "Київ-Site"
+ * sanitizeNameForUrl("What's Next?")       // "Whats-Next"
+ */
+export const sanitizeNameForUrl = (name: string): string => {
+  // Convert spaces to hyphens before core sanitization
+  const withHyphens = name.replace(/\s+/g, '-');
+  return sanitizeNameCore(withHyphens) || 'export';
+};

--- a/dev-client/src/utils/share.ts
+++ b/dev-client/src/utils/share.ts
@@ -18,29 +18,7 @@
 import {Platform} from 'react-native';
 import Share from 'react-native-share';
 
-/**
- * Sanitize a name for use in a URL path.
- *
- * Converts spaces to hyphens, removes characters that are problematic
- * for URLs or filesystems, and leaves Unicode intact (clients auto-encode).
- *
- * @example
- * sanitizeNameForUrl("Project: Phase 1")  // "Project-Phase-1"
- * sanitizeNameForUrl("Київ Site")         // "Київ-Site"
- * sanitizeNameForUrl("What's Next?")      // "Whats-Next"
- */
-export function sanitizeNameForUrl(name: string): string {
-  return (
-    name
-      .trim()
-      .replace(/\s+/g, '-') // spaces → hyphen
-      .replace(/[/:]/g, '-') // path-like chars → hyphen
-      .replace(/[<>"'\\|?*#&=%()]/g, '') // remove URL/filesystem problem chars
-      .replace(/-{2,}/g, '-') // collapse multiple hyphens
-      .replace(/^-+|-+$/g, '') || // trim leading/trailing hyphens
-    'export' // fallback if empty
-  );
-}
+export {sanitizeNameForUrl} from 'terraso-mobile-client/utils/sanitize';
 
 /**
  * Shares a URL using the platform's native share sheet via react-native-share


### PR DESCRIPTION
- Add sanitizeFilename for local file saves (names with / were failing amount others).
- Unify sanitization logic in utils/sanitize.ts, so mostly use the same sanitization for export and local file save.
