### PR TITLE
fix(android): block READ_MEDIA_* permissions for Google Play compliance

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -113,7 +113,10 @@ const defaultConfig: ExpoConfig = {
       'android.permissions.RECORD_AUDIO',
       'android.permissions.MODIFY_AUDIO_SETTINGS',
       'android.permissions.VIBRATE',
+      // Block broad media permissions - app uses Android Photo Picker instead
+      'android.permission.READ_MEDIA_IMAGES',
       'android.permission.READ_MEDIA_VIDEO',
+      'android.permission.READ_MEDIA_AUDIO',
     ],
   },
   ios: {


### PR DESCRIPTION
- Google Play rejected the app for declaring READ_MEDIA_IMAGES and READ_MEDIA_VIDEO . 
- The app uses Android Photo Picker instead, which doesn't require these permissions on Android 13+.
