### PR TITLE
feat: add Copy JWT Access Token option in settings (dev only)

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -32,6 +32,7 @@
         "expo-build-properties": "~1.0.9",
         "expo-camera": "~17.0.8",
         "expo-checkbox": "~5.0.7",
+        "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.9",
         "expo-crypto": "~15.0.7",
         "expo-dev-client": "~6.0.15",
@@ -14307,6 +14308,17 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -52,6 +52,7 @@
     "expo-build-properties": "~1.0.9",
     "expo-camera": "~17.0.8",
     "expo-checkbox": "~5.0.7",
+    "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.9",
     "expo-crypto": "~15.0.7",
     "expo-dev-client": "~6.0.15",

--- a/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/UserSettingsScreen.tsx
@@ -22,6 +22,7 @@ import {RestrictByFlag} from 'terraso-mobile-client/components/restrictions/Rest
 import {UiComponentList} from 'terraso-mobile-client/components/util/UiComponentList';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
+import {CopyAccessTokenItem} from 'terraso-mobile-client/screens/UserSettingsScreen/components/menu/CopyAccessTokenItem';
 import {DataExportItem} from 'terraso-mobile-client/screens/UserSettingsScreen/components/menu/DataExportItem';
 import {DeleteAccountItem} from 'terraso-mobile-client/screens/UserSettingsScreen/components/menu/DeleteAccountItem';
 import {HelpItem} from 'terraso-mobile-client/screens/UserSettingsScreen/components/menu/HelpItem';
@@ -47,6 +48,7 @@ export function UserSettingsScreen() {
           <PrivacyItem />
           <TosItem />
           <SelectLanguageItem />
+          <CopyAccessTokenItem />
           <SignOutItem />
           <DeleteAccountItem />
         </MenuList>

--- a/dev-client/src/screens/UserSettingsScreen/components/menu/CopyAccessTokenItem.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/menu/CopyAccessTokenItem.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2026 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {useCallback} from 'react';
+import {useTranslation} from 'react-i18next';
+
+import * as Clipboard from 'expo-clipboard';
+
+import {getAPIConfig} from 'terraso-client-shared/config';
+
+import {MenuItem} from 'terraso-mobile-client/components/menus/MenuItem';
+import {APP_CONFIG} from 'terraso-mobile-client/config';
+
+export const CopyAccessTokenItem = () => {
+  const {t} = useTranslation();
+
+  const handleCopyToken = useCallback(async () => {
+    const token = await getAPIConfig().tokenStorage.getToken('atoken');
+    if (token) {
+      await Clipboard.setStringAsync(token);
+    }
+  }, []);
+
+  if (APP_CONFIG.environment === 'production') {
+    return null;
+  }
+
+  return (
+    <MenuItem
+      variant="default"
+      icon="content-copy"
+      label={t('settings.copy_access_token')}
+      onPress={handleCopyToken}
+    />
+  );
+};

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -405,6 +405,7 @@
     },
     "settings": {
         "unknown_user": "Unknown user",
+        "copy_access_token": "Copy JWT Access Token",
         "sign_out": "Sign out",
         "delete_account": "Delete account",
         "delete_account_pending": "Pending",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -399,6 +399,7 @@
         "beta": "beta",
         "version": "Versión {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Usuario desconocido",
+        "copy_access_token": "TK Copy JWT Access Token",
         "sign_out": "Cerrar sesión",
         "delete_account": "Eliminar cuenta",
         "delete_account_pending": "Pendiente",

--- a/dev-client/src/translations/fr.json
+++ b/dev-client/src/translations/fr.json
@@ -399,6 +399,7 @@
         "beta": "bêta",
         "version": "Version {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Utilisateur inconnu",
+        "copy_access_token": "TK Copy JWT Access Token",
         "sign_out": "se déconnecter",
         "delete_account": "Supprimer le compte",
         "delete_account_pending": "En attente",

--- a/dev-client/src/translations/ka.json
+++ b/dev-client/src/translations/ka.json
@@ -399,6 +399,7 @@
         "beta": "ბეტა",
         "version": "ვერსია {{version}} ({{build}}) {{environment}}",
         "unknown_user": "უცნობი მომხმარებელი",
+        "copy_access_token": "TK Copy JWT Access Token",
         "sign_out": "გასვლა",
         "delete_account": "ანგარიშის წაშლა",
         "delete_account_pending": "მოლოდინის რეჟიმშია",

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -399,6 +399,7 @@
         "beta": "бета-версія",
         "version": "Version {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Невідомий користувач",
+        "copy_access_token": "TK Copy JWT Access Token",
         "sign_out": "Вийти",
         "delete_account": "Видалити обліковий запис",
         "delete_account_pending": "У процесі, не завершено",


### PR DESCRIPTION
Add a menu item in settings that copies the current user's JWT access token to the clipboard. Only visible in non-production environments to help with debugging and API testing.

### Related Issues
Fixes #3204

### Verification steps
Look at issue 3204 and you can follow along.
Also, should confirm doesn't show up in production.
