### PR TITLE
fix: forward check-i18n arguments to find-i18n-keys

### DIFF
--- a/dev-client/scripts/localization/check-i18n.sh
+++ b/dev-client/scripts/localization/check-i18n.sh
@@ -6,7 +6,7 @@ echo '------- Check keys -------'
 echo '** Warning: these lists may not be complete';
 echo '** Please use as a secondary check only';
 for translation_file in src/translations/*.json; do
-  node scripts/localization/find-i18n-keys.mjs . --catalog "$translation_file"
+  node scripts/localization/find-i18n-keys.mjs . --catalog "$translation_file" "$@"
 done
 
 echo ''


### PR DESCRIPTION
## Description
Very simple change to allow arguments for `find-i18n-keys` script when it is run within `check-i18n` script (like `npm run check-i18n -- --json`)