### PR TITLE
docs: add info about simulating offline mode with Little Snitch tool

### DIFF
--- a/dev-client/src/App.tsx
+++ b/dev-client/src/App.tsx
@@ -82,6 +82,18 @@ if (persistedReduxState) {
 }
 const store = createStore(persistedReduxState);
 
+/* Developer FYI: To enable the Little Snitch tool to simulate offline mode without losing connection to Metro:
+ * - Uncomment the code below
+ * - import NetInfo from '@react-native-community/netinfo'
+ * - See "Offline Debugging" section in Terraso Development Guide for more info
+ */
+// NetInfo.configure({
+//   reachabilityUrl: 'https://connectivitycheck.gstatic.com/generate_204',
+//   reachabilityTest: async response => response.status === 204,
+//   reachabilityLongTimeout: 2000,
+//   useNativeReachability: false,
+// });
+
 const App = () => {
   return (
     <AppWrappers store={store}>


### PR DESCRIPTION
## Description
This allows developers to use the "Little Snitch" tool to simulate offline mode in the app, but not lose connection to Metro (so the app still logs to the console, and you can use debug tools).

I added info under ["Offline debugging" in the Terraso Development Guide](https://docs.google.com/document/d/1IEy2LX1_ZSVYTZkAaL9P0IePm2huslViU7BC89KY_Lw/edit?tab=t.0#heading=h.takbf32jwxwi)

Honestly I don’t understand why this makes a difference, because allegedly the url I have in the code is the same as how Android OS checks connectivity natively?? But based on my manual testing it does seem to make a difference! Otherwise changing the profile won't cause the app to recognize it should be in offline mode, it just fails to connect to a bunch of stuff.

@johannesparty There's a lot of context here, so let me know when you get around to this PR and I can talk thru some of the context!

### Related Issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/3202 as best as I can right now
