### PR TITLE
fix: update iOS build to use Xcode 26.2 and macOS 26 runner

### DIFF
--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   ios-build:
     name: iOS Build
-    runs-on: macos-15
+    runs-on: macos-26
     environment: ${{ ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'beta')) && 'production') || (startsWith(github.ref, 'refs/tags/v') && 'staging') }}
     env:
       STRICT: ${{ inputs.STRICT }}
@@ -94,7 +94,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "^16.2"
+          xcode-version: "26.2"
 
       - name: Build iOS App
         uses: yukiarrr/ios-build-action@v1.12.0


### PR DESCRIPTION
Apple requires iOS 26 SDK (Xcode 26) starting April 2026. Updates GitHub Actions workflow to use macos-26 runner and Xcode 26.2.

I tested this works (v331beta)
