### PR TITLE
fix: the FF_testing flag will always be off in prod

### DIFF
--- a/dev-client/src/config/featureFlags.test.ts
+++ b/dev-client/src/config/featureFlags.test.ts
@@ -73,7 +73,7 @@ test('feature flags can be disabled', () => {
   });
 });
 
-test('testing feature flag is disabled in production', () => {
+test('testing feature flag is default disabled in production', () => {
   jest.isolateModules(() => {
     jest.mock('terraso-mobile-client/config/index', () => ({
       APP_CONFIG: {
@@ -88,6 +88,25 @@ test('testing feature flag is disabled in production', () => {
 
     expect(isFlagEnabled('FF_testing')).toBe(false);
     expect(willFlagBeEnabledOnReload('FF_testing')).toBe(false);
+  });
+});
+
+test('testing feature flag is disabled in production even if saved as ON in storage', () => {
+  jest.isolateModules(() => {
+    jest.mock('terraso-mobile-client/config/index', () => ({
+      APP_CONFIG: {
+        environment: 'production',
+      },
+    }));
+
+    const {kvStorage} = require('terraso-mobile-client/persistence/kvStorage');
+    kvStorage.setBool('FF_testing', true);
+
+    const {
+      isFlagEnabled,
+    } = require('terraso-mobile-client/config/featureFlags');
+
+    expect(isFlagEnabled('FF_testing')).toBe(false);
   });
 });
 

--- a/dev-client/src/config/featureFlags.ts
+++ b/dev-client/src/config/featureFlags.ts
@@ -63,7 +63,14 @@ export const setFlagWillBeEnabledOnReload = (
 };
 
 const ENABLED_FLAGS = Object.fromEntries(
-  Object.keys(featureFlags).map(
-    key => [key, willFlagBeEnabledOnReload(key as FeatureFlagName)] as const,
-  ),
+  Object.keys(featureFlags).map(key => {
+    let isEnabled = willFlagBeEnabledOnReload(key as FeatureFlagName);
+
+    // There shouldn't be an opportunity to turn FF_testing on in prod, so this is just for extra safety
+    if (key === 'FF_testing') {
+      isEnabled = isEnabled && APP_CONFIG.environment !== 'production';
+    }
+
+    return [key, isEnabled] as const;
+  }),
 );


### PR DESCRIPTION
## Description
Even if it was somehow on in kvstorage, `FF_testing` feature flag will always be off in prod. 

### Related Issues
Not sure how it happened, but this is because derek [reported](https://tech-matters.slack.com/archives/C06BQTCAUJF/p1770065160193659) seeing UI behind that flag in a prod build