### PR TITLE
fix: show Create Sites header when site list is empty

### DIFF
--- a/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
@@ -125,9 +125,7 @@ export const SiteListBottomSheet = memo(
                   <Heading variant="h6">{t('site.list_title')}</Heading>
                 )}
               </Row>
-              {sites.length > 0 && (
-                <SiteFilterModal useDistance={useDistance} />
-              )}
+              {!isEmpty && <SiteFilterModal useDistance={useDistance} />}
             </Column>
             <RestrictByConnectivity offline={true}>
               <View style={styles.alertView}>
@@ -136,7 +134,7 @@ export const SiteListBottomSheet = memo(
             </RestrictByConnectivity>
           </>
         ),
-        [isEmpty, t, sites.length, useDistance],
+        [isEmpty, t, useDistance],
       );
 
       return (


### PR DESCRIPTION
## Description
Looks like a recent-ish change made some code conditional on `isEmpty`, but only showed the `ListHeaderComponent` when the site list was not empty. We should still show the header when the site list is empty.

Aside: The code style of having `ListHeaderComponent` as a react element variable instead of a component with JSX feels kind of weird, but should be fine. I suppose it makes it cleaner in the places it's used, since you don't have to pass props.

### Related issues
Addresses https://github.com/techmatters/terraso-mobile-client/issues/3211