### PR TITLE
fix: use 'staging' tag instead of 'beta' to trigger staging builds via github actions

### DIFF
--- a/.github/workflows/build-shared-android.yml
+++ b/.github/workflows/build-shared-android.yml
@@ -39,7 +39,7 @@ jobs:
   android-build:
     name: Android Build
     runs-on: ubuntu-latest
-    environment: ${{ ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'beta')) && 'production') || (startsWith(github.ref, 'refs/tags/v') && 'staging') }}
+    environment: ${{ ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'staging')) && 'production') || (startsWith(github.ref, 'refs/tags/v') && 'staging') }}
     env:
       STRICT: ${{ inputs.STRICT }}
       ENV: ${{ vars.ENV }}

--- a/.github/workflows/build-shared-ios.yml
+++ b/.github/workflows/build-shared-ios.yml
@@ -42,7 +42,7 @@ jobs:
   ios-build:
     name: iOS Build
     runs-on: macos-26
-    environment: ${{ ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'beta')) && 'production') || (startsWith(github.ref, 'refs/tags/v') && 'staging') }}
+    environment: ${{ ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'staging')) && 'production') || (startsWith(github.ref, 'refs/tags/v') && 'staging') }}
     env:
       STRICT: ${{ inputs.STRICT }}
       ENV: ${{ vars.ENV }}

--- a/dev-client/.env.sample
+++ b/dev-client/.env.sample
@@ -63,7 +63,7 @@ ALWAYS_SHOW_WELCOME="false"
 
 # Optional: Set a custom build number for local development.
 # This is useful for testing PostHog feature flags that target specific build numbers.
-# Format: v[number] or v[number]beta (e.g., v9999, v9999beta)
+# Format: v[number] or v[number]staging (e.g., v9999, v9999staging)
 # If not set, defaults to 1 for local builds.
 # Note: This requires running `npm run prebuild` after changing.
 # APP_BUILD=v9999

--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -24,7 +24,7 @@ import {withSentry} from '@sentry/react-native/expo';
 
 import {fromEntries} from 'terraso-client-shared/utils';
 
-const BUILD_REGEX = /^v?(?<build>[0-9]+)(?<tag>beta)?$/;
+const BUILD_REGEX = /^v?(?<build>[0-9]+)(?<tag>staging)?$/;
 
 const STRICT = process.env.STRICT === 'true';
 
@@ -81,7 +81,7 @@ if (typeof APP_BUILD === 'string') {
   const result = BUILD_REGEX.exec(APP_BUILD);
   if (result === null) {
     throw Error(
-      `invalid app build: ${APP_BUILD}. should be v[0-9]+ or v[0-9]+beta`,
+      `invalid app build: ${APP_BUILD}. should be v[0-9]+ or v[0-9]+staging`,
     );
   }
   buildNumber = parseInt(result.groups!.build, 10);

--- a/dev-client/src/screens/UserSettingsScreen/components/VersionIndicatorComponent.tsx
+++ b/dev-client/src/screens/UserSettingsScreen/components/VersionIndicatorComponent.tsx
@@ -37,7 +37,7 @@ export function VersionIndicator() {
   let environment;
 
   if (APP_CONFIG.environment === 'staging') {
-    environment = t('settings.beta');
+    environment = t('settings.staging');
   } else if (APP_CONFIG.environment !== 'production') {
     environment = APP_CONFIG.environment;
   }

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -412,7 +412,7 @@
         "delete_account": "Delete account",
         "delete_account_pending": "Pending",
         "unknown_version": "Untagged application version {{environment}}",
-        "beta": "beta",
+        "staging": "staging",
         "version": "Version {{version}} ({{build}}) {{environment}}",
         "select_language": "Language: {{language}}"
     },

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -398,7 +398,7 @@
         "offline_cant_edit": "Estás desconectado. Los proyectos no se pueden editar."
     },
     "settings": {
-        "beta": "beta",
+        "staging": "staging",
         "version": "Versión {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Usuario desconocido",
         "copy_access_token": "TK Copy JWT Access Token",

--- a/dev-client/src/translations/fr.json
+++ b/dev-client/src/translations/fr.json
@@ -398,7 +398,7 @@
         "offline_cant_edit": "Vous êtes hors ligne. Les projets ne peuvent pas être modifiés."
     },
     "settings": {
-        "beta": "bêta",
+        "staging": "staging",
         "version": "Version {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Utilisateur inconnu",
         "copy_access_token": "TK Copy JWT Access Token",

--- a/dev-client/src/translations/ka.json
+++ b/dev-client/src/translations/ka.json
@@ -398,7 +398,7 @@
         "offline_cant_edit": "თქვენ ხაზგარეშე ხართ. პროექტების რედაქტირება შეუძლებელია."
     },
     "settings": {
-        "beta": "ბეტა",
+        "staging": "staging",
         "version": "ვერსია {{version}} ({{build}}) {{environment}}",
         "unknown_user": "უცნობი მომხმარებელი",
         "copy_access_token": "TK Copy JWT Access Token",

--- a/dev-client/src/translations/sw.json
+++ b/dev-client/src/translations/sw.json
@@ -398,7 +398,7 @@
         "offline_cant_edit": "Uko nje ya mtandao. Miradi haiwezi kuhaririwa."
     },
     "settings": {
-        "beta": "beta",
+        "staging": "staging",
         "version": "Toleo {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Mtumiaji asiyejulikana",
         "copy_access_token": "Copy JWT Access Token",

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -398,7 +398,7 @@
         "offline_cant_edit": "Ви офлайн. Проекти не можна редагувати."
     },
     "settings": {
-        "beta": "бета-версія",
+        "staging": "staging",
         "version": "Version {{version}} ({{build}}) {{environment}}",
         "unknown_user": "Невідомий користувач",
         "copy_access_token": "TK Copy JWT Access Token",


### PR DESCRIPTION
## Description
- Github tag 'staging' should now kick off a staging build (instead of prior 'beta' tag)
- Change version indicator from 'beta' to 'staging'

### Related Issues
Addresses https://github.com/techmatters/terraso-product/issues/1577