### PR TITLE
fix: fetch name from apple signon

### DIFF
--- a/dev-client/src/auth/index.ts
+++ b/dev-client/src/auth/index.ts
@@ -79,9 +79,15 @@ interface AuthTokens {
   is_new_account?: boolean;
 }
 
+type AppleNameInfo = {
+  firstName?: string;
+  lastName?: string;
+};
+
 async function exchangeToken(
   identityJwt: string,
   provider: Omit<AuthProvider, 'google'> | `google-${'ios' | 'android'}`,
+  appleNames?: AppleNameInfo,
 ) {
   let body: any = {
     provider,
@@ -90,6 +96,16 @@ async function exchangeToken(
   if (provider === 'apple' && Platform.OS === 'ios') {
     body.client_id = configs.apple.clientId;
   }
+  // Apple's id_token does not contain name claims; if the iOS Sign in with
+  // Apple credential gave us the user's name (only happens on the very first
+  // authorization), forward it so the backend can persist/backfill it.
+  if (appleNames?.firstName) {
+    body.first_name = appleNames.firstName;
+  }
+  if (appleNames?.lastName) {
+    body.last_name = appleNames.lastName;
+  }
+
   const payload = await request<AuthTokens>({
     path: '/auth/token-exchange',
     body: body,
@@ -105,23 +121,32 @@ async function exchangeToken(
 
 const apiConfig = getAPIConfig();
 
-async function getAppleIdToken() {
-  try {
-    let idToken = (
-      await signInAsync({
-        requestedScopes: [
-          AppleAuthenticationScope.FULL_NAME,
-          AppleAuthenticationScope.EMAIL,
-        ],
-      })
-    ).identityToken;
+type AppleSignInResult = {
+  idToken: string;
+  firstName?: string;
+  lastName?: string;
+};
 
-    // The two auth methods have different types the return:
-    // - signInAsync can return string|null
-    // - AccessTokenRequest can return string|undefined
-    // To work around this, I confirm the Apple idToken is not null.
-    // before returning it.
-    return idToken !== null ? idToken : undefined;
+async function getAppleSignInResult(): Promise<AppleSignInResult | undefined> {
+  try {
+    const credential = await signInAsync({
+      requestedScopes: [
+        AppleAuthenticationScope.FULL_NAME,
+        AppleAuthenticationScope.EMAIL,
+      ],
+    });
+
+    if (credential.identityToken === null) {
+      return undefined;
+    }
+
+    // credential.fullName is populated only on the very first authorization
+    // for this Apple ID + Service ID; on subsequent sign-ins it's all nulls.
+    return {
+      idToken: credential.identityToken,
+      firstName: credential.fullName?.givenName ?? undefined,
+      lastName: credential.fullName?.familyName ?? undefined,
+    };
   } catch (e: any) {
     if (e.code === 'ERR_REQUEST_CANCELED') {
       console.log('Sign in with Apple canceled', e);
@@ -152,8 +177,17 @@ async function getGoogleMicrosoftIdToken(provider: AuthProvider) {
 
 export async function auth(provider: AuthProvider) {
   let idToken: string | undefined;
+  let appleNames: AppleNameInfo | undefined;
+
   if (provider === 'apple' && Platform.OS === 'ios') {
-    idToken = await getAppleIdToken();
+    const result = await getAppleSignInResult();
+    if (result) {
+      idToken = result.idToken;
+      appleNames = {
+        firstName: result.firstName,
+        lastName: result.lastName,
+      };
+    }
   } else {
     idToken = await getGoogleMicrosoftIdToken(provider);
   }
@@ -172,6 +206,7 @@ export async function auth(provider: AuthProvider) {
   let {atoken, rtoken, is_new_account} = await exchangeToken(
     idToken,
     platformProvider,
+    appleNames,
   );
 
   await Promise.all([

--- a/dev-client/src/auth/index.ts
+++ b/dev-client/src/auth/index.ts
@@ -80,8 +80,8 @@ interface AuthTokens {
 }
 
 type AppleNameInfo = {
-  firstName?: string;
-  lastName?: string;
+  firstName: string | undefined;
+  lastName: string | undefined;
 };
 
 async function exchangeToken(
@@ -123,8 +123,8 @@ const apiConfig = getAPIConfig();
 
 type AppleSignInResult = {
   idToken: string;
-  firstName?: string;
-  lastName?: string;
+  firstName: string | undefined;
+  lastName: string | undefined;
 };
 
 async function getAppleSignInResult(): Promise<AppleSignInResult | undefined> {

--- a/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
+++ b/dev-client/src/screens/ProjectTeamScreen/components/UserItem.tsx
@@ -60,7 +60,7 @@ export const UserItem = ({
   const {t} = useTranslation();
 
   const userLabel = useMemo(() => {
-    let name = formatName(user.firstName, user.lastName);
+    let name = formatName(user.firstName, user.lastName, user.email);
     if (isForCurrentUser) {
       return t('general.you_name', {name: name});
     } else {

--- a/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
+++ b/dev-client/src/screens/SiteNotesScreen/components/SiteNoteCard.tsx
@@ -28,6 +28,7 @@ import {Row, Text} from 'terraso-mobile-client/components/NativeBaseAdapters';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 import {useUserCanEditSiteNote} from 'terraso-mobile-client/hooks/permissionHooks';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
+import {useSelector} from 'terraso-mobile-client/store';
 import {formatDate, formatFullName} from 'terraso-mobile-client/util';
 
 type Props = {
@@ -44,6 +45,9 @@ export const SiteNoteCard = ({note}: Props) => {
     noteId: note.id,
   });
   const canViewEditScreen = !isOffline && userCanEditNote;
+  const authorEmail = useSelector(
+    state => state.account.users[note.authorId]?.email,
+  );
 
   const onEditNote = useCallback(() => {
     if (canViewEditScreen) {
@@ -67,7 +71,11 @@ export const SiteNoteCard = ({note}: Props) => {
         <Text variant="body2" italic>
           {t('site.notes.note_attribution', {
             createdAt: formatDate(note.createdAt),
-            name: formatFullName(note.authorFirstName, note.authorLastName),
+            name: formatFullName(
+              note.authorFirstName,
+              note.authorLastName,
+              authorEmail,
+            ),
           })}
         </Text>
         <Spacer />

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -62,16 +62,30 @@ export const formatCoordinateInEnglish = (value: number) => {
   });
 };
 
+// Obscures an email by keeping only the first and last character of the local
+// part, e.g. "johannes@schmidtparty.com" -> "j...s@schmidtparty.com". Used as
+// a fallback when a user has no name. Local parts shorter than 3 characters
+// are returned as-is (nothing to obscure meaningfully).
+export const obscureEmail = (email: string): string => {
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex < 0) return email;
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex);
+  if (local.length < 3) return email;
+  return `${local[0]}...${local[local.length - 1]}${domain}`;
+};
+
 // Both functions accept an optional email fallback used when both first and
 // last name are empty (some user accounts have no name set on the backend).
+// The email is obscured before display (see obscureEmail).
 export const formatName = (
   firstName: string,
   lastName?: string,
   emailFallback?: string,
 ) => {
-  return (
-    [lastName, firstName].filter(Boolean).join(', ') || emailFallback || ''
-  );
+  const name = [lastName, firstName].filter(Boolean).join(', ');
+  if (name) return name;
+  return emailFallback ? obscureEmail(emailFallback) : '';
 };
 
 export const formatFullName = (
@@ -79,7 +93,9 @@ export const formatFullName = (
   lastName?: string,
   emailFallback?: string,
 ) => {
-  return [firstName, lastName].filter(Boolean).join(' ') || emailFallback || '';
+  const name = [firstName, lastName].filter(Boolean).join(' ');
+  if (name) return name;
+  return emailFallback ? obscureEmail(emailFallback) : '';
 };
 
 export const removeKeys = (a: any, b: any) => {

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -62,12 +62,24 @@ export const formatCoordinateInEnglish = (value: number) => {
   });
 };
 
-export const formatName = (firstName: string, lastName?: string) => {
-  return [lastName, firstName].filter(Boolean).join(', ');
+// Both functions accept an optional email fallback used when both first and
+// last name are empty (some user accounts have no name set on the backend).
+export const formatName = (
+  firstName: string,
+  lastName?: string,
+  emailFallback?: string,
+) => {
+  return (
+    [lastName, firstName].filter(Boolean).join(', ') || emailFallback || ''
+  );
 };
 
-export const formatFullName = (firstName: string, lastName?: string) => {
-  return [firstName, lastName].filter(Boolean).join(' ');
+export const formatFullName = (
+  firstName: string,
+  lastName?: string,
+  emailFallback?: string,
+) => {
+  return [firstName, lastName].filter(Boolean).join(' ') || emailFallback || '';
 };
 
 export const removeKeys = (a: any, b: any) => {


### PR DESCRIPTION
1- Grab name from sign-on-with-apple (never worked before) and pass to backend for saving.  Note this requires backend code to be updated to accept the name this way.

2- Display <first>...<last>@<domain> when name isn't available.  for example "iamcool@domain.com" would show as "i...l@domain.com".  Note this only applies if actual name not available.  show up in notes and in team members in a project.