### PR TITLE
fix: cd into dev-client before running npm ci in post-merge hook

### DIFF
--- a/dev-client/.husky/post-merge
+++ b/dev-client/.husky/post-merge
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npm ci
+cd "$(dirname "$0")/.." && npm ci


### PR DESCRIPTION
tldr: This never worked so far as I can tell, but as long as you manually do the npm ci or npm install, like before the hook, all was fine.  We saw the error a bit last week when debugging your build.  Simple fix.

The post-merge hook was running `npm ci` with no directory change, but git always invokes hooks with cwd set to the repo top-level. Since package-lock.json lives in dev-client/ (not the repo root), every `git pull` that performed a real merge failed with EUSAGE:

    npm error The `npm ci` command can only install with an existing
    package-lock.json or npm-shrinkwrap.json...

Broken since PR #3035 (commit 6d113ca5, 2025-09-29, Paul), which added the post-merge hook and simultaneously moved .husky/ from the repo root into dev-client/. Either change alone would have been fine; together they left `npm ci` executing one level above the lockfile. The pre-commit hook survived the move because it runs path-agnostic lint scripts through husky's own wrappers.  

Fix: `cd "$(dirname "$0")/.."` resolves the script's own directory (dev-client/.husky/) and steps up to dev-client/, regardless of where git invokes the hook from.
