### PR TITLE
chore: bundle update pod-install Ruby gems

### DIFF
--- a/dev-client/Gemfile.lock
+++ b/dev-client/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
-    ffi (1.17.2)
+    ffi (1.17.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -77,22 +77,20 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.18.0)
+    json (2.19.4)
     logger (1.7.0)
-    minitest (6.0.1)
-      prism (~> 1.5)
+    minitest (5.27.0)
     molinillo (0.8.0)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
-    prism (1.7.0)
     public_suffix (4.0.7)
     rexml (3.4.4)
     ruby-macho (2.5.1)
     securerandom (0.4.1)
-    typhoeus (1.4.1)
-      ethon (>= 0.9.0)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     xcodeproj (1.27.0)
@@ -111,7 +109,7 @@ DEPENDENCIES
   cocoapods (>= 1.15.2)
 
 RUBY VERSION
-   ruby 3.2.2p53
+  ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.16
+  4.0.8


### PR DESCRIPTION
Ran `bundle update json minitest prism typhoeus ffi` to apply the dependabot-proposed bumps and let the resolver re-work the graph. All of these gems are used transitively during `pod install` (via cocoapods, cocoapods-core, or activesupport), so they're exercised by any local iOS build.

Direct effects on the five targeted gems:

- ffi        1.17.2 → 1.17.4 (dependabot #3201 proposed 1.17.3)
- json       2.18.0 → 2.19.4 (dependabot #3255 proposed 2.19.2)
- typhoeus   1.4.1  → 1.6.0  (dependabot #3214 proposed 1.5.0)
- minitest   6.0.1  → 5.27.0 (REGRESSED — explanation below)
- prism      1.7.0  → removed (no longer needed)

Ride-along updates from the resolver's re-work:

- activesupport  → 7.2.3
- algoliasearch  → 1.27.5
- cocoapods      → 1.16.2
- cocoapods-core → 1.16.2
- ethon          → 0.18.0

Why minitest regressed: bundler's resolver chose minitest 5.27.0 because activesupport's dep closure doesn't yet support minitest 6.x's breaking changes (drops MiniTest, assert_send, mocks/stubs). This makes dependabot PR #3252 (minitest 6.0.1 → 6.0.2) incompatible, and #3223 (prism 1.7.0 → 1.9.0) obsolete since prism is no longer in the tree.

Local pod install + iOS build verified working with this lockfile.

Supersedes: #3201, #3214, #3255
Renders obsolete: #3252, #3223
