### PR TITLE
fix: ios launch banner

### DIFF
--- a/dev-client/scripts/filter-build-logs.js
+++ b/dev-client/scripts/filter-build-logs.js
@@ -20,6 +20,13 @@
 
 const readline = require('readline');
 
+// Defensive: force synchronous stdout in case this filter is ever invoked
+// as a non-terminal pipeline stage. When stdout is a TTY (the common case
+// in rebuild_all) Node already writes synchronously, so this is a no-op.
+if (process.stdout._handle && typeof process.stdout._handle.setBlocking === 'function') {
+  process.stdout._handle.setBlocking(true);
+}
+
 const debug = process.argv.includes('--debug');
 
 // Lines matching any of these start a suppressed block.
@@ -98,6 +105,16 @@ const PREAMBLE_MAX_LINES = 6;
 let inBlock = false;
 let preambleBuffer = [];
 
+// Metro (and some other tools) emit ANSI color codes when writing to a TTY,
+// which the PTY wrapper gives them. That means the raw line has codes like
+// "\x1b[1miOS\x1b[22m \x1b[32mBundled\x1b[39m ..." — anchored regexes like
+// ^\[ and substring matches like `[MapboxCommon]` still work sometimes by
+// coincidence, but ^iOS, ^ LOG, and similar miss. Strip CSI codes for all
+// pattern matching while still emitting the original (colored) line so the
+// terminal renders as intended.
+const ansiCsi = /\x1b\[[0-9;]*[a-zA-Z]/g;
+const stripAnsi = s => s.replace(ansiCsi, '');
+
 function emit(line) {
   process.stdout.write(line + '\n');
 }
@@ -121,9 +138,11 @@ function dropPreamble() {
 const rl = readline.createInterface({input: process.stdin});
 
 rl.on('line', line => {
+  const plain = stripAnsi(line);
+
   if (preambleBuffer.length > 0) {
     preambleBuffer.push(line);
-    if (NOISE_PATTERNS.some(p => p.test(line))) {
+    if (NOISE_PATTERNS.some(p => p.test(plain))) {
       dropPreamble();
       return;
     }
@@ -133,24 +152,24 @@ rl.on('line', line => {
     return;
   }
 
-  if (PREAMBLE_PATTERN.test(line)) {
+  if (PREAMBLE_PATTERN.test(plain)) {
     preambleBuffer.push(line);
     return;
   }
 
-  if (NOISE_PATTERNS.some(p => p.test(line))) {
+  if (NOISE_PATTERNS.some(p => p.test(plain))) {
     inBlock = true;
     suppress(line);
     return;
   }
 
   if (inBlock) {
-    if (line.includes('}}')) {
+    if (plain.includes('}}')) {
       inBlock = false;
       suppress(line);
       return;
     }
-    if (NEW_ENTRY_PATTERN.test(line)) {
+    if (NEW_ENTRY_PATTERN.test(plain)) {
       inBlock = false;
       // fall through to print
     } else {

--- a/dev-client/scripts/report-launch-time.js
+++ b/dev-client/scripts/report-launch-time.js
@@ -23,7 +23,10 @@ let launched = false;
 
 readline.createInterface({input: process.stdin}).on('line', line => {
   process.stdout.write(line + '\n');
-  if (!launched && /^(iOS|Android) Bundled/.test(line)) {
+  // Substring match (not anchored) so we still match when Metro's iOS
+  // progress bars have accumulated \r-overwrite frames before "iOS Bundled"
+  // within the same buffered line coming out of the PTY wrapper.
+  if (!launched && /(iOS|Android) Bundled/.test(line)) {
     launched = true;
     const e = Math.floor(Date.now() / 1000) - start;
     const mins = Math.floor(e / 60);

--- a/dev-client/scripts/report-launch-time.js
+++ b/dev-client/scripts/report-launch-time.js
@@ -17,16 +17,32 @@
 const readline = require('readline');
 const fs = require('fs');
 
+// Force synchronous writes to stdout so lines reach the downstream filter
+// stage in real time instead of queuing in Node's async pipe buffer.
+// See the same guard in run-expo-pty.js for the full rationale.
+if (process.stdout._handle && typeof process.stdout._handle.setBlocking === 'function') {
+  process.stdout._handle.setBlocking(true);
+}
+
 const start = Number(process.env.REBUILD_START);
 const marker = process.env.REBUILD_LAUNCH_MARKER;
 let launched = false;
+
+// Metro colorizes its output when stdout is a TTY (which our PTY wrapper
+// provides). So "iOS Bundled ..." arrives with ANSI escape codes between
+// "iOS" and "Bundled" — the literal substring "iOS Bundled" doesn't exist
+// in the raw line even though it looks that way rendered. Strip CSI codes
+// for matching only; pass through the original line so the terminal still
+// renders colors.
+const ansiCsi = /\x1b\[[0-9;]*[a-zA-Z]/g;
+const stripAnsi = s => s.replace(ansiCsi, '');
 
 readline.createInterface({input: process.stdin}).on('line', line => {
   process.stdout.write(line + '\n');
   // Substring match (not anchored) so we still match when Metro's iOS
   // progress bars have accumulated \r-overwrite frames before "iOS Bundled"
   // within the same buffered line coming out of the PTY wrapper.
-  if (!launched && /(iOS|Android) Bundled/.test(line)) {
+  if (!launched && /(iOS|Android) Bundled/.test(stripAnsi(line))) {
     launched = true;
     const e = Math.floor(Date.now() / 1000) - start;
     const mins = Math.floor(e / 60);

--- a/dev-client/scripts/run-expo-pty.js
+++ b/dev-client/scripts/run-expo-pty.js
@@ -14,6 +14,16 @@
  *         node run-expo-pty.js npm run ios -- --device <id>
  */
 
+// Force synchronous writes to stdout so lines reach the downstream pipeline
+// stage (report-launch-time.js) in real time instead of queuing in Node's
+// async pipe buffer. Without this, low-volume build output can sit invisibly
+// in the buffer until something (a reload, another build step) generates
+// enough data to flush it. The _handle API isn't stable public API, so guard
+// defensively — if unavailable, we just fall back to async writes.
+if (process.stdout._handle && typeof process.stdout._handle.setBlocking === 'function') {
+  process.stdout._handle.setBlocking(true);
+}
+
 // node-pty ships prebuilt natives, but npm sometimes doesn't set the exec bit
 // on the bundled spawn-helper (seen on macOS arm64 + Node 25). Fix it up
 // before loading the module so we don't get a cryptic "posix_spawnp failed".

--- a/dev-client/scripts/run-expo-pty.js
+++ b/dev-client/scripts/run-expo-pty.js
@@ -64,9 +64,13 @@ const term = pty.spawn(cmd, cmdArgs, {
   env: process.env,
 });
 
-// Line-buffer PTY output. PTYs terminate lines with \r\n; strip the \r so
-// downstream pipeline stages (readline-based) see clean lines. Partial lines
-// (progress indicators with \r-only) stay in the buffer until \n arrives.
+// Line-buffer PTY output on \n only. Embedded \r characters (Metro's iOS
+// progress bars use bare \r to overwrite in place) are preserved inside the
+// line — the terminal at the end of the pipe interprets them as "cursor to
+// col 0" so progress bars render correctly as in-place overwrites.
+// Downstream scanners (report-launch-time.js) match substrings rather than
+// anchored line starts, so they still see "iOS Bundled" inside the line
+// even when it's preceded by accumulated progress frames.
 let buffer = '';
 term.onData(chunk => {
   buffer += chunk;


### PR DESCRIPTION
fix the rebuild-all script.
feel free to make fun of me for wasting time on this.
at least I think it works well now. 
