### PR TITLE
fix: update welcome interstitial for 1.4.6

### DIFF
--- a/dev-client/src/screens/WelcomeScreen.tsx
+++ b/dev-client/src/screens/WelcomeScreen.tsx
@@ -66,9 +66,6 @@ export const WelcomeScreen = () => {
           <Text variant="body1-strong" mb="sm">
             {t('welcome.next.title')}
           </Text>
-          <Text variant="body1" mb="sm">
-            {t('welcome.next.subtitle')}
-          </Text>
           <TranslatedBulletList i18nKeyPrefix="welcome.next.bullet_" />
 
           <Text variant="body1-strong">{t('welcome.learn_more')}</Text>

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -3,16 +3,17 @@
         "title": "Welcome to LandPKS Soil ID",
         "version_includes": {
             "title": "This version includes:",
-            "bullet_1": "Data export feature for projects, individual sites, and all sites visible to user",
-            "bullet_2": "Language picker",
-            "bullet_3": "Experimental translations for French and Georgian",
-            "bullet_4": "New rate soil experience for easier soil identification"
+            "bullet_1": "Offline: enabled site creation, edit site metadata and notes",
+            "bullet_2": "New language: Swahili",
+            "bullet_3": "Improved translations for Ukrainian, Georgian, and Spanish",
+            "bullet_4": "More descriptive error message for sync conflicts",
+            "bullet_5": "Improved experience of searching for coordinates on map",
+            "bullet_6": "Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
+            "bullet_7": "Fixed a bug where the color module would crash with overexposed photos"
         },
         "next": {
-            "title": "What’s next?",
-            "subtitle": "Future versions will include:",
-            "bullet_1": "Create sites offline",
-            "bullet_2": "Edit notes offline"
+            "title": "Future versions will include:",
+            "bullet_1": "Soil pH"
         },
         "learn_more": "Learn more and stay updated:",
         "link_text": "LandPKS from Terraso",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -3,17 +3,17 @@
         "title": "Bienvenido a LandPKS Soil ID",
         "next": {
             "title": "¿Qué sigue?",
-            "bullet_1": "TK Soil pH"
+            "bullet_1": "pH del suelo"
         },
         "version_includes": {
             "title": "Esta versión incluye:",
-            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
-            "bullet_2": "TK New language: Swahili",
-            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
-            "bullet_4": "TK More descriptive error message for sync conflicts",
-            "bullet_5": "TK Improved experience of searching for coordinates on map",
-            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
-            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
+            "bullet_1": "Sin conexión: creación de sitios y edición de metadatos y notas habilitadas",
+            "bullet_2": "Nuevo idioma: suajili",
+            "bullet_3": "Traducciones mejoradas para ucraniano, georgiano y español",
+            "bullet_4": "Mensaje de error más descriptivo para conflictos de sincronización",
+            "bullet_5": "Experiencia mejorada al buscar coordenadas en el mapa",
+            "bullet_6": "Se solucionó un problema por el cual los usuarios que cerraban sesión y volvían a iniciar sesión con una cuenta diferente veían temporalmente los datos de la primera cuenta",
+            "bullet_7": "Se solucionó un error por el cual el módulo de color fallaba con fotos sobreexpuestas"
         },
         "learn_more": "Aprender más y mantenerte actualizado:",
         "link_text": "LandPKS de Terraso",

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -3,16 +3,17 @@
         "title": "Bienvenido a LandPKS Soil ID",
         "next": {
             "title": "¿Qué sigue?",
-            "subtitle": "Versiones futuras incluirán:",
-            "bullet_1": "Crear sitios sin conexión",
-            "bullet_2": "Editar notas sin conexión"
+            "bullet_1": "TK Soil pH"
         },
         "version_includes": {
             "title": "Esta versión incluye:",
-            "bullet_1": "Función de exportación de datos para proyectos, sitios individuales y todos los sitios visibles para el usuario",
-            "bullet_2": "Selector de idioma",
-            "bullet_3": "Traducciones experimentales para francés y georgiano",
-            "bullet_4": "Nueva experiencia de calificación de suelos para una identificación más sencilla"
+            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
+            "bullet_2": "TK New language: Swahili",
+            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
+            "bullet_4": "TK More descriptive error message for sync conflicts",
+            "bullet_5": "TK Improved experience of searching for coordinates on map",
+            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
+            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
         },
         "learn_more": "Aprender más y mantenerte actualizado:",
         "link_text": "LandPKS de Terraso",

--- a/dev-client/src/translations/fr.json
+++ b/dev-client/src/translations/fr.json
@@ -3,17 +3,17 @@
         "title": "Bienvenue sur LandPKS Soil ID",
         "next": {
             "title": "Quelle est la prochaine étape ?",
-            "bullet_1": "TK Soil pH"
+            "bullet_1": "pH du sol"
         },
         "version_includes": {
             "title": "Cette version comprend :",
-            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
-            "bullet_2": "TK New language: Swahili",
-            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
-            "bullet_4": "TK More descriptive error message for sync conflicts",
-            "bullet_5": "TK Improved experience of searching for coordinates on map",
-            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
-            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
+            "bullet_1": "Hors ligne : création de sites et modification des métadonnées et notes activées",
+            "bullet_2": "Nouvelle langue : swahili",
+            "bullet_3": "Traductions améliorées pour l'ukrainien, le géorgien et l'espagnol",
+            "bullet_4": "Message d'erreur plus détaillé pour les conflits de synchronisation",
+            "bullet_5": "Expérience améliorée pour la recherche de coordonnées sur la carte",
+            "bullet_6": "Correction d'un problème où les utilisateurs qui se déconnectaient puis se reconnectaient avec un autre compte voyaient temporairement les données du premier compte",
+            "bullet_7": "Correction d'un bug où le module de couleur plantait avec des photos surexposées"
         },
         "learn_more": "Apprenez-en plus et restez informé :",
         "link_text": "LandPKS de Terraso",

--- a/dev-client/src/translations/fr.json
+++ b/dev-client/src/translations/fr.json
@@ -3,16 +3,17 @@
         "title": "Bienvenue sur LandPKS Soil ID",
         "next": {
             "title": "Quelle est la prochaine étape ?",
-            "subtitle": "Les versions futures incluront:",
-            "bullet_1": "Créer des sites hors ligne",
-            "bullet_2": "Modifier les notes hors ligne"
+            "bullet_1": "TK Soil pH"
         },
         "version_includes": {
             "title": "Cette version comprend :",
-            "bullet_1": "Fonctionnalité d'exportation de données pour les projets, les sites individuels et tous les sites visibles par l'utilisateur",
-            "bullet_2": "Sélecteur de langue",
-            "bullet_3": "Traductions expérimentales pour le français et le géorgien",
-            "bullet_4": "Nouvelle expérience de notation des sols pour une identification plus facile des sols"
+            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
+            "bullet_2": "TK New language: Swahili",
+            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
+            "bullet_4": "TK More descriptive error message for sync conflicts",
+            "bullet_5": "TK Improved experience of searching for coordinates on map",
+            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
+            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
         },
         "learn_more": "Apprenez-en plus et restez informé :",
         "link_text": "LandPKS de Terraso",

--- a/dev-client/src/translations/ka.json
+++ b/dev-client/src/translations/ka.json
@@ -3,16 +3,17 @@
         "title": "კეთილი იყოს თქვენი მობრძანება LandPKS Soil ID-ში",
         "next": {
             "title": "რა არის შემდეგი?",
-            "subtitle": "მომავალი ვერსიები მოიცავს:",
-            "bullet_1": "შექმენით საიტები ოფლაინში",
-            "bullet_2": "შენიშვნების რედაქტირება ოფლაინში"
+            "bullet_1": "TK Soil pH"
         },
         "version_includes": {
             "title": "ეს ვერსია მოიცავს:",
-            "bullet_1": "მონაცემთა ექსპორტის ფუნქცია პროექტებისთვის, ინდივიდუალური საიტებისთვის და მომხმარებლისთვის ხილული ყველა საიტისთვის",
-            "bullet_2": "ენის ამომრჩევი",
-            "bullet_3": "ექსპერიმენტული თარგმანები ფრანგული და ქართული ენებისთვის",
-            "bullet_4": "ნიადაგის შეფასების ახალი გამოცდილება ნიადაგის უფრო მარტივი იდენტიფიცირებისთვის"
+            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
+            "bullet_2": "TK New language: Swahili",
+            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
+            "bullet_4": "TK More descriptive error message for sync conflicts",
+            "bullet_5": "TK Improved experience of searching for coordinates on map",
+            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
+            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
         },
         "learn_more": "გაიგეთ მეტი და იყავით ინფორმირებული:",
         "link_text": "LandPKS ტერასოდან",

--- a/dev-client/src/translations/ka.json
+++ b/dev-client/src/translations/ka.json
@@ -3,17 +3,17 @@
         "title": "კეთილი იყოს თქვენი მობრძანება LandPKS Soil ID-ში",
         "next": {
             "title": "რა არის შემდეგი?",
-            "bullet_1": "TK Soil pH"
+            "bullet_1": "ნიადაგის pH"
         },
         "version_includes": {
             "title": "ეს ვერსია მოიცავს:",
-            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
-            "bullet_2": "TK New language: Swahili",
-            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
-            "bullet_4": "TK More descriptive error message for sync conflicts",
-            "bullet_5": "TK Improved experience of searching for coordinates on map",
-            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
-            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
+            "bullet_1": "ხაზგარეშე რეჟიმში: საიტების შექმნა, საიტის მეტამონაცემებისა და შენიშვნების რედაქტირება ჩართულია",
+            "bullet_2": "ახალი ენა: სუაჰილი",
+            "bullet_3": "გაუმჯობესებული თარგმანები უკრაინული, ქართული და ესპანური ენებისთვის",
+            "bullet_4": "უფრო დეტალური შეცდომის შეტყობინება სინქრონიზაციის კონფლიქტებისთვის",
+            "bullet_5": "გაუმჯობესებული გამოცდილება რუკაზე კოორდინატების ძიებისას",
+            "bullet_6": "გასწორდა პრობლემა, რომლის გამოც სხვა ანგარიშზე გადასვლისას მომხმარებლები დროებით ხედავდნენ პირველი ანგარიშის მონაცემებს",
+            "bullet_7": "გასწორდა შეცდომა, რომლის გამოც ფერის მოდული იჭედებოდა ჭარბად დაექსპონირებულ ფოტოებზე"
         },
         "learn_more": "გაიგეთ მეტი და იყავით ინფორმირებული:",
         "link_text": "LandPKS ტერასოდან",

--- a/dev-client/src/translations/sw.json
+++ b/dev-client/src/translations/sw.json
@@ -3,16 +3,17 @@
         "title": "Karibu kwenye LandPKS Soil ID",
         "next": {
             "title": "Nini kitafuata?",
-            "subtitle": "Matoleo yajayo yatajumuisha:",
-            "bullet_1": "Unda maeneo nje ya mtandao",
-            "bullet_2": "Hariri madokezo nje ya mtandao"
+            "bullet_1": "TK Soil pH"
         },
         "version_includes": {
             "title": "Toleo hili linajumuisha:",
-            "bullet_1": "Kipengele cha usafirishaji data kwa miradi, maeneo ya kibinafsi, na maeneo yote yanayoonekana kwa mtumiaji",
-            "bullet_2": "Kiteuzi cha lugha",
-            "bullet_3": "Tafsiri za majaribio za Kifaransa na Kijojia",
-            "bullet_4": "Uzoefu mpya wa kiwango cha udongo kwa ajili ya utambuzi rahisi wa udongo"
+            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
+            "bullet_2": "TK New language: Swahili",
+            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
+            "bullet_4": "TK More descriptive error message for sync conflicts",
+            "bullet_5": "TK Improved experience of searching for coordinates on map",
+            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
+            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
         },
         "learn_more": "Jifunze zaidi na uendelee kupata taarifa mpya:",
         "link_text": "LandPKS kutoka Terraso",

--- a/dev-client/src/translations/sw.json
+++ b/dev-client/src/translations/sw.json
@@ -3,17 +3,17 @@
         "title": "Karibu kwenye LandPKS Soil ID",
         "next": {
             "title": "Nini kitafuata?",
-            "bullet_1": "TK Soil pH"
+            "bullet_1": "pH ya udongo"
         },
         "version_includes": {
             "title": "Toleo hili linajumuisha:",
-            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
-            "bullet_2": "TK New language: Swahili",
-            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
-            "bullet_4": "TK More descriptive error message for sync conflicts",
-            "bullet_5": "TK Improved experience of searching for coordinates on map",
-            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
-            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
+            "bullet_1": "Nje ya mtandao: kuwezesha kuunda maeneo na kuhariri metadata na vidokezo vya maeneo",
+            "bullet_2": "Lugha mpya: Kiswahili",
+            "bullet_3": "Tafsiri zilizoboreshwa kwa Kiukreni, Kijojia, na Kihispania",
+            "bullet_4": "Ujumbe wa kosa wa kina zaidi kwa migongano ya usawazishaji",
+            "bullet_5": "Uzoefu ulioboreshwa wa kutafuta viwianishi kwenye ramani",
+            "bullet_6": "Imerekebishwa hitilafu ambapo watumiaji walioondoka na kuingia tena kwa akaunti tofauti waliona data ya akaunti ya kwanza kwa muda",
+            "bullet_7": "Imerekebishwa hitilafu ambapo moduli ya rangi ilianguka kwa picha zilizopigwa kwa mwanga mwingi sana"
         },
         "learn_more": "Jifunze zaidi na uendelee kupata taarifa mpya:",
         "link_text": "LandPKS kutoka Terraso",

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -3,17 +3,17 @@
         "title": "Ласкаво просимо до LandPKS Soil ID",
         "next": {
             "title": "Що далі?",
-            "bullet_1": "TK Soil pH"
+            "bullet_1": "pH ґрунту"
         },
         "version_includes": {
             "title": "Ця версія включає:",
-            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
-            "bullet_2": "TK New language: Swahili",
-            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
-            "bullet_4": "TK More descriptive error message for sync conflicts",
-            "bullet_5": "TK Improved experience of searching for coordinates on map",
-            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
-            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
+            "bullet_1": "Офлайн: увімкнено створення ділянок, редагування метаданих ділянок та нотаток",
+            "bullet_2": "Нова мова: суахілі",
+            "bullet_3": "Покращені переклади для української, грузинської та іспанської мов",
+            "bullet_4": "Більш детальне повідомлення про помилку для конфліктів синхронізації",
+            "bullet_5": "Покращений досвід пошуку координат на карті",
+            "bullet_6": "Виправлено проблему, через яку користувачі, які виходили з системи та входили з іншим обліковим записом, тимчасово бачили дані першого облікового запису",
+            "bullet_7": "Виправлено помилку, через яку модуль кольору аварійно завершував роботу з переекспонованими фотографіями"
         },
         "learn_more": "Дізнайтеся більше та будьте в курсі подій:",
         "link_text": "LandPKS від Terraso",

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -3,16 +3,17 @@
         "title": "Ласкаво просимо до LandPKS Soil ID",
         "next": {
             "title": "Що далі?",
-            "subtitle": "Майбутні версії включатимуть:",
-            "bullet_1": "Створюйте сайти офлайн",
-            "bullet_2": "Редагувати нотатки офлайн"
+            "bullet_1": "TK Soil pH"
         },
         "version_includes": {
             "title": "Ця версія включає:",
-            "bullet_1": "Функція експорту даних для проектів, окремих сайтів та всіх сайтів, видимих ​​користувачеві",
-            "bullet_2": "Вибір мови",
-            "bullet_3": "Експериментальні переклади з французької та грузинської мов",
-            "bullet_4": "Новий інтерфейс оцінки ґрунту для легшої ідентифікації ґрунту"
+            "bullet_1": "TK Offline: enabled site creation, edit site metadata and notes",
+            "bullet_2": "TK New language: Swahili",
+            "bullet_3": "TK Improved translations for Ukrainian, Georgian, and Spanish",
+            "bullet_4": "TK More descriptive error message for sync conflicts",
+            "bullet_5": "TK Improved experience of searching for coordinates on map",
+            "bullet_6": "TK Fixed an issue where users who signed out and signed in with a different account temporarily saw the first account’s data",
+            "bullet_7": "TK Fixed a bug where the color module would crash with overexposed photos"
         },
         "learn_more": "Дізнайтеся більше та будьте в курсі подій:",
         "link_text": "LandPKS від Terraso",


### PR DESCRIPTION
Changed strings including previously missing 1.4.5 changes
Got rid of welcome.next.subtitle based on feedback from Derek

Here is what it looks like on a small phone (iPhone Air simulator):
<img width="1260" height="2736" alt="image" src="https://github.com/user-attachments/assets/3ea964b8-7b4c-48a5-95d9-b4c2eea14326" />
