### PR TITLE
feat: i18n-check warns on empty sections; delete-unused prunes them

### DIFF
--- a/dev-client/scripts/i18n/check.mjs
+++ b/dev-client/scripts/i18n/check.mjs
@@ -18,12 +18,13 @@
  */
 
 /*
- * The bundled i18n gate. Runs four checks in turn and aggregates results
+ * The bundled i18n gate. Runs the checks in turn and aggregates results
  * into ERRORS (block CI / pre-commit / poeditor-merge) and WARNINGS (printed
  * but non-blocking).
  *
  *   1. find-keys     — code references a key that doesn't exist in en.json    [ERROR]
  *                    — en.json has a key that no source file references       [WARNING]
+ *                    — any locale catalog has an empty `"foo": {}` section    [WARNING]
  *   2. find-variables — non-en locale has different {{vars}} than en.json     [ERROR]
  *   3. missing-check  — non-en locale is missing a key present in en.json     [ERROR]
  *   4. tk-placeholders — locale value still starts with "TK " (untranslated)  [WARNING]
@@ -50,6 +51,23 @@ const DEFAULTS = {
   catalogPath: 'src/translations/en.json',
   translationsDir: 'src/translations',
 };
+
+/**
+ * Walk a parsed catalog and return dotted paths of every empty plain object
+ * (excluding the root). Skips arrays.
+ */
+export function findEmptySections(obj, parentPath = []) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return [];
+  const out = [];
+  if (parentPath.length > 0 && Object.keys(obj).length === 0) {
+    out.push(parentPath.join('.'));
+    return out;
+  }
+  for (const [k, v] of Object.entries(obj)) {
+    out.push(...findEmptySections(v, [...parentPath, k]));
+  }
+  return out;
+}
 
 /**
  * Run all four checks and return aggregated findings.
@@ -94,6 +112,42 @@ export async function runAllChecks(opts = {}) {
         '  npm run i18n-delete-unused           # dry-run',
         '  npm run i18n-delete-unused -- --yes  # actually delete',
         'The next `npm run poeditor-merge` will propagate the deletions to POEditor.',
+      ].join('\n'),
+    });
+  }
+
+  // Empty sections — e.g. "speed_dial": {} left over after all child keys
+  // were deleted. Operationally a kind of "unused" content, so we surface
+  // it under the same warning umbrella.
+  const emptySections = []; // [{language, path}]
+  {
+    const files = readdirSync(translationsDir).filter(f => f.endsWith('.json'));
+    for (const f of files) {
+      const language = path.parse(f).name;
+      const data = JSON.parse(
+        readFileSync(path.join(translationsDir, f), 'utf8'),
+      );
+      for (const p of findEmptySections(data)) {
+        emptySections.push({language, path: p});
+      }
+    }
+  }
+  if (emptySections.length > 0) {
+    const byLocale = {};
+    for (const e of emptySections) {
+      byLocale[e.language] = (byLocale[e.language] || 0) + 1;
+    }
+    const breakdown = Object.entries(byLocale)
+      .sort()
+      .map(([l, n]) => `${l}: ${n}`)
+      .join(', ');
+    warnings.push({
+      title: `${emptySections.length} empty section(s) in catalogs (${breakdown})`,
+      items: emptySections.map(e => `[${e.language}] '${e.path}'`),
+      fix: [
+        'Run:',
+        '  npm run i18n-delete-unused           # dry-run',
+        '  npm run i18n-delete-unused -- --yes  # actually prune',
       ].join('\n'),
     });
   }

--- a/dev-client/scripts/i18n/delete-unused.mjs
+++ b/dev-client/scripts/i18n/delete-unused.mjs
@@ -18,10 +18,15 @@
  */
 
 /*
- * Delete keys that the scanner reports as unused (catalog has them, source
- * doesn't reference them). Removes from every locale file in src/translations/
- * so all stay in sync. Use after a manual review of the warning list from
- * `npm run i18n-check`.
+ * Catalog cleanup. Two passes per locale file in src/translations/:
+ *
+ *   1. Delete keys the scanner flags as unused (catalog has them, source
+ *      doesn't reference them).
+ *   2. Prune empty `"foo": {}` sections — both ones left over from the
+ *      delete pass, and pre-existing dead structure.
+ *
+ * Both passes always run; pass 2 is useful even when there are no unused
+ * keys to delete. Operates on every locale so all stay in sync.
  *
  * USE WITH CARE. The scanner has heuristics; if it doesn't yet recognize a
  * pattern your code uses (e.g. a custom-prop component or unusual lookup),
@@ -29,8 +34,8 @@
  * output before passing --yes.
  *
  * Usage:
- *   npm run i18n-delete-unused          # dry-run, prints the list
- *   npm run i18n-delete-unused -- --yes # actually delete
+ *   npm run i18n-delete-unused          # dry-run, shows what would change
+ *   npm run i18n-delete-unused -- --yes # actually apply
  */
 
 import {readdirSync, readFileSync, writeFileSync} from 'fs';
@@ -47,26 +52,8 @@ const SOURCE_ROOT = '.';
 
 const APPLY = process.argv.slice(2).includes('--yes');
 
-const scan = runScan({roots: [SOURCE_ROOT], catalogPath: CATALOG_PATH});
-const unused = scan.inCatalogNotScan;
-
-if (unused.length === 0) {
-  console.log('No unused keys found.');
-  process.exit(0);
-}
-
-console.log(`Found ${unused.length} unused key(s):`);
-for (const k of unused) console.log(`  ${k}`);
-
-if (!APPLY) {
-  console.log(
-    `\nDry run. Re-run with --yes to delete these keys from every locale file.`,
-  );
-  process.exit(0);
-}
-
 // Recursive in-place delete by dotted-path. Returns true iff the leaf existed
-// and was removed; doesn't prune now-empty parent objects (cheap to leave).
+// and was removed.
 function deleteAtPath(obj, parts) {
   if (parts.length === 0) return false;
   const [head, ...rest] = parts;
@@ -81,25 +68,87 @@ function deleteAtPath(obj, parts) {
   return false;
 }
 
+// Recursively prune empty plain-object children. Returns the dotted paths
+// that were removed (post-recursion order: deepest first).
+function pruneEmpty(obj, parentPath = []) {
+  const removed = [];
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return removed;
+  for (const k of Object.keys(obj)) {
+    const v = obj[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      removed.push(...pruneEmpty(v, [...parentPath, k]));
+      if (Object.keys(v).length === 0) {
+        delete obj[k];
+        removed.push([...parentPath, k].join('.'));
+      }
+    }
+  }
+  return removed;
+}
+
+// ---------- compute changes per locale ----------
+const scan = runScan({roots: [SOURCE_ROOT], catalogPath: CATALOG_PATH});
+const unused = scan.inCatalogNotScan;
+
 const localeFiles = readdirSync(TRANSLATIONS_DIR)
   .filter(f => f.endsWith('.json'))
   .map(f => path.join(TRANSLATIONS_DIR, f));
 
-let totalRemoved = 0;
+const fileChanges = []; // {file, removed, prunedPaths, data, trailing}
 for (const f of localeFiles) {
   const raw = readFileSync(f, 'utf8');
   const trailing = raw.endsWith('\n') ? '\n' : '';
-  const parsed = JSON.parse(raw);
-  let hit = 0;
+  const data = JSON.parse(raw);
+
+  let removed = 0;
   for (const k of unused) {
-    if (deleteAtPath(parsed, k.split('.'))) hit++;
+    if (deleteAtPath(data, k.split('.'))) removed++;
   }
-  const out = JSON.stringify(parsed, null, 4) + trailing;
-  writeFileSync(f, out);
-  console.log(`${path.relative(process.cwd(), f)}: removed ${hit} key(s)`);
-  totalRemoved += hit;
+  const prunedPaths = pruneEmpty(data);
+
+  fileChanges.push({file: f, removed, prunedPaths, data, trailing});
+}
+
+const totalRemoved = fileChanges.reduce((s, c) => s + c.removed, 0);
+const totalPruned = fileChanges.reduce((s, c) => s + c.prunedPaths.length, 0);
+
+if (totalRemoved === 0 && totalPruned === 0) {
+  console.log('Nothing to do — no unused keys, no empty sections.');
+  process.exit(0);
+}
+
+// ---------- preview ----------
+if (unused.length > 0) {
+  console.log(`Found ${unused.length} unused key(s):`);
+  for (const k of unused) console.log(`  ${k}`);
+}
+
+if (totalPruned > 0) {
+  console.log(
+    `\n${unused.length > 0 ? 'After deletion, would prune' : 'Would prune'} ${totalPruned} empty section(s):`,
+  );
+  for (const c of fileChanges) {
+    if (c.prunedPaths.length === 0) continue;
+    console.log(`  ${path.basename(c.file)}:`);
+    for (const p of c.prunedPaths) console.log(`    ${p}`);
+  }
+}
+
+if (!APPLY) {
+  console.log(`\nDry run. Re-run with --yes to apply.`);
+  process.exit(0);
+}
+
+// ---------- apply ----------
+for (const c of fileChanges) {
+  if (c.removed === 0 && c.prunedPaths.length === 0) continue;
+  writeFileSync(c.file, JSON.stringify(c.data, null, 4) + c.trailing);
+  const rel = path.relative(process.cwd(), c.file);
+  console.log(
+    `${rel}: removed ${c.removed} key(s), pruned ${c.prunedPaths.length} empty section(s)`,
+  );
 }
 
 console.log(
-  `\nDone. ${totalRemoved} key removal(s) across ${localeFiles.length} file(s).`,
+  `\nDone. ${totalRemoved} key removal(s), ${totalPruned} empty section(s) pruned across ${localeFiles.length} file(s).`,
 );


### PR DESCRIPTION
Empty sections — `"speed_dial": {}` left behind after every child key was deleted — were invisible to both the check and the cleanup script. The catalog walker only collects leaf keys, and deleteAtPath in delete-unused only removed the leaf, never the now-empty parent.

Two changes:

  - check.mjs: walk every locale JSON for empty plain-object sections, surface them as a warning (same severity as "unused keys"). Reports per-locale counts and dotted paths. Fix hint points at i18n-delete- unused, which now handles the cleanup.

  - delete-unused.mjs: after the unused-key delete pass, run pruneEmpty over every locale to remove `"foo": {}` blocks. The prune pass runs even when there are zero unused keys, so the same command tidies up pre-existing empty sections too. Dry-run shows everything that would change; --yes applies.

Both pre-existing empty sections (e.g. from a manual edit) and ones that would result from the unused-key deletion are caught.
