### PR TITLE
fix: snapshot newUser in role screen so a pull can't pop the flow

### DIFF
--- a/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
+++ b/dev-client/src/screens/AddUserToProjectScreen/AddUserToProjectRoleScreen.tsx
@@ -61,7 +61,15 @@ export const AddUserToProjectRoleScreen = ({projectId, userId}: Props) => {
   const posthog = usePostHog();
 
   const project = useSelector(state => state.project.projects[projectId]);
-  const newUser = useSelector(state => state.account.users[userId]);
+  // Snapshot the searched user on first render. The user was just added to
+  // `state.account.users` by checkUserInProject in the previous screen, but
+  // a background pull (which uses replace-not-merge semantics for users) can
+  // drop them before we navigate away — they aren't on any of the current
+  // user's projects yet, so the pull payload doesn't include them. Without
+  // the snapshot, the missing-newUser data requirement fires and pops the
+  // screen out from under the in-progress add-team-member flow.
+  const newUserFromStore = useSelector(state => state.account.users[userId]);
+  const [newUser] = useState(newUserFromStore);
 
   const [selectedRole, setSelectedRole] = useState<ProjectRole>('VIEWER');
 


### PR DESCRIPTION
When an admin adds a team member, the previous screen looks up the target user by email via checkUserInProject, which adds the user to state.account.users. The role screen then reads them via useSelector.

But pullUserData.fulfilled calls setUsers(state.account, payload.users) — replace, not merge. The pull payload only contains users in the current admin's projects; the just-searched user isn't on any project yet, so they're dropped from local state. The role screen's data requirement fires, the sync-error dialog shows, and the screen pops mid-flow.

Snapshot the user on first render via useState. The screen is a one-shot form — there's no need to react to user updates while it's visible. The lookup happened seconds ago; freezing the value through the brief lifetime of the form is correct.

Repros reliably with: open project → Add Team Member → enter email → Next → press "pull" in sync debug pane → screen pops. After this fix the pull leaves the screen alone.

Scoped to this screen rather than changing setUsers semantics globally (replace → merge) because removing replace-on-pull has wider implications that don't need to be litigated for this one bug.
