### PR TITLE
feat: include Mapbox attribution on maps

### DIFF
--- a/dev-client/src/components/SiteCard.tsx
+++ b/dev-client/src/components/SiteCard.tsx
@@ -75,6 +75,7 @@ export const SiteCard = ({
           coords={site}
           style={styles.mapView}
           pointerEvents="none"
+          showAttribution={false}
         />
         {project && (
           <PeopleChip count={Object.keys(project.memberships).length} />

--- a/dev-client/src/components/StaticMapView.tsx
+++ b/dev-client/src/components/StaticMapView.tsx
@@ -96,6 +96,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   displayCenterMarker?: boolean;
   pointerEvents?: 'none' | 'auto' | 'box-none' | 'box-only';
+  showAttribution?: boolean;
 };
 
 export const StaticMapView = ({
@@ -104,6 +105,7 @@ export const StaticMapView = ({
   style,
   displayCenterMarker,
   pointerEvents,
+  showAttribution = true,
 }: Props) => {
   const cameraSettings = useMemo(
     () =>
@@ -122,12 +124,12 @@ export const StaticMapView = ({
       style={style}
       styleURL={Mapbox.StyleURL.Satellite}
       scaleBarEnabled={false}
-      logoEnabled={false}
+      attributionEnabled={showAttribution}
+      logoEnabled={showAttribution}
       zoomEnabled={false}
       scrollEnabled={false}
       pitchEnabled={false}
       rotateEnabled={false}
-      attributionEnabled={false}
       pointerEvents={pointerEvents}
       // Use TextureView on Android to fix z-order issues with thumbnails
       // bleeding through onto the main map. TextureView respects normal

--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -25,6 +25,8 @@ import {
   useRef,
   useState,
 } from 'react';
+import {LayoutChangeEvent} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import BottomSheet from '@gorhom/bottom-sheet';
 import Mapbox from '@rnmapbox/maps';
@@ -54,6 +56,7 @@ import {
   noneCallout,
   siteCallout,
 } from 'terraso-mobile-client/screens/SitesScreen/SitesScreenCallout';
+import {getStartingSnapValue} from 'terraso-mobile-client/screens/SitesScreen/utils/getStartingSnapValue';
 import {getSitesScreenFilters} from 'terraso-mobile-client/screens/SitesScreen/utils/sitesScreenFilters';
 import {useSelector} from 'terraso-mobile-client/store';
 import {
@@ -154,11 +157,39 @@ export const SitesScreen = memo(() => {
     [siteDistances, siteProjectRoles],
   );
 
+  const insets = useSafeAreaInsets();
+  const [snapIndex, setSnapIndex] = useState(1);
+  const [isSheetAnimating, setIsSheetAnimating] = useState(false);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  const snapPercents = useMemo(
+    () => [getStartingSnapValue(insets.bottom), 50, 75],
+    [insets.bottom],
+  );
+
+  const attributionBottom = useMemo(
+    () => (containerHeight * (snapPercents[snapIndex] ?? 50)) / 100 + 8,
+    [containerHeight, snapPercents, snapIndex],
+  );
+
+  const attributionVisible = !isSheetAnimating;
+
+  const onSheetAnimate = useCallback(() => {
+    setIsSheetAnimating(true);
+  }, []);
+  const onSheetChange = useCallback((index: number) => {
+    setSnapIndex(index);
+    setIsSheetAnimating(false);
+  }, []);
+  const onContainerLayout = useCallback((e: LayoutChangeEvent) => {
+    setContainerHeight(e.nativeEvent.layout.height);
+  }, []);
+
   return (
     <ScreenScaffold
       AppBar={<AppBar LeftButton={null} RightButton={<LandPKSInfoButton />} />}>
       <ListFilterProvider items={siteList} filters={filters}>
-        <Box testID="sites-screen" flex={1}>
+        <Box testID="sites-screen" flex={1} onLayout={onContainerLayout}>
           <FeatureFlagPollingTrigger />
           <PosthogBanner />
           <Box flex={1}>
@@ -174,6 +205,8 @@ export const SitesScreen = memo(() => {
               setCalloutState={setCalloutState}
               styleURL={mapStyleURL}
               onMapFinishedLoading={onMapFinishedLoading}
+              attributionBottom={attributionBottom}
+              attributionVisible={attributionVisible}
             />
           </Box>
           <SiteListBottomSheet
@@ -181,6 +214,8 @@ export const SitesScreen = memo(() => {
             sites={siteList}
             showSiteOnMap={showSiteOnMap}
             snapIndex={1}
+            onChange={onSheetChange}
+            onAnimate={onSheetAnimate}
           />
         </Box>
       </ListFilterProvider>

--- a/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteListBottomSheet.tsx
@@ -55,11 +55,13 @@ type Props = {
   sites: Site[];
   showSiteOnMap: (site: Site) => void;
   snapIndex?: number;
+  onChange?: (index: number) => void;
+  onAnimate?: (fromIndex: number, toIndex: number) => void;
 };
 
 export const SiteListBottomSheet = memo(
   forwardRef<BottomSheetMethods, Props>(
-    ({sites, showSiteOnMap, snapIndex}, ref) => {
+    ({sites, showSiteOnMap, snapIndex, onChange, onAnimate}, ref) => {
       const {t} = useTranslation();
       const isLoadingData = useSelector(
         state => state.soilData.status === 'loading',
@@ -134,6 +136,8 @@ export const SiteListBottomSheet = memo(
           snapPoints={snapPoints}
           enableDynamicSizing={false}
           index={snapIndex}
+          onChange={onChange}
+          onAnimate={onAnimate}
           backgroundStyle={backgroundStyle}
           handleIndicatorStyle={{backgroundColor: colors.grey[800]}}>
           {isLoadingData ? (

--- a/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
@@ -67,6 +67,8 @@ type Props = {
   setCalloutState: (state: CalloutState) => void;
   styleURL?: string;
   onMapFinishedLoading?: () => void;
+  attributionBottom?: number;
+  attributionVisible?: boolean;
 };
 
 export type MapRef = {
@@ -76,7 +78,14 @@ export type MapRef = {
 export const SiteMap = memo(
   forwardRef<MapRef, Props>(
     (
-      {setCalloutState, calloutState, styleURL, onMapFinishedLoading},
+      {
+        setCalloutState,
+        calloutState,
+        styleURL,
+        onMapFinishedLoading,
+        attributionBottom = 8,
+        attributionVisible = true,
+      },
       forwardedRef,
     ): React.JSX.Element => {
       const mapRef = useRef<Mapbox.MapView>(null);
@@ -279,6 +288,10 @@ export const SiteMap = memo(
           ref={mapRef}
           style={styles.mapView}
           scaleBarEnabled={false}
+          attributionEnabled={attributionVisible}
+          logoEnabled={attributionVisible}
+          logoPosition={{bottom: attributionBottom, left: 8}}
+          attributionPosition={{bottom: attributionBottom, right: 8}}
           styleURL={styleURL}
           onPress={onPress}
           onDidFinishLoadingMap={onMapFinishedLoading}>


### PR DESCRIPTION
see https://tech-matters.slack.com/archives/C0376RCCXD2/p1778262930558469 and https://tech-matters.slack.com/archives/C0376RCCXD2/p1778262930558469

screenshots in slack https://tech-matters.slack.com/archives/C0376RCCXD2/p1778265153652109

you can also try v348staging build.

Detailed summary:

Mapbox's TOS requires the logo + (i) attribution wherever Mapbox tiles are shown (https://docs.mapbox.com/help/dive-deeper/attribution/). The main SitesScreen map had them at their default bottom-left position (hidden behind the SiteList bottom sheet), and StaticMapView had them explicitly disabled.

SiteMap (main interactive map):
- Place the logo at bottom-left and the (i) info button at bottom-right of the map view, with a `bottom` offset that sits just above the bottom sheet's top edge at the current snap.
- Recompute the offset on each settled snap (onChange) so the controls stay above the sheet at every snap level, including the 75% snap.
- Hide while the sheet is animating between snaps so the controls don't visibly lag the sheet's motion.
- Plumbed through two new optional props on SiteListBottomSheet (onChange, onAnimate) and two new optional props on SiteMap (attributionBottom, attributionVisible).

StaticMapView (single-site map and site card thumbnails):
- Re-enable the standard bottom-corner logo + (i) by default, restoring TOS compliance on the location dashboard.
- The site list's tiny thumbnails are too small to legibly carry the controls, so add a `showAttribution` prop (default true) and pass false from SiteCard. Larger StaticMapView usages keep the default on.
