### PR TITLE
feat: remind to re-sync the soil-id DB when soil descriptions change

### DIFF
--- a/dev-client/scripts/i18n/poeditor-merge.mjs
+++ b/dev-client/scripts/i18n/poeditor-merge.mjs
@@ -1088,6 +1088,31 @@ async function main() {
 
   const commitMessage = commitLines.join('\n');
 
+  // Heads-up if WRB soil description translations changed: the backend serves
+  // these from the soil-id `wrb_fao90_desc` table, not from these JSON files, so
+  // they need a separate re-sync to take effect.
+  const soilDescriptionsChanged = LANGUAGES.some(lang => {
+    const d = langData[lang];
+    if (!d) return false;
+    return [
+      ...d.localDiff.added.keys(),
+      ...d.poeditorDiff.added.keys(),
+      ...d.localDiff.removed,
+      ...d.poeditorDiff.removed,
+      ...d.localDiff.changed.keys(),
+      ...d.poeditorDiff.changed.keys(),
+    ].some(key => key.startsWith('soil.match_info.'));
+  });
+  const printSoilSyncReminder = () => {
+    if (!soilDescriptionsChanged) return;
+    console.log(
+      '\n⚠️  Soil description translations (soil.match_info.*) changed.\n' +
+        '   The backend serves these from the soil-id `wrb_fao90_desc` table, not these\n' +
+        '   JSON files. Re-sync it: run soil-id-algorithm/scripts/wrb_descriptions_sync.py\n' +
+        '   (review the diff, then --write), then regenerate/redistribute the soil-id-db dump.',
+    );
+  };
+
   if (NO_COMMIT) {
     // Skip commit/tag — just report what changed
     console.log('Skipping commit and tag (--no-commit).\n');
@@ -1108,6 +1133,7 @@ async function main() {
       '  git checkout -- locales/po/ src/translations/ locales/po-save/ locales/sync-tag',
     );
     console.log(`\nChanges summarized: ${report.path}`);
+    printSoilSyncReminder();
     execSync(`open ${report.path}`);
     return;
   }
@@ -1147,6 +1173,7 @@ async function main() {
   console.log('Remember to push the commit and tag when ready:');
   console.log(`  git push && git push origin ${tagName}`);
   console.log(`\nChanges summarized: open ${report.path}`);
+  printSoilSyncReminder();
   execSync(`open ${report.path}`);
 }
 


### PR DESCRIPTION
The WRB soil Description/Management narratives shown in the app live in `soil.match_info.*` in our i18n files, **but the backend serves the same narratives from the soil-id `wrb_fao90_desc` Postgres table**, not from these JSON files. So when a POEditor merge changes those keys, the backend copy drifts until it is separately re-synced.

This adds a reminder to `poeditor-merge.mjs`: when a merge touches any `soil.match_info.*` key, it prints a note to re-sync the soil-id DB via `soil-id-algorithm/scripts/wrb_descriptions_sync.py` (review the diff, then `--write`) and regenerate/redistribute the soil-id-db dump. The reminder prints on the commit and `--no-commit` paths (not on `--dry-run`, which changes nothing); behavior is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)