### PR TITLE
fix: log the real pull failure instead of "Rejected" placeholder

### DIFF
--- a/dev-client/src/model/sync/syncGlobalReducer.ts
+++ b/dev-client/src/model/sync/syncGlobalReducer.ts
@@ -110,7 +110,13 @@ export const syncGlobalReducer = createGlobalReducer(builder => {
   });
 
   builder.addCase(pullUserData.rejected, (_state, action) => {
-    console.error('⬇️ pull rejected:', action.error);
+    // The shared createAsyncThunk wrapper (terraso-client-shared/src/store/
+    // utils.ts) catches and re-rejects via rejectWithValue({error,
+    // parsedErrors}) — that makes action.error a literal {message:
+    // "Rejected"} placeholder, while the real failure info lives in
+    // action.payload.error. Prefer it; fall back to action.error for
+    // rejections that bypassed the wrapper (condition / abort / etc.).
+    console.error('⬇️ pull rejected:', action.payload?.error ?? action.error);
   });
 
   builder.addCase(pushUserData.fulfilled, (state, action) => {


### PR DESCRIPTION
minor: only changes console output to make debugging easier.  no end-user-visible change.

pullUserData is wrapped by terraso-client-shared/src/store/utils.ts' createAsyncThunk, which catches the underlying error and re-rejects via rejectWithValue({ error, parsedErrors }). After that, action.error is just the literal { message: "Rejected" } placeholder Redux Toolkit emits, and the real failure info is on action.payload.error.

Today's "pull rejected:" console.error prints the placeholder, which is useless for debugging. Prefer action.payload?.error and fall back to action.error so we still see something for rejections that bypass the wrapper (condition / abort / etc.).

Comment in code explains the wrapper behavior so the next person debugging a pull failure doesn't have to re-derive it.
