### PR TITLE
refactor: send raw Munsell to soil-ID instead of client-side LAB

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -83,7 +83,7 @@
         "react-redux": "^9.2.0",
         "reduce-reducers": "^1.0.4",
         "setimmediate": "^1.0.5",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#6cb06d2b40562f8a7f9f28a1e4f349cc005763cb",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-06-17.0",
         "use-debounce": "^10.0.6",
         "uuid": "^11.1.0",
         "yup": "^1.7.1"
@@ -24739,15 +24739,14 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#6cb06d2b40562f8a7f9f28a1e4f349cc005763cb",
-      "integrity": "sha512-NWzcDrjszjBzeBe/SYcqbN3DwCiMr+UbVoEVrgEKUdpTAlOR4F2mD790NpFiXXGOI5BJ1giSURLwjN1YQ/kOVw==",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#7ef1e7271a03c4f51e53709206b56890664bd87f",
       "dependencies": {
         "@reduxjs/toolkit": "^2.11.1",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-06-13.0",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-06-17.0",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "LandPKS Soil ID",
+  "name": "terraso-mobile-client",
   "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "LandPKS Soil ID",
+      "name": "terraso-mobile-client",
       "version": "1.4.6",
       "hasInstallScript": true,
       "dependencies": {
@@ -83,7 +83,7 @@
         "react-redux": "^9.2.0",
         "reduce-reducers": "^1.0.4",
         "setimmediate": "^1.0.5",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-04-23.0",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#6cb06d2b40562f8a7f9f28a1e4f349cc005763cb",
         "use-debounce": "^10.0.6",
         "uuid": "^11.1.0",
         "yup": "^1.7.1"
@@ -24735,18 +24735,19 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#7fcff697833ecd16e27dc858ba9bfa6d28ebd1c6"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#4b32a981e14cb886ee4cec25fe1899a846f5ef86"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#cb0c799e415ed985b88d92ec495118084d5e710f",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#6cb06d2b40562f8a7f9f28a1e4f349cc005763cb",
+      "integrity": "sha512-NWzcDrjszjBzeBe/SYcqbN3DwCiMr+UbVoEVrgEKUdpTAlOR4F2mD790NpFiXXGOI5BJ1giSURLwjN1YQ/kOVw==",
       "dependencies": {
         "@reduxjs/toolkit": "^2.11.1",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-04-21.0",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-06-13.0",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -112,7 +112,7 @@
     "react-redux": "^9.2.0",
     "reduce-reducers": "^1.0.4",
     "setimmediate": "^1.0.5",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-04-23.0",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#6cb06d2b40562f8a7f9f28a1e4f349cc005763cb",
     "use-debounce": "^10.0.6",
     "uuid": "^11.1.0",
     "yup": "^1.7.1"

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -112,7 +112,7 @@
     "react-redux": "^9.2.0",
     "reduce-reducers": "^1.0.4",
     "setimmediate": "^1.0.5",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#6cb06d2b40562f8a7f9f28a1e4f349cc005763cb",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-06-17.0",
     "use-debounce": "^10.0.6",
     "uuid": "^11.1.0",
     "yup": "^1.7.1"

--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchInputs.test.tsx
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchInputs.test.tsx
@@ -15,15 +15,11 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  DepthDependentSoilData,
-  SoilData,
-} from 'terraso-client-shared/soilId/soilIdTypes';
+import {SoilData} from 'terraso-client-shared/soilId/soilIdTypes';
 
 import {
   degreeToPercent,
   selectToPercent,
-  soilDataLabColorInput,
   soilDataSlopePercent,
   soilDataToIdInput,
 } from 'terraso-mobile-client/model/soilIdMatch/actions/soilIdMatchInputs';
@@ -77,42 +73,6 @@ describe('soilDataSlopePercent', () => {
   });
 });
 
-describe('soilDataLabColorInput', () => {
-  let data: DepthDependentSoilData;
-
-  beforeEach(() => {
-    data = {
-      colorHue: undefined,
-      colorValue: undefined,
-      colorChroma: undefined,
-    } as DepthDependentSoilData;
-  });
-
-  test('handles missing values', () => {
-    expect(soilDataLabColorInput(data)).toBeUndefined();
-
-    data.colorHue = 1;
-    expect(soilDataLabColorInput(data)).toBeUndefined();
-
-    data.colorValue = 1;
-    expect(soilDataLabColorInput(data)).toBeUndefined();
-
-    data.colorChroma = 1;
-    expect(soilDataLabColorInput(data)).toBeDefined();
-  });
-
-  test('applies the conversion math', () => {
-    data.colorHue = 0.5;
-    data.colorValue = 0.5;
-    data.colorChroma = 0.5;
-
-    const {L, A, B} = soilDataLabColorInput(data)!;
-    expect(L).toBeCloseTo(5.124);
-    expect(A).toBeCloseTo(3.437);
-    expect(B).toBeCloseTo(-0.784);
-  });
-});
-
 describe('soilDataToIdInput', () => {
   let data: SoilData;
 
@@ -124,14 +84,14 @@ describe('soilDataToIdInput', () => {
     } as SoilData;
   });
 
-  test('restructures data', () => {
+  test('forwards raw Munsell as colorMunsellNumeric', () => {
     data.slopeSteepnessDegree = 45;
     data.depthDependentData = [
       {
         depthInterval: {start: 1, end: 2},
-        colorHue: 0,
-        colorValue: 0,
-        colorChroma: 0,
+        colorHue: 17.5,
+        colorValue: 5,
+        colorChroma: 4,
         rockFragmentVolume: 'VOLUME_0_1',
         texture: 'CLAY',
       },
@@ -140,12 +100,28 @@ describe('soilDataToIdInput', () => {
       depthDependentData: [
         {
           depthInterval: {start: 1, end: 2},
-          colorLAB: {L: 0, A: 0, B: 0},
+          colorMunsellNumeric: {hue: 17.5, value: 5, chroma: 4},
           rockFragmentVolume: 'VOLUME_0_1',
           texture: 'CLAY',
         },
       ],
       slope: 100,
     });
+  });
+
+  test('omits colorMunsellNumeric when any Munsell coordinate is missing', () => {
+    data.slopeSteepnessDegree = 45;
+    data.depthDependentData = [
+      {
+        depthInterval: {start: 1, end: 2},
+        colorHue: 17.5,
+        colorValue: 5,
+        // colorChroma intentionally absent
+        rockFragmentVolume: 'VOLUME_0_1',
+        texture: 'CLAY',
+      },
+    ];
+    const result = soilDataToIdInput(data);
+    expect(result.depthDependentData[0].colorMunsellNumeric).toBeUndefined();
   });
 });

--- a/dev-client/src/model/soilIdMatch/actions/soilIdMatchInputs.ts
+++ b/dev-client/src/model/soilIdMatch/actions/soilIdMatchInputs.ts
@@ -15,10 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {mhvcToLab} from 'munsell';
-
 import {
-  LabColorInput,
   Maybe,
   SoilIdInputData,
   SoilIdInputDepthDependentData,
@@ -78,20 +75,6 @@ export const soilDataSlopePercent = (
   }
 };
 
-export const soilDataLabColorInput = (
-  data: DepthDependentSoilData,
-): LabColorInput | undefined => {
-  if (
-    typeof data.colorHue !== 'number' ||
-    typeof data.colorValue !== 'number' ||
-    typeof data.colorChroma !== 'number'
-  ) {
-    return undefined;
-  }
-  const [L, A, B] = mhvcToLab(data.colorHue, data.colorValue, data.colorChroma);
-  return {L, A, B};
-};
-
 export const soilDataToIdInput = (data: SoilData): SoilIdInputData => {
   return {
     depthDependentData: data.depthDependentData.map(
@@ -105,9 +88,18 @@ export const soilDataToIdInput = (data: SoilData): SoilIdInputData => {
 export const soilDepthDependentDataToIdInput = (
   data: DepthDependentSoilData,
 ): SoilIdInputDepthDependentData => {
+  const {colorHue, colorValue, colorChroma} = data;
+  // Send raw Munsell; the backend converts to LAB via its reference table.
+  // Keep the all-three-numbers guard — partial Munsell is meaningless here.
+  const colorMunsellNumeric =
+    typeof colorHue === 'number' &&
+    typeof colorValue === 'number' &&
+    typeof colorChroma === 'number'
+      ? {hue: colorHue, value: colorValue, chroma: colorChroma}
+      : undefined;
   return {
     depthInterval: data.depthInterval,
-    colorLAB: soilDataLabColorInput(data),
+    colorMunsellNumeric,
     rockFragmentVolume: data.rockFragmentVolume,
     texture: data.texture,
   };


### PR DESCRIPTION
Stop converting Munsell → LAB on the client for the soil-ID match request. Send the stored hue/value/chroma directly via the backend's new `colorMunsellNumeric` input; the backend converts to LAB using its soil-id reference table, so the conversion happens in exactly one place.

This is the **mobile counterpart to backend techmatters/terraso-backend#2052** (the soil-ID API now accepts Munsell color), and it closes a latent inconsistency between mobile's `npm-munsell` LAB and the backend's table-derived LAB (slightly different L\*a\*b\* for the same Munsell triple).

### Changes
- `soilIdMatchInputs.ts` — drop the `mhvcToLab` import and the `soilDataLabColorInput` helper; build `colorMunsellNumeric` inline from `colorHue`/`colorValue`/`colorChroma`, keeping the all-three-numbers guard (partial Munsell is meaningless to send).
- Tests updated (raw-forwarding case + omit-when-a-coordinate-is-missing case).
- `npm munsell` stays — still used by `colorDetection.ts` (photo gamut check) and `colorConversions.ts` (swatches). Only the soil-ID request path drops the LAB conversion.
- Sync/push path untouched (already sends raw `colorHue`/`colorValue`/`colorChroma`).

### ⚠️ Behavior change worth a look in review
Out-of-gamut photo-derived colors (chroma ≳ 30) previously shipped an interpolated LAB to the backend. Now those Munsell triples won't match the backend's reference table, so the server silently drops the color for that depth (no error). Intentional — those were junk values.

### ⚠️ Merge prerequisite (cross-repo)
Depends on **terraso-client-shared** GraphQL types including `MunsellColorInput` / `colorMunsellNumeric` (generated from the #2052 backend schema). The `terraso-client-shared` pin in `dev-client/package.json` must bump to a tagged release that has them before this can merge — they were only generated locally during development so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
