### PR TITLE
fix: allow soil depths up to 300cm (and log real push failures)

### DIFF
--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -83,7 +83,7 @@
         "react-redux": "^9.2.0",
         "reduce-reducers": "^1.0.4",
         "setimmediate": "^1.0.5",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-06-17.0",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-06-26.1",
         "use-debounce": "^10.0.6",
         "uuid": "^11.1.0",
         "yup": "^1.7.1"
@@ -24739,14 +24739,14 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#7ef1e7271a03c4f51e53709206b56890664bd87f",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#fdcc3f96e81893c1022ededb9068f52c3422cc49",
       "dependencies": {
         "@reduxjs/toolkit": "^2.11.1",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-06-17.0",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-06-26.1",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -112,7 +112,7 @@
     "react-redux": "^9.2.0",
     "reduce-reducers": "^1.0.4",
     "setimmediate": "^1.0.5",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-06-17.0",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-06-26.1",
     "use-debounce": "^10.0.6",
     "uuid": "^11.1.0",
     "yup": "^1.7.1"

--- a/dev-client/src/constants.ts
+++ b/dev-client/src/constants.ts
@@ -24,7 +24,7 @@ export const LATITUDE_MIN = -90;
 export const LATITUDE_MAX = 90;
 export const LONGITUDE_MIN = -180;
 export const LONGITUDE_MAX = 180;
-export const DEPTH_MAX = 200;
+export const DEPTH_MAX = 300;
 
 export const SITE_NAME_MIN_LENGTH = 3;
 export const SITE_NAME_MAX_LENGTH = 50;

--- a/dev-client/src/model/sync/syncGlobalReducer.ts
+++ b/dev-client/src/model/sync/syncGlobalReducer.ts
@@ -175,6 +175,8 @@ export const syncGlobalReducer = createGlobalReducer(builder => {
   });
 
   builder.addCase(pushUserData.rejected, (_state, action) => {
-    console.error('⬆️ push rejected:', action.error);
+    // See pullUserData.rejected above for why action.payload.error is
+    // preferred over action.error.
+    console.error('⬆️ push rejected:', action.payload?.error ?? action.error);
   });
 });


### PR DESCRIPTION
## Summary
- Raise `DEPTH_MAX` from 200 to 300, lifting the cap on all three site-level depth-interval paths (NRCS, BLM, CUSTOM). NRCS users now see an Add Depth button to extend past 200cm; BLM/CUSTOM users can add intervals up to 300 instead of 200.
- Mirror the recent pull-side logging fix (#3301) on the push side so a rejected `pushUserData` thunk surfaces the real error instead of the `{message: "Rejected"}` placeholder.

## Notes
- The NRCS preset table is unchanged (still ships 0..200). Users opt in to deeper intervals by adding them.
- terraso-backend still rejects intervals > 200 with `INVALID_DATA`. Until the backend cap is raised, the client-side change isn't useful end-to-end — but it's a no-op for users who don't try to add a > 200 interval.
- The push-side logging fix only affects thunk-level rejections (network errors, etc). Per-record server failures still come back via the existing `logPushResults` channel as enum reasons.

## Test plan
- [ ] Site with NRCS preset: Add Depth button appears; can add an interval ending at 300
- [ ] Site with BLM preset: Add Depth button works as before; can add an interval ending at 300
- [ ] Site with CUSTOM preset: existing add/edit flows still work; cap is 300
- [ ] Try to add an interval ending > 300: validation rejects with the standard message
- [ ] Trigger a push thunk rejection (e.g. airplane mode mid-push): console shows a real error object, not `{message: "Rejected"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)