### PR TITLE
fix: update version to 1.4.7

### DIFF
--- a/dev-client/app.config.ts
+++ b/dev-client/app.config.ts
@@ -93,7 +93,7 @@ if (typeof APP_BUILD === 'string') {
 const defaultConfig: ExpoConfig = {
   name: 'LandPKS Soil ID',
   slug: 'landpks',
-  version: '1.4.6',
+  version: '1.4.7',
   newArchEnabled: true,
   orientation: 'portrait',
   splash: {

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraso-mobile-client",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraso-mobile-client",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "hasInstallScript": true,
       "dependencies": {
         "@craftzdog/react-native-buffer": "^6.1.1",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraso-mobile-client",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "scripts": {
     "android": "npx dotenv -e ~/secrets/terraso-mobile-client/.env -- expo run:android",


### PR DESCRIPTION
## Description
iOS doesn't let us make a new staging build unless the version number is greater than the previously globally-released version. So, bump version to 1.4.7 using the update-version script