### PR TITLE
fix: serialize RNMBX image queue to avoid CUICatalog heap corruption

### DIFF
--- a/dev-client/patches/@rnmapbox+maps+10.2.5.patch
+++ b/dev-client/patches/@rnmapbox+maps+10.2.5.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXImageQueue.swift b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXImageQueue.swift
+index 0560de2..ca2d772 100644
+--- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXImageQueue.swift
++++ b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXImageQueue.swift
+@@ -127,6 +127,12 @@ class RNMBXImageQueue {
+   var imageQueue : OperationQueue = {
+     let result = OperationQueue()
+     result.name = "comp.mapbox.RNMBX.DownloadImageQueue"
++    // Serialize image loads. Each operation resolves a local asset off the main
++    // thread via +[UIImage imageNamed:inBundle:], which reaches into Apple's
++    // non-thread-safe CUICatalog cache. Concurrent operations race on that cache
++    // and corrupt the heap (SIGABRT: "pointer being freed was not allocated").
++    // maxConcurrentOperationCount = 1 removes the race between our own loads.
++    result.maxConcurrentOperationCount = 1
+     return result
+   }()
+   


### PR DESCRIPTION
## Official bug report: 

https://github.com/techmatters/terraso-mobile-client/issues/3312

Note: this is a simple patch in RN MapBox image loading, but it occurs infrequently so maybe not urgent.  On the other hand, we could be having invalid free without detecting, which is pretty bad.


## Problem

A Sentry crash report showed a native `SIGABRT` — `pointer being freed was not allocated` — from the iOS asset-catalog cache:

```
libsystem_malloc  ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
CoreFoundation    -[NSCache setName:]
CoreUI            -[CUICatalog negativeCache]
...
React             RCTImageFromLocalAssetURL
LandPKSSoilID     closure in RNMBXImageQueueOperation.start (RNMBXImageQueue.swift:72)
libdispatch       _dispatch_worker_thread2
```

## Root cause

`SiteMap.tsx` renders `<Mapbox.Images images={mapImages} />` with three local pin PNGs (`sitePin`, `selectedSitePin`, `temporarySitePin`). To load each, `@rnmapbox/maps` enqueues an `RNMBXImageQueueOperation` whose `start()` dispatches to a background global queue and calls React's image loader, which resolves the local asset via `+[UIImage imageNamed:inBundle:]`.

That reaches into Apple's `CUICatalog` cache, which is **not thread-safe**. The RNMBX download `OperationQueue` sets no `maxConcurrentOperationCount`, so multiple pin images can resolve simultaneously on separate background threads and race on that cache — corrupting the heap and aborting.

This is rare (a single report) because it requires two+ images resolving at once, both off the main thread, hitting the narrow unsynchronized window on a cold catalog cache — usually one image wins the cache first.

## Fix

`patch-package` patch that sets `maxConcurrentOperationCount = 1` on the RNMBX image download `OperationQueue`, serializing these loads so they can't race on CUICatalog. Applied automatically via the existing `postinstall` → `patch-package` hook; takes effect on the next native iOS build.

## Notes

- Native-only change — needs a native rebuild (not just a Metro reload) to take effect.
- Patch is pinned to `@rnmapbox+maps+10.2.5`; a version bump will require regenerating it.
- Hard to unit-verify (native heisen-race); confidence rests on the patch matching the crash stack exactly — all crashing frames are inside this one queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)