### PR TITLE
fix: TextField and FormTextField show error on first focus, instead of on "blur"

### DIFF
--- a/dev-client/__tests__/snapshot/__snapshots__/CreateSiteScreen-test.tsx.snap
+++ b/dev-client/__tests__/snapshot/__snapshots__/CreateSiteScreen-test.tsx.snap
@@ -598,7 +598,31 @@ exports[`renders correctly 1`] = `
                                         "paddingLeft": 4,
                                       }
                                     }
-                                  />
+                                  >
+                                    <Text
+                                      collapsable={false}
+                                      maxFontSizeMultiplier={1.5}
+                                      onLayout={[Function]}
+                                      style={
+                                        {
+                                          "color": "rgba(73, 69, 79, 1)",
+                                          "fontFamily": "System",
+                                          "fontSize": 12,
+                                          "fontWeight": "400",
+                                          "letterSpacing": 0.25,
+                                          "lineHeight": 20,
+                                          "opacity": 1,
+                                          "paddingHorizontal": 12,
+                                          "paddingVertical": 4,
+                                          "textAlign": "left",
+                                          "transform": [],
+                                          "writingDirection": "ltr",
+                                        }
+                                      }
+                                    >
+                                      0 / 50 characters
+                                    </Text>
+                                  </View>
                                 </View>
                                 <View
                                   dataSet={{}}

--- a/dev-client/src/components/form/FormTextField.test.tsx
+++ b/dev-client/src/components/form/FormTextField.test.tsx
@@ -62,7 +62,7 @@ describe('FormTextField', () => {
     expect(getByDisplayValue('a@b.com')).toBeTruthy();
   });
 
-  test('does not show error before the field is touched (default onTouch)', async () => {
+  test('does not show error before the field is focused (default afterFirstFocus)', async () => {
     const {queryByText} = await renderInFormik(
       {email: ''},
       <FormTextField<EmailForm> name="email" testID="field" />,
@@ -72,7 +72,7 @@ describe('FormTextField', () => {
     expect(queryByText('Required')).toBeNull();
   });
 
-  test('shows error after the field is blurred', async () => {
+  test('shows error after the field is focused (default afterFirstFocus)', async () => {
     const {queryByText, getByTestId} = await renderInFormik(
       {email: ''},
       <FormTextField<EmailForm> name="email" testID="field" />,
@@ -80,7 +80,7 @@ describe('FormTextField', () => {
     );
 
     await act(async () => {
-      fireEvent(getByTestId('field'), 'blur');
+      fireEvent(getByTestId('field'), 'focus');
     });
 
     expect(queryByText('Required')).toBeTruthy();
@@ -132,31 +132,7 @@ describe('FormTextField', () => {
     expect(queryByText('Invalid email')).toBeTruthy();
   });
 
-  test('explicit errorTiming="afterBlur" defers to the derived rule (shows after blur)', async () => {
-    /* Within FormTextField only `'immediate'` is a real override; explicit
-     * `'afterBlur'` falls into the derived branch and behaves like omitting
-     * the prop. Pin that down so a refactor can't silently break the
-     * touched/submit escalation. */
-    const {queryByText, getByTestId} = await renderInFormik(
-      {email: ''},
-      <FormTextField<EmailForm>
-        name="email"
-        testID="field"
-        errorTiming="afterBlur"
-      />,
-      {validate: () => ({email: 'Required'})},
-    );
-
-    expect(queryByText('Required')).toBeNull();
-
-    await act(async () => {
-      fireEvent(getByTestId('field'), 'blur');
-    });
-
-    expect(queryByText('Required')).toBeTruthy();
-  });
-
-  test('explicit errorTiming="afterBlur" still escalates after submit', async () => {
+  test('explicit errorTiming="afterFirstFocus" still escalates after submit', async () => {
     let submitForm: (() => void) | undefined;
     const {queryByText} = render(
       <Formik<EmailForm>
@@ -169,7 +145,7 @@ describe('FormTextField', () => {
             <FormTextField<EmailForm>
               name="email"
               testID="field"
-              errorTiming="afterBlur"
+              errorTiming="afterFirstFocus"
             />
           );
         }}
@@ -186,10 +162,10 @@ describe('FormTextField', () => {
     expect(queryByText('Required')).toBeTruthy();
   });
 
-  test('shows error after submit even when the field was never blurred', async () => {
+  test('shows error after submit even when the field was never focused', async () => {
     /* Regression for the AddTeamMemberForm bug: user types and taps the
-     * submit button without ever blurring. setErrors / yup errors must
-     * surface because submitCount>0 satisfies the touched signal. */
+     * submit button without ever focusing away. setErrors / yup errors must
+     * surface because submitCount>0 forces 'immediate' timing. */
     let submitForm: (() => void) | undefined;
     const {queryByText} = render(
       <Formik<EmailForm>
@@ -250,25 +226,6 @@ describe('FormTextField', () => {
     });
 
     expect(callerHandler).toHaveBeenCalledWith('new');
-  });
-
-  test('layered onBlur runs after Formik setFieldTouched', async () => {
-    const callerHandler = jest.fn();
-
-    const {getByTestId} = await renderInFormik(
-      {email: ''},
-      <FormTextField<EmailForm>
-        name="email"
-        testID="field"
-        onBlur={callerHandler}
-      />,
-    );
-
-    await act(async () => {
-      fireEvent(getByTestId('field'), 'blur');
-    });
-
-    expect(callerHandler).toHaveBeenCalled();
   });
 
   test('forwards display props (label, helperText, required) to TextField', async () => {

--- a/dev-client/src/components/form/FormTextField.tsx
+++ b/dev-client/src/components/form/FormTextField.tsx
@@ -24,16 +24,6 @@ import {
 
 /* FormTextField — use instead of TextField when in a Formik form.
  *
- * Reads value / errors / touched / submitCount from the surrounding Formik
- * provider and forwards them to TextField. TextField owns the display rule;
- * we just supply the "touched" signal as touched OR submitCount>0 so post-
- * submit errors surface even when the user never blurred the field.
- *
- * onChangeText / onBlur are LAYERED — they run after Formik has updated
- * its own state for this field, and exist for side effects only (e.g.,
- * updating a linked field). Callers do NOT need to call setFieldValue or
- * handleChange for `name` themselves.
- *
  * For async / backend errors, push them into Formik via setFieldError(name,
  * message) so they flow through the same display channel as Yup errors. */
 
@@ -52,8 +42,9 @@ type StringFieldKeys<TValues> = {
 export type FormTextFieldProps<TValues extends FormikValues> =
   SharedTextFieldProps & {
     name: StringFieldKeys<TValues>;
+
+    // Optional onChangeText runs after FormTextField  has already updated  Formik state for `name` — callers should NOT call setFieldValue(name, ...) themselves.
     onChangeText?: (value: string) => void;
-    onBlur?: () => void;
   };
 
 /* Generic over the surrounding Formik form's values shape. Callers must
@@ -67,7 +58,6 @@ export type FormTextFieldProps<TValues extends FormikValues> =
 export const FormTextField = <TValues extends FormikValues>({
   name,
   onChangeText,
-  onBlur,
   errorTiming,
   ...rest
 }: FormTextFieldProps<TValues>) => {
@@ -85,16 +75,10 @@ export const FormTextField = <TValues extends FormikValues>({
     );
   }
   const error = typeof rawError === 'string' ? rawError : undefined;
-  const isTouched = Boolean(formik.touched[name]);
 
   const handleChangeText = (next: string) => {
     formik.setFieldValue(name, next);
     onChangeText?.(next);
-  };
-
-  const handleBlur = () => {
-    formik.setFieldTouched(name, true);
-    onBlur?.();
   };
 
   return (
@@ -102,20 +86,9 @@ export const FormTextField = <TValues extends FormikValues>({
       {...rest}
       value={(value ?? '') as string}
       onChangeText={handleChangeText}
-      onBlur={handleBlur}
       error={error}
-      /* Timing may be afterBlur or immediate.
-       * With 'afterBlur' (default), we also show errors after form is submitted.
-       * (This is critical for backend errors set via setErrors.)
-       * And 'immediate' is useful when the surrounding form has no blur path
-       * (e.g., single-field edit screens). */
-      errorTiming={
-        errorTiming === 'immediate'
-          ? 'immediate'
-          : isTouched || formik.submitCount > 0
-            ? 'immediate'
-            : 'afterBlur'
-      }
+      /* Generally forms will disable their submit buttons if there are errors. But just in case, mae sure we show errors after form submit. */
+      errorTiming={formik.submitCount > 0 ? 'immediate' : errorTiming}
     />
   );
 };

--- a/dev-client/src/components/form/FormTextField.tsx
+++ b/dev-client/src/components/form/FormTextField.tsx
@@ -43,7 +43,7 @@ export type FormTextFieldProps<TValues extends FormikValues> =
   SharedTextFieldProps & {
     name: StringFieldKeys<TValues>;
 
-    // Optional onChangeText runs after FormTextField  has already updated  Formik state for `name` — callers should NOT call setFieldValue(name, ...) themselves.
+    // Optional onChangeText runs after FormTextField has already updated Formik state for `name` — callers should NOT call setFieldValue(name, ...) themselves.
     onChangeText?: (value: string) => void;
   };
 
@@ -87,7 +87,7 @@ export const FormTextField = <TValues extends FormikValues>({
       value={(value ?? '') as string}
       onChangeText={handleChangeText}
       error={error}
-      /* Generally forms will disable their submit buttons if there are errors. But just in case, mae sure we show errors after form submit. */
+      /* Forms usually disable submit while invalid, but if a submit does happen (e.g., backend error set via setFieldError), force errors visible regardless of focus state. */
       errorTiming={formik.submitCount > 0 ? 'immediate' : errorTiming}
     />
   );

--- a/dev-client/src/components/inputs/TextField.test.tsx
+++ b/dev-client/src/components/inputs/TextField.test.tsx
@@ -47,22 +47,6 @@ describe('TextField', () => {
     expect(onChangeText).toHaveBeenCalledWith('new text');
   });
 
-  test('calls onBlur when the input loses focus', () => {
-    const onBlur = jest.fn();
-
-    const {getByTestId} = render(
-      <TextField
-        value=""
-        onChangeText={() => {}}
-        onBlur={onBlur}
-        testID="field"
-      />,
-    );
-    fireEvent(getByTestId('field'), 'blur');
-
-    expect(onBlur).toHaveBeenCalled();
-  });
-
   test('appends asterisk to the label when required', () => {
     /* Paper renders the label in two animated nodes (active + inactive); we
      * tolerate either via getAllByText with a regex. */
@@ -114,7 +98,7 @@ describe('TextField', () => {
     expect(queryByText('We never share it')).toBeTruthy();
   });
 
-  test('shows error and hides helper text once the field has been blurred', () => {
+  test('shows error and hides helper text once the field has been focused', () => {
     const {queryByText, getByTestId} = render(
       <TextField
         value=""
@@ -125,13 +109,13 @@ describe('TextField', () => {
       />,
     );
 
-    fireEvent(getByTestId('field'), 'blur');
+    fireEvent(getByTestId('field'), 'focus');
 
     expect(queryByText('An error!')).toBeTruthy();
     expect(queryByText('We never share it')).toBeNull();
   });
 
-  test('hides error until the field has been blurred', () => {
+  test('hides error until the field has been focused', () => {
     const {queryByText, getByTestId} = render(
       <TextField
         value=""
@@ -143,12 +127,12 @@ describe('TextField', () => {
 
     expect(queryByText('An error!')).toBeNull();
 
-    fireEvent(getByTestId('field'), 'blur');
+    fireEvent(getByTestId('field'), 'focus');
 
     expect(queryByText('An error!')).toBeTruthy();
   });
 
-  test('shows "Required" error for a required field with empty value once blurred', () => {
+  test('shows "Required" error for a required field with empty value once focused', () => {
     const {queryByText, getByTestId} = render(
       <TextField
         value=""
@@ -161,14 +145,14 @@ describe('TextField', () => {
 
     expect(queryByText('Required')).toBeNull();
 
-    fireEvent(getByTestId('field'), 'blur');
+    fireEvent(getByTestId('field'), 'focus');
 
     expect(queryByText('Required')).toBeTruthy();
   });
 
-  test('shows error without a blur when errorTiming="immediate"', () => {
+  test('shows error without a focus when errorTiming="immediate"', () => {
     /* Mirrors the FormTextField post-submit case: parent forces immediate
-     * display so a backend error surfaces even if the user never blurred. */
+     * display so a backend error surfaces even if the user never focused. */
     const {queryByText} = render(
       <TextField
         value=""
@@ -256,7 +240,7 @@ describe('TextField', () => {
       />,
     );
 
-    fireEvent(getByTestId('field'), 'blur');
+    fireEvent(getByTestId('field'), 'focus');
 
     expect(queryByText('An error!')).toBeNull();
     expect(queryByText('We never share it')).toBeNull();

--- a/dev-client/src/components/inputs/TextField.tsx
+++ b/dev-client/src/components/inputs/TextField.tsx
@@ -107,10 +107,6 @@ export const TextField = forwardRef<RNTextInput, TextFieldProps>(
       setHasBeenFocused(true);
     };
 
-    const handleBlur = () => {
-      setIsFocused(false);
-    };
-
     let errorToShow = error;
     if (!error && required && !value) {
       errorToShow = t('general.required');
@@ -145,7 +141,7 @@ export const TextField = forwardRef<RNTextInput, TextFieldProps>(
           value={value}
           onChangeText={onChangeText}
           onFocus={handleFocus}
-          onBlur={handleBlur}
+          onBlur={() => setIsFocused(false)}
           error={showError}
           multiline={multiline}
           maxLength={maxLength}

--- a/dev-client/src/components/inputs/TextField.tsx
+++ b/dev-client/src/components/inputs/TextField.tsx
@@ -53,10 +53,7 @@ export type SharedTextFieldProps = {
   readOnly?: boolean;
   required?: boolean;
   helperText?: string;
-  /* When to surface `error`.
-   * Defaults to 'afterBlur'. Single-field forms often want 'immediate'.
-   * FormTextField passes 'immediate' once Formik's touched/submitCount opens
-   * the gate, so backend errors after submit-without-blur still display. */
+  // When to surface `error` to user
   errorTiming?: ErrorTiming;
 
   style?: RNPTextInputProps['style'];
@@ -69,7 +66,6 @@ export type SharedTextFieldProps = {
 export type ControlledStateProps = {
   value: string;
   onChangeText?: (value: string) => void;
-  onBlur?: () => void;
   // Parent decides which error string to surface; TextField only decides timing.
   error?: string;
 };
@@ -93,9 +89,8 @@ export const TextField = forwardRef<RNTextInput, TextFieldProps>(
       maxLength,
       value = '',
       onChangeText,
-      onBlur,
       error,
-      errorTiming = 'afterBlur',
+      errorTiming = 'afterFirstFocus',
     },
     ref,
   ) => {
@@ -105,23 +100,22 @@ export const TextField = forwardRef<RNTextInput, TextFieldProps>(
     /* Focus state tracked locally because Paper's TextInput doesn't expose a
      * focus signal to consumers. */
     const [isFocused, setIsFocused] = useState(false);
+    const [hasBeenFocused, setHasBeenFocused] = useState(false);
 
-    /* Used only when errorTiming === 'afterBlur'.
-     * Doesn't reset on subsequent focus — once blurred, always blurred. */
-    const [hasBeenBlurred, setHasBeenBlurred] = useState(false);
+    const handleFocus = () => {
+      setIsFocused(true);
+      setHasBeenFocused(true);
+    };
 
-    const handleFocus = () => setIsFocused(true);
     const handleBlur = () => {
       setIsFocused(false);
-      setHasBeenBlurred(true);
-      onBlur?.();
     };
 
     let errorToShow = error;
     if (!error && required && !value) {
       errorToShow = t('general.required');
     }
-    const showError = shouldShowError(errorToShow, hasBeenBlurred, errorTiming);
+    const showError = shouldShowError(errorToShow, hasBeenFocused, errorTiming);
 
     /* Asterisk rides along with the floating label so it's positioned
      * consistently whether the field is empty (label sits in the input) or

--- a/dev-client/src/components/inputs/TextFieldHelpers.test.ts
+++ b/dev-client/src/components/inputs/TextFieldHelpers.test.ts
@@ -26,9 +26,9 @@ describe('shouldShowError', () => {
     expect(shouldShowError('', true, 'immediate')).toBe(false);
   });
 
-  test("'afterBlur' hides error until the field has been blurred", () => {
-    expect(shouldShowError('Required', false, 'afterBlur')).toBe(false);
-    expect(shouldShowError('Required', true, 'afterBlur')).toBe(true);
+  test("'afterFirstFocus' hides error until the field has been focused", () => {
+    expect(shouldShowError('Required', false, 'afterFirstFocus')).toBe(false);
+    expect(shouldShowError('Required', true, 'afterFirstFocus')).toBe(true);
   });
 
   test("'immediate' shows the error regardless of blur state", () => {

--- a/dev-client/src/components/inputs/TextFieldHelpers.ts
+++ b/dev-client/src/components/inputs/TextFieldHelpers.ts
@@ -23,9 +23,9 @@ import type {TextInputProps as RNTextInputProps} from 'react-native';
 export type TextFieldType = 'text' | 'email' | 'numeric';
 
 /* When TextField surfaces an `error` string:
- *   - 'afterBlur': only after the field has been blurred once (default UX)
- *   - 'immediate': as soon as `error` is set */
-export type ErrorTiming = 'immediate' | 'afterBlur';
+ *   - 'afterFirstFocus': after the user first focuses the field (default UX)
+ *   - 'immediate': as soon as `error` is set (may be on fist viewing) */
+export type ErrorTiming = 'afterFirstFocus' | 'immediate';
 
 export type TypePresetValues = {
   keyboardType: RNTextInputProps['keyboardType'];
@@ -53,13 +53,13 @@ export const TYPE_PRESETS: Record<TextFieldType, TypePresetValues> = {
 
 /* Gate the *display* of an error. Validation runs continuously (so `isValid`
  * stays accurate for submit buttons); this just decides when to surface it.
- * `hasBeenBlurred` is TextField's internal blur tracker; FormTextField forces
+ * `hasBeenFocused` tracks if the field has been focused; FormTextField forces
  * 'immediate' once the form-level signal (touched OR submitCount>0) opens. */
 export const shouldShowError = (
   error: string | undefined,
-  hasBeenBlurred: boolean,
+  hasBeenFocused: boolean,
   errorTiming: ErrorTiming,
 ): boolean => {
   if (!error) return false;
-  return errorTiming === 'immediate' || hasBeenBlurred;
+  return errorTiming === 'immediate' || hasBeenFocused;
 };

--- a/dev-client/src/components/inputs/TextFieldHelpers.ts
+++ b/dev-client/src/components/inputs/TextFieldHelpers.ts
@@ -22,11 +22,12 @@ import type {TextInputProps as RNTextInputProps} from 'react-native';
 
 export type TextFieldType = 'text' | 'email' | 'numeric';
 
-/* When TextField surfaces an `error` string:
+/* When TextField starts showing `error`.
+ * After the first time, errors are then shown immediately.
  *   - 'afterFirstFocus': after the user first focuses the field (default UX)
  *   - 'immediate': as soon as `error` is set (may be on first viewing).
- *      FormTextField forces 'immediate' after submit so backend errors surface
- *      without focus. */
+ *      FormTextField forces 'immediate' once Formik marks the field touched
+ *      (on focus or on submit) so backend errors surface without focus. */
 export type ErrorTiming = 'afterFirstFocus' | 'immediate';
 
 export type TypePresetValues = {
@@ -59,8 +60,8 @@ export const TYPE_PRESETS: Record<TextFieldType, TypePresetValues> = {
 
 /* Gate the *display* of an error. Validation runs continuously (so `isValid`
  * stays accurate for submit buttons); this just decides when to surface it.
- * FormTextField forces 'immediate' once submitCount>0 so post-submit errors
- * (e.g., backend errors) surface even on fields the user never focused. */
+ * FormTextField forces 'immediate' once Formik marks the field touched so
+ * post-submit errors (e.g., backend errors) surface even without focus. */
 export const shouldShowError = (
   error: string | undefined,
   hasBeenFocused: boolean,

--- a/dev-client/src/components/inputs/TextFieldHelpers.ts
+++ b/dev-client/src/components/inputs/TextFieldHelpers.ts
@@ -34,7 +34,11 @@ export type TypePresetValues = {
 };
 
 /* `type` bundles the keyboard / capitalization / autoComplete trio so callers
- * don't have to set all three for common cases (and so they can't forget one). */
+ * don't have to set all three for common cases (and so they can't forget one).
+ *
+ * FYI: Some iOS devices may not display the same keyboard layout. For example,
+ * 'numeric' displayed a more extensive keyboard on Courtney's ipad
+ */
 export const TYPE_PRESETS: Record<TextFieldType, TypePresetValues> = {
   text: {
     keyboardType: 'default',

--- a/dev-client/src/components/inputs/TextFieldHelpers.ts
+++ b/dev-client/src/components/inputs/TextFieldHelpers.ts
@@ -24,7 +24,9 @@ export type TextFieldType = 'text' | 'email' | 'numeric';
 
 /* When TextField surfaces an `error` string:
  *   - 'afterFirstFocus': after the user first focuses the field (default UX)
- *   - 'immediate': as soon as `error` is set (may be on fist viewing) */
+ *   - 'immediate': as soon as `error` is set (may be on first viewing).
+ *      FormTextField forces 'immediate' after submit so backend errors surface
+ *      without focus. */
 export type ErrorTiming = 'afterFirstFocus' | 'immediate';
 
 export type TypePresetValues = {
@@ -57,8 +59,8 @@ export const TYPE_PRESETS: Record<TextFieldType, TypePresetValues> = {
 
 /* Gate the *display* of an error. Validation runs continuously (so `isValid`
  * stays accurate for submit buttons); this just decides when to surface it.
- * `hasBeenFocused` tracks if the field has been focused; FormTextField forces
- * 'immediate' once the form-level signal (touched OR submitCount>0) opens. */
+ * FormTextField forces 'immediate' once submitCount>0 so post-submit errors
+ * (e.g., backend errors) surface even on fields the user never focused. */
 export const shouldShowError = (
   error: string | undefined,
   hasBeenFocused: boolean,

--- a/dev-client/src/components/util/UiComponentList.tsx
+++ b/dev-client/src/components/util/UiComponentList.tsx
@@ -148,7 +148,7 @@ const TextFieldExamples = () => {
     amount === ''
       ? undefined
       : Number.isNaN(amountNumber) || amountNumber < 100 || amountNumber > 10000
-        ? 'Must be a number between 0 and 10000'
+        ? 'Must be a number between 100 and 10000'
         : undefined;
 
   return (

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteForm.tsx
@@ -88,6 +88,7 @@ export const CreateSiteForm = ({
             placeholder={t('site.create.name_label')}
             label={t('site.create.name_label')}
             required
+            showCounter
           />
 
           <FormLabel>{t('site.create.location_label')}</FormLabel>

--- a/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
+++ b/dev-client/src/screens/SiteSettingsScreen/SiteSettingsScreen.tsx
@@ -126,9 +126,6 @@ export const SiteSettingsScreen = ({siteId}: Props) => {
                   placeholder={t('site.create.name_label')}
                   required
                   showCounter
-                  /* Screen has no blur path (single field, only buttons
-                   * elsewhere), so afterBlur would never escalate. */
-                  errorTiming="immediate"
                 />
                 <View mt={4} alignItems="flex-end">
                   <ContainedButton

--- a/dev-client/src/screens/SlopeScreen/components/ManualSteepnessOverlaySheet.tsx
+++ b/dev-client/src/screens/SlopeScreen/components/ManualSteepnessOverlaySheet.tsx
@@ -78,7 +78,7 @@ export const ManualSteepnessOverlaySheet = ({siteId, trigger}: Props) => {
           .number()
           .nullable()
           .optional()
-          .typeError(t('slope.steepness.percentage_help'))
+          .typeError(t('slope.steepness.degree_help'))
           .min(0, t('slope.steepness.degree_help'))
           .max(89, t('slope.steepness.degree_help')),
       }),


### PR DESCRIPTION
## Description
**Motivation**: The `errorTiming = afterBlur` option didn't work well. Different devices and forms vs standalone TextFields seemed to behave inconsistently (like, Android considered tapping out of the field to be 'onBlur', but on iOS it would only count if you tapped to another text field). 

**Decision**: Courtney and I decided to show the error to the user on `afterFirstFocus` instead of `afterBlur`. This is more consistent throughout scenarios and slightly simplifies the code.

**Changes**:
- Introduce and default to `afterFirstFocus`
- Remove `afterBlur`. (Not sure if `immediate` is reaaally needed anymore, but kept it in for one hypothetical case, and in case we want to extend errorTiming logic options)
- Also updated a few minor things in specific usages:
  - Manual steepness degree error text showed wrong string
  - Create Site should show character count

Also we should update the Figma and props documentation

### Related Issues
Fixes https://github.com/techmatters/terraso-mobile-client/issues/1718 and several of the "Implement" tasks (https://github.com/techmatters/terraso-mobile-client/issues/3240, etc)