### PR TITLE
fix: validate coordinates before moving the map camera

### DIFF
--- a/dev-client/src/screens/BottomTabsScreen.tsx
+++ b/dev-client/src/screens/BottomTabsScreen.tsx
@@ -33,6 +33,7 @@ import {ProjectListScreen} from 'terraso-mobile-client/screens/ProjectListScreen
 import {SitesScreen} from 'terraso-mobile-client/screens/SitesScreen/SitesScreen';
 import {UserSettingsScreen} from 'terraso-mobile-client/screens/UserSettingsScreen/UserSettingsScreen';
 import {useDispatch} from 'terraso-mobile-client/store';
+import {isValidCoords} from 'terraso-mobile-client/util';
 
 export const BottomTabsScreen = memo(() => {
   const dispatch = useDispatch();
@@ -56,7 +57,10 @@ export const BottomTabsScreen = memo(() => {
       locationManager
         .getLastKnownLocation()
         .then(initCoords => {
-          if (initCoords !== null) {
+          // Reject non-finite coordinates so invalid GPS never enters the
+          // store and reaches Mapbox's native setCamera (which crashes on
+          // non-numeric coordinates).
+          if (initCoords !== null && isValidCoords(initCoords.coords)) {
             dispatch(
               updateLocation({
                 coords: initCoords.coords,
@@ -71,6 +75,9 @@ export const BottomTabsScreen = memo(() => {
 
       // add listener to update location on user movement
       const listener = ({coords}: Location) => {
+        if (!isValidCoords(coords)) {
+          return;
+        }
         dispatch(
           updateLocation({
             coords: coords,

--- a/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteMap.tsx
@@ -49,6 +49,7 @@ import {
 } from 'terraso-mobile-client/screens/SitesScreen/SitesScreenCallout';
 import {repositionCamera} from 'terraso-mobile-client/screens/SitesScreen/utils/repositionCamera';
 import {siteFeatureCollection} from 'terraso-mobile-client/screens/SitesScreen/utils/siteFeatureCollection';
+import {isValidCoords} from 'terraso-mobile-client/util';
 
 // Extract OnPressEvent type from ShapeSource's onPress prop
 type OnPressEvent =
@@ -94,6 +95,12 @@ export const SiteMap = memo(
 
       useImperativeHandle(forwardedRef, () => ({
         moveToPoint: (coords: Coords) => {
+          // Non-finite coordinates make Mapbox's native setCamera throw
+          // "coordinates must contain numbers", which crashes the app. Guard
+          // here so every caller (initial camera, search, site pins) is safe.
+          if (!isValidCoords(coords)) {
+            return;
+          }
           cameraRef.current?.setCamera({
             centerCoordinate: coordsToPosition(coords),
             zoomLevel: STARTING_ZOOM_LEVEL,

--- a/dev-client/src/util.test.ts
+++ b/dev-client/src/util.test.ts
@@ -15,7 +15,38 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {isValidCoordinates} from 'terraso-mobile-client/util';
+import {isValidCoordinates, isValidCoords} from 'terraso-mobile-client/util';
+
+describe('isValidCoords', () => {
+  it('accepts finite, in-range coordinates', () => {
+    expect(isValidCoords({latitude: 12.345, longitude: 67.89})).toBe(true);
+    expect(isValidCoords({latitude: 0, longitude: 0})).toBe(true);
+    expect(isValidCoords({latitude: -90, longitude: 180})).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(isValidCoords(null)).toBe(false);
+  });
+
+  it('rejects NaN coordinates', () => {
+    expect(isValidCoords({latitude: NaN, longitude: 0})).toBe(false);
+    expect(isValidCoords({latitude: 0, longitude: NaN})).toBe(false);
+  });
+
+  it('rejects undefined coordinates', () => {
+    expect(isValidCoords({latitude: undefined, longitude: 0} as never)).toBe(
+      false,
+    );
+    expect(isValidCoords({latitude: 0, longitude: undefined} as never)).toBe(
+      false,
+    );
+  });
+
+  it('rejects out-of-range coordinates', () => {
+    expect(isValidCoords({latitude: 91, longitude: 0})).toBe(false);
+    expect(isValidCoords({latitude: 0, longitude: 181})).toBe(false);
+  });
+});
 
 describe('isValidCoordinates', () => {
   describe('valid coordinates', () => {

--- a/dev-client/src/util.ts
+++ b/dev-client/src/util.ts
@@ -172,6 +172,17 @@ export const isValidCoordinates = (input: string) => {
   return isValidLatitude(latitude) && isValidLongitude(longitude);
 };
 
+// Guards against non-finite coordinates (NaN/undefined/Infinity) reaching
+// native map APIs. Mapbox's setCamera throws "coordinates must contain numbers"
+// on a non-numeric centerCoordinate, which crashes the app via Hermes. Some
+// devices (e.g. Wi-Fi-only iPads using a CoreLocation fallback) can surface a
+// non-null location whose latitude/longitude are not finite numbers.
+// isValidLatitude/isValidLongitude already reject these (NaN >= -90 is false).
+export const isValidCoords = (coords: Coords | null): coords is Coords =>
+  coords !== null &&
+  isValidLatitude(coords.latitude) &&
+  isValidLongitude(coords.longitude);
+
 export const getSoilWebUrl = (coords: Coords) => {
   return `https://casoilresource.lawr.ucdavis.edu/gmap/?loc=${coords.latitude},${coords.longitude}`;
 };


### PR DESCRIPTION
## Problem

A Sentry crash — `EXC_BAD_ACCESS` in Hermes — traced to Mapbox's native `setCamera` throwing *"coordinates must contain numbers"* when handed a non-finite `centerCoordinate`, which Hermes then crashes on while converting the native exception to a JS error.

https://techmatters.sentry.io/issues/7609074277/?referrer=alert_email&alert_type=email&alert_timestamp=1783988264473&alert_rule_id=14823299&notification_uuid=cb5ccee8-4cf1-45b1-bd7b-16b32533836c&environment=production


User-location coords flow from `@rnmapbox/maps`' `locationManager` into Redux (`BottomTabsScreen`), then to `moveToPoint` → `coordsToPosition` → `setCamera`. The only guard along the way is `currentUserCoords !== null` (`SitesScreen.tsx:113`), which does **not** catch `NaN`/`undefined` latitude or longitude. A device that returns a non-null but invalid location (per the report, a Wi-Fi-only iPad surfacing a CoreLocation fallback) sends non-finite coords straight to native Mapbox.

## Fix

Add an `isValidCoords` type guard in `util.ts`, reusing the existing `isValidLatitude`/`isValidLongitude` (which already reject `NaN`/`undefined`, since `NaN >= -90` is `false`). Apply it at two choke points:

- **`BottomTabsScreen`** — don't dispatch invalid coords into the store, so garbage GPS never enters Redux (both `getLastKnownLocation` and the movement listener).
- **`SiteMap.moveToPoint`** — skip `setCamera` for invalid coords, protecting every caller (initial camera, search, site pins) as a backstop.

Adds unit tests for `isValidCoords` (finite/in-range, null, `NaN`, `undefined`, out-of-range).

## User-facing behavior

Instead of crashing, the app falls back gracefully and self-corrects:

| Situation | Before | After |
|---|---|---|
| Non-null but non-finite coords on load | **Crash (SIGABRT)** | Default US view (`DEFAULT_LOCATION`, zoom 3), then auto-centers when the first valid fix arrives |
| Tap "locate me" with no valid fix | crash risk | Silent no-op |

The initial-camera effect doesn't latch as "done" on invalid coords, so it still auto-centers once a valid fix lands. The native user-location puck is unaffected (it reads device location directly, not Redux).

## Notes

- The upstream question of *why* a device returns a non-finite location remains a theory; this makes it a non-event either way.
- Verified: `check-ts`, eslint/prettier, and unit tests (23 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)