### PR TITLE
fix: add "Unaffiliated (no project)" option to sites list filter

### DIFF
--- a/dev-client/src/screens/SitesScreen/components/SiteFilterModal.tsx
+++ b/dev-client/src/screens/SitesScreen/components/SiteFilterModal.tsx
@@ -25,6 +25,7 @@ import {
   SelectFilter,
   TextInputFilter,
 } from 'terraso-mobile-client/components/ListFilter';
+import {UNAFFILIATED_PROJECT_FILTER_VALUE} from 'terraso-mobile-client/screens/SitesScreen/utils/sitesScreenFilters';
 import {useSelector} from 'terraso-mobile-client/store';
 
 type Props = {
@@ -62,10 +63,16 @@ export const SiteFilterModal = ({useDistance}: Props) => {
   );
 
   const projects = useSelector(state => state.project.projects);
-  const projectIds = useMemo(() => Object.keys(projects), [projects]);
-  const renderProject = useCallback(
-    (id: string) => projects[id].name,
+  const projectIds = useMemo(
+    () => [UNAFFILIATED_PROJECT_FILTER_VALUE, ...Object.keys(projects)],
     [projects],
+  );
+  const renderProject = useCallback(
+    (id: string) =>
+      id === UNAFFILIATED_PROJECT_FILTER_VALUE
+        ? t('general.filter.unaffiliated')
+        : projects[id].name,
+    [projects, t],
   );
   const projectKey = useCallback((id: string) => id, []);
 

--- a/dev-client/src/screens/SitesScreen/utils/sitesScreenFilters.ts
+++ b/dev-client/src/screens/SitesScreen/utils/sitesScreenFilters.ts
@@ -22,6 +22,12 @@ import {normalizeText} from 'terraso-client-shared/utils';
 import {SortingOption} from 'terraso-mobile-client/components/ListFilter';
 import {equals, searchText} from 'terraso-mobile-client/util';
 
+// Sentinel filter value for the "Unaffiliated (no project)" option in the
+// project filter. Sites without a project have `projectId === undefined`,
+// which ListFilter's default lookup stringifies to "undefined" — the custom
+// filter function below matches on that.
+export const UNAFFILIATED_PROJECT_FILTER_VALUE = '__unaffiliated__';
+
 export const getSitesScreenFilters = (
   siteDistances: Record<string, number> | null,
   siteProjectRoles: {
@@ -64,7 +70,10 @@ export const getSitesScreenFilters = (
     },
     project: {
       kind: 'filter',
-      f: equals,
+      f: (val: string) => (comp: string | undefined) =>
+        val === UNAFFILIATED_PROJECT_FILTER_VALUE
+          ? comp === undefined || comp === 'undefined'
+          : val === comp,
       lookup: {
         key: 'projectId',
       },

--- a/dev-client/src/screens/SitesScreen/utils/sitesScreenFilters.ts
+++ b/dev-client/src/screens/SitesScreen/utils/sitesScreenFilters.ts
@@ -72,7 +72,7 @@ export const getSitesScreenFilters = (
       kind: 'filter',
       f: (val: string) => (comp: string | undefined) =>
         val === UNAFFILIATED_PROJECT_FILTER_VALUE
-          ? comp === undefined || comp === 'undefined'
+          ? comp === 'undefined'
           : val === comp,
       lookup: {
         key: 'projectId',

--- a/dev-client/src/translations/en.json
+++ b/dev-client/src/translations/en.json
@@ -383,7 +383,8 @@
         "close": "Close",
         "filter": {
             "no_role": "None",
-            "no_project": "None"
+            "no_project": "None",
+            "unaffiliated": "Unaffiliated (no project)"
         },
         "nullable_option": "None",
         "info": {

--- a/dev-client/src/translations/es.json
+++ b/dev-client/src/translations/es.json
@@ -376,7 +376,8 @@
         "email_label": "Dirección de email",
         "filter": {
             "no_role": "Ninguno",
-            "no_project": "Ninguno"
+            "no_project": "Ninguno",
+            "unaffiliated": "Sin afiliación (sin proyecto)"
         },
         "nullable_option": "Ninguno",
         "info": {

--- a/dev-client/src/translations/fr.json
+++ b/dev-client/src/translations/fr.json
@@ -376,7 +376,8 @@
         "email_label": "Adresse email",
         "filter": {
             "no_role": "Aucun",
-            "no_project": "Aucun"
+            "no_project": "Aucun",
+            "unaffiliated": "Non affilié (sans projet)"
         },
         "nullable_option": "Aucun",
         "info": {

--- a/dev-client/src/translations/ka.json
+++ b/dev-client/src/translations/ka.json
@@ -376,7 +376,8 @@
         "email_label": "ელექტრონული ფოსტის მისამართი",
         "filter": {
             "no_role": "არცერთი",
-            "no_project": "არცერთი"
+            "no_project": "არცერთი",
+            "unaffiliated": "Unaffiliated (no project)"
         },
         "nullable_option": "არცერთი",
         "info": {

--- a/dev-client/src/translations/sw.json
+++ b/dev-client/src/translations/sw.json
@@ -376,7 +376,8 @@
         "email_label": "Anwani ya barua pepe",
         "filter": {
             "no_role": "Hakuna",
-            "no_project": "Hakuna"
+            "no_project": "Hakuna",
+            "unaffiliated": "Unaffiliated (no project)"
         },
         "nullable_option": "Hakuna",
         "info": {

--- a/dev-client/src/translations/uk.json
+++ b/dev-client/src/translations/uk.json
@@ -376,7 +376,8 @@
         "email_label": "Адреса електронної пошти",
         "filter": {
             "no_role": "Немає",
-            "no_project": "Немає"
+            "no_project": "Немає",
+            "unaffiliated": "Unaffiliated (no project)"
         },
         "nullable_option": "Немає",
         "info": {


### PR DESCRIPTION
## Summary
- Closes #2665
- Adds an "Unaffiliated (no project)" option as the second entry of the project dropdown in the Sites screen filter modal (after the "None" option that clears the filter)
- Selecting it filters the list to sites whose `projectId` is undefined

## Implementation notes
- New `UNAFFILIATED_PROJECT_FILTER_VALUE` sentinel constant in `sitesScreenFilters.ts`
- Project filter's function now special-cases the sentinel — matches sites with no project — and otherwise falls back to strict equality (behavior unchanged for real project IDs)
- New `general.filter.unaffiliated` translation key added to all locales. English/Spanish/French have real translations; ka/sw/uk carry English placeholders for POEditor to localize

## Not in scope
Issue comment thread also raised the question of renaming/hiding the "None" (clear-filter) label. That is separate and untouched here — this PR only adds the missing option.

## Test plan
- [ ] Open Sites screen → open filter modal → open the project dropdown
- [ ] Confirm order: `None`, `Unaffiliated (no project)`, then user's projects
- [ ] Pick `Unaffiliated (no project)` → Apply → only sites with no project remain
- [ ] Pick a real project → Apply → only that project's sites remain (regression check)
- [ ] Pick `None` → Apply → filter clears
- [ ] Switch language to es/fr → label localized; ka/sw/uk fall back to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)