### PR TITLE
fix: run reference-card WB correction in linear-light

### DIFF
--- a/dev-client/jest/unit/setup.ts
+++ b/dev-client/jest/unit/setup.ts
@@ -14,3 +14,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+
+// react-native-worklets 0.8+ (reanimated 4.x's peer) hard-asserts its
+// native side is initialized on import. Recursive proxy stub so any imported
+// name (createSerializable, serializableMappingCache.set, etc.) safely
+// no-ops. See jest/integration/setup.ts for the same fix on the other side.
+const mockWorkletsStub: any = new Proxy(function () {}, {
+  get: (_target, prop) => (prop === 'then' ? undefined : mockWorkletsStub),
+  apply: () => mockWorkletsStub,
+});
+jest.mock('react-native-worklets', () => mockWorkletsStub);
+
+// expo-media-library@56 exports classes that extend a native module
+// (`ExpoMediaLibraryNext`), which is undefined at import time in jest and
+// throws "Super expression must either be null or a function". Any unit test
+// whose require-chain reaches components/inputs/image/ImagePicker.tsx will
+// pull expo-media-library in and blow up — stub the one API we use.
+jest.mock('expo-media-library', () => ({
+  createAssetAsync: jest.fn(() => Promise.resolve()),
+}));

--- a/dev-client/src/model/color/colorDetection.test.ts
+++ b/dev-client/src/model/color/colorDetection.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2026 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  correctSampleRGB,
+  linearToSrgb,
+  srgbToLinear,
+} from 'terraso-mobile-client/model/color/colorDetection';
+import {RGB} from 'terraso-mobile-client/model/color/types';
+
+describe('srgbToLinear', () => {
+  test('anchors: 0 → 0, 255 → 1', () => {
+    expect(srgbToLinear(0)).toBe(0);
+    expect(srgbToLinear(255)).toBeCloseTo(1, 6);
+  });
+
+  test('linear piece for very-dark values', () => {
+    // Below the 0.04045 threshold on the sRGB curve, the transfer function is
+    // exactly c/12.92 (a straight line). Concretely: sRGB 10/255 → 10/(255*12.92).
+    expect(srgbToLinear(10)).toBeCloseTo(10 / 255 / 12.92, 8);
+  });
+
+  test('gamma piece for mid-tones', () => {
+    // Middle-grey sRGB 128 should be roughly 0.216 in linear (≈ 21.6% reflectance).
+    expect(srgbToLinear(128)).toBeCloseTo(0.21586, 4);
+  });
+});
+
+describe('linearToSrgb', () => {
+  test('anchors: 0 → 0, 1 → 255', () => {
+    expect(linearToSrgb(0)).toBe(0);
+    expect(linearToSrgb(1)).toBe(255);
+  });
+
+  test('clamps values outside [0, 1]', () => {
+    expect(linearToSrgb(-0.5)).toBe(0);
+    expect(linearToSrgb(1.5)).toBe(255);
+    expect(linearToSrgb(100)).toBe(255);
+  });
+
+  test('roundtrip srgb → linear → srgb is within ±1 for all 8-bit values', () => {
+    // Rounding at the final `* 255` step means we tolerate a 1-count drift.
+    for (let c = 0; c <= 255; c++) {
+      const roundtripped = linearToSrgb(srgbToLinear(c));
+      expect(Math.abs(roundtripped - c)).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('correctSampleRGB', () => {
+  test('identity: when the card matches the reference, the sample is returned essentially unchanged', () => {
+    const card: RGB = [200, 200, 200];
+    const sample: RGB = [120, 80, 40];
+    const reference: RGB = [200, 200, 200];
+    const [r, g, b] = correctSampleRGB(card, sample, reference);
+    // Small drift is expected from linear ↔ sRGB rounding.
+    expect(Math.abs(r - 120)).toBeLessThanOrEqual(1);
+    expect(Math.abs(g - 80)).toBeLessThanOrEqual(1);
+    expect(Math.abs(b - 40)).toBeLessThanOrEqual(1);
+  });
+
+  test('clamps output to [0, 255] even under aggressive gain', () => {
+    const card: RGB = [10, 10, 10];
+    const sample: RGB = [200, 200, 200];
+    const reference: RGB = [250, 250, 250];
+    const result = correctSampleRGB(card, sample, reference);
+    result.forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(255);
+      expect(Number.isFinite(v)).toBe(true);
+    });
+  });
+
+  test('handles a fully-black card without producing NaN/Infinity', () => {
+    const card: RGB = [0, 0, 0];
+    const sample: RGB = [100, 100, 100];
+    const reference: RGB = [200, 200, 200];
+    const result = correctSampleRGB(card, sample, reference);
+    result.forEach(v => {
+      expect(Number.isFinite(v)).toBe(true);
+    });
+  });
+
+  test('gives a different result than the old sRGB-space math for a realistic warm-cast scenario', () => {
+    // Reference card measured as sRGB [249.92, 242.07, 161.42] under D65
+    // (CANARY_POST_IT). Under warm indoor light the camera might sense the
+    // card as sRGB [200, 190, 130]. This exercises the whole non-linear
+    // curve — the ratio in sRGB space is a materially different number than
+    // in linear space, so the corrected sample must differ from the naive
+    // sRGB-space product.
+    const card: RGB = [200, 190, 130];
+    const sample: RGB = [110, 90, 70];
+    const reference: RGB = [249.92, 242.07, 161.42];
+
+    const [r, g, b] = correctSampleRGB(card, sample, reference);
+
+    const oldSrgbSpace = (cardV: number, sampleV: number, refV: number) =>
+      Math.round((refV / cardV) * sampleV);
+    const oldR = oldSrgbSpace(card[0], sample[0], reference[0]);
+    const oldG = oldSrgbSpace(card[1], sample[1], reference[1]);
+    const oldB = oldSrgbSpace(card[2], sample[2], reference[2]);
+
+    // The linear-space correction produces a different (larger, because gamma
+    // stretches the highlights) number than sRGB-space scaling for every
+    // channel of this scenario.
+    expect(r).toBeGreaterThan(oldR);
+    expect(g).toBeGreaterThan(oldG);
+    expect(b).toBeGreaterThan(oldB);
+  });
+});

--- a/dev-client/src/model/color/colorDetection.ts
+++ b/dev-client/src/model/color/colorDetection.ts
@@ -145,14 +145,37 @@ export const predictColorFromReference = (
   );
 };
 
-const correctSampleRGB = (
+// Standard piecewise sRGB transfer function.
+export const srgbToLinear = (c: number): number => {
+  const x = c / 255;
+  return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+};
+
+// Inverse of srgbToLinear. Clamps to [0, 255].
+export const linearToSrgb = (x: number): number => {
+  const clamped = Math.max(0, Math.min(1, x));
+  const c =
+    clamped <= 0.0031308
+      ? 12.92 * clamped
+      : 1.055 * Math.pow(clamped, 1 / 2.4) - 0.055;
+  return Math.max(0, Math.min(255, Math.round(c * 255)));
+};
+
+export const correctSampleRGB = (
   cardPixel: RGB,
   samplePixel: RGB,
   referenceRGB: RGB,
 ): RGB => {
-  return cardPixel.map(
-    (cardV, index) => (referenceRGB[index] / cardV) * samplePixel[index],
-  ) as RGB;
+  // Per-channel gain (von-Kries-style WB correction) is only physically correct
+  // in linear-light space. Doing it on sRGB-encoded values under/over-corrects
+  // depending on where each value sits on the gamma curve.
+  return cardPixel.map((cardV, index) => {
+    const cardLin = srgbToLinear(cardV);
+    if (cardLin === 0) return 0; // guard against a fully-black card
+    const sampleLin = srgbToLinear(samplePixel[index]);
+    const referenceLin = srgbToLinear(referenceRGB[index]);
+    return linearToSrgb((referenceLin / cardLin) * sampleLin);
+  }) as RGB;
 };
 
 export const dominantColor = (pixels: RGBA[]): RGB => {


### PR DESCRIPTION
## Summary

Cherry-picked from the raw-camera work-in-progress. Real quality improvement to the soil-color analysis pipeline, independent of any raw-camera work.

**Stacked on #3326** (`build/ios-device-picker`).

## The bug

The soil-color pipeline scales the sample's per-channel RGB to match a measured reference-card color, then converts to Munsell. That scaling was applied to sRGB-encoded pixel values, but per-channel gain (von-Kries-style WB correction) is only physically correct in linear-light space. Applied on sRGB values it under- or over-corrects depending on where each value sits on the gamma curve — errors grow with the strength of the illumination cast.

## The fix

- Add `srgbToLinear` / `linearToSrgb` helpers implementing the standard piecewise sRGB transfer function
- Rewrite `correctSampleRGB` to convert to linear, apply the per-channel gain, convert back to sRGB with clamping to `[0, 255]` (previously unclamped — a dark card could produce >255 or Infinity)
- Guard against a fully-black reference card (returns 0 for that channel instead of dividing by zero)
- Unit tests for the sRGB transfer functions (anchors, linear-piece, gamma-piece, roundtrip within ±1) and for `correctSampleRGB` (identity, clamping, black-card guard, differs from old sRGB-space math on a realistic warm-cast scenario)

## Non-code follow-up

The new unit test transitively imports `expo-media-library` + reanimated (through `ImagePicker` → `colorDetection`), and the unit-test config previously had no mocks. Added the same two mocks the integration config gained during the SDK bumps: `expo-media-library` (creates classes over undefined native module) and `react-native-worklets` (hard-asserts native init).

## Verified locally

- 39 unit test suites (521 tests) all pass, including the 10 new color-math tests
- `check-ts`, `eslint`, `prettier`, `i18n-check` — all green

## Test plan
- [ ] CI green
- [ ] Optional: sanity-check color analysis on device with a real soil sample under mildly-warm lighting — the corrected color should be more accurate than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)