### PR TITLE
ci: run PR-gating workflows on stacked PRs (any base branch)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ on:
       - main
       - dependencies
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get iOS/Android builds too.
 
 jobs:
   ios-build-only:

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -2,9 +2,8 @@ name: Conventional Commits
 
 on:
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get commit-message linting too.
     types:
       - opened
       - edited

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,8 @@ on:
       - main
       - dependencies
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get lint too.
     types:
       - opened
       - edited

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get i18n-check too.
     types:
       - opened
       - edited

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ on:
       - main
       - dependencies
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs (PR-to-PR) get CI too. Without this, only PRs to main/dependencies
+    # would trigger, and stacked PRs sit silent.
     types:
       - opened
       - edited


### PR DESCRIPTION
## Summary

Removes the `branches: [main, dependencies]` filter under the `pull_request:` trigger on the five PR-gating workflows (`test`, `build`, `lint`, `localization`, `check-commits`).

## Why

That filter is a **base-branch filter** — the workflow only runs if the PR targets `main` or `dependencies`. Stacked PRs (PR-to-PR, e.g. #3325 targeting #3324) got no CI at all, which we hit hard when the SDK-bump PRs stacked five deep and only the bottom one had check results.

## What still runs when

- `push:` triggers unchanged — still only fire on pushes to `main` / `dependencies`
- `merge_group:` unchanged
- `types:` unchanged (still `opened` + `edited` + `synchronize` where those were present)
- Only the `branches:` filter under `pull_request:` is removed

## Cost

Near-zero. CI runs on actual PR events; opening a stacked PR is exactly when you want the checks. GitHub only bills for CI minutes actually consumed.

## Rollout on the existing stack

To retroactively make the current stacked PRs (#3325–#3328) benefit, they need this commit in their HEAD. Follow-up work (not in this PR): rebase the stack so each downstream branch picks it up. Merging this PR alone doesn't help the existing stacked PRs until they're rebased.

## Test plan
- [ ] CI on this PR itself runs (it targets main — should be uncontroversial)
- [ ] Reviewer sanity-check the trigger config is what they'd expect

🤖 Generated with [Claude Code](https://claude.com/claude-code)