### PR TITLE
build: helper scripts to pick + target an iOS device or simulator

### DIFF
--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -8,6 +8,8 @@
     "rebuild-all": "bash scripts/rebuild_all",
     "rebuild-all-ios": "bash scripts/rebuild_all ios",
     "rebuild-all-android": "bash scripts/rebuild_all android",
+    "list-ios-devices": "bash scripts/list-ios-devices",
+    "pick-ios-device": "bash scripts/pick-ios-device",
     "eslint": "eslint ./ --ext .js --ext .ts --ext .tsx --max-warnings 0 --ignore-path ../.gitignore",
     "lint": "npm run eslint && npm run prettier",
     "lint-js": "npm run lint",

--- a/dev-client/scripts/list-ios-devices
+++ b/dev-client/scripts/list-ios-devices
@@ -1,0 +1,24 @@
+#!/bin/bash
+# List connected physical iOS devices (iPhone/iPad).
+#
+# Filters for lines with TWO paren groups — (iOS version) (UDID) — which
+# excludes the host Mac (single paren group, no version). Simulators are in
+# a separate "== Simulators ==" section and skipped automatically.
+
+set -e
+
+devices=$(xcrun xctrace list devices 2>&1 | awk '
+  /^== Devices ==/ { in_devices=1; next }
+  /^== /           { in_devices=0 }
+  in_devices && /\([0-9.]+\).*\([0-9A-Fa-f-]+\)$/ { print }
+')
+
+if [[ -z "$devices" ]]; then
+  echo "No connected iOS devices."
+  echo "  - Plug in your iPhone via USB (or connect via network via Xcode)"
+  echo "  - Unlock the phone and tap 'Trust this computer' if prompted"
+  echo "  - Confirm the phone appears in Xcode: Window > Devices and Simulators"
+  exit 1
+fi
+
+echo "$devices"

--- a/dev-client/scripts/list-ios-devices
+++ b/dev-client/scripts/list-ios-devices
@@ -1,24 +1,43 @@
 #!/bin/bash
-# List connected physical iOS devices (iPhone/iPad).
+# List connected physical iOS devices AND available simulators, grouped.
 #
-# Filters for lines with TWO paren groups — (iOS version) (UDID) — which
-# excludes the host Mac (single paren group, no version). Simulators are in
-# a separate "== Simulators ==" section and skipped automatically.
+# The `== Devices ==` and `== Simulators ==` sections of xctrace's output are
+# parsed separately. Both sections list the Mac host with only a single paren
+# group; iPhones/iPads/simulators have TWO paren groups — (iOS version) (UDID)
+# — so the regex filter naturally excludes the Mac. Apple Watch and Apple TV
+# simulators are filtered out to reduce noise (the app targets iPhone + iPad).
 
 set -e
 
-devices=$(xcrun xctrace list devices 2>&1 | awk '
+raw=$(xcrun xctrace list devices 2>&1)
+
+hardware=$(echo "$raw" | awk '
   /^== Devices ==/ { in_devices=1; next }
   /^== /           { in_devices=0 }
   in_devices && /\([0-9.]+\).*\([0-9A-Fa-f-]+\)$/ { print }
 ')
 
-if [[ -z "$devices" ]]; then
-  echo "No connected iOS devices."
-  echo "  - Plug in your iPhone via USB (or connect via network via Xcode)"
-  echo "  - Unlock the phone and tap 'Trust this computer' if prompted"
-  echo "  - Confirm the phone appears in Xcode: Window > Devices and Simulators"
+simulators=$(echo "$raw" | awk '
+  /^== Simulators ==/ { in_sims=1; next }
+  /^== /              { in_sims=0 }
+  in_sims && /\([0-9.]+\).*\([0-9A-Fa-f-]+\)$/ && !/Apple Watch/ && !/Apple TV/ { print }
+')
+
+if [[ -z "$hardware" && -z "$simulators" ]]; then
+  echo "No connected devices or simulators found."
+  echo "  - For a physical device: plug in your iPhone via USB, unlock it,"
+  echo "    and tap 'Trust this computer' if prompted"
+  echo "  - For a simulator: open Xcode > Window > Devices and Simulators"
   exit 1
 fi
 
-echo "$devices"
+if [[ -n "$hardware" ]]; then
+  echo "Physical devices:"
+  echo "$hardware" | sed 's/^/  /'
+  echo ""
+fi
+
+if [[ -n "$simulators" ]]; then
+  echo "Simulators:"
+  echo "$simulators" | sed 's/^/  /'
+fi

--- a/dev-client/scripts/pick-ios-device
+++ b/dev-client/scripts/pick-ios-device
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Interactive: list connected physical iOS devices, prompt to pick one,
+# save the UDID to ~/.landpks-ios-device so scripts/rebuild_all can pick
+# it up on subsequent runs.
+#
+# File format is one line: `<UDID>  # <display name>` — the # comment is
+# for the human; rebuild_all reads only the first whitespace-separated
+# token.
+
+set -e
+
+DEVICE_FILE="$HOME/.landpks-ios-device"
+
+devices=$(xcrun xctrace list devices 2>&1 | awk '
+  /^== Devices ==/ { in_devices=1; next }
+  /^== /           { in_devices=0 }
+  in_devices && /\([0-9.]+\).*\([0-9A-Fa-f-]+\)$/ { print }
+')
+
+if [[ -z "$devices" ]]; then
+  echo "No connected iOS devices."
+  echo "  - Plug in your iPhone via USB (or connect via network via Xcode)"
+  echo "  - Unlock the phone and tap 'Trust this computer' if prompted"
+  echo "  - Confirm the phone appears in Xcode: Window > Devices and Simulators"
+  exit 1
+fi
+
+echo "Connected devices:"
+i=1
+while IFS= read -r line; do
+  printf "  [%d] %s\n" "$i" "$line"
+  i=$((i + 1))
+done <<<"$devices"
+
+count=$((i - 1))
+echo ""
+if [[ "$count" -eq 1 ]]; then
+  choice=1
+  echo "Only one device — auto-selecting [1]."
+else
+  read -r -p "Pick device [1-$count]: " choice
+fi
+
+if ! [[ "$choice" =~ ^[0-9]+$ ]] || [[ "$choice" -lt 1 ]] || [[ "$choice" -gt "$count" ]]; then
+  echo "Invalid selection: $choice"
+  exit 1
+fi
+
+chosen=$(echo "$devices" | sed -n "${choice}p")
+# UDID is the final "(...)" group on the line — parens contents are hex + hyphens.
+udid=$(echo "$chosen" | grep -oE '\([0-9A-Fa-f-]+\)$' | tr -d '()')
+# Human-readable name is everything before " (<iOS version>)". Strip both paren groups.
+name=$(echo "$chosen" | sed -E 's/ \([0-9.]+\) \([0-9A-Fa-f-]+\)$//')
+
+if [[ -z "$udid" ]]; then
+  echo "Could not parse UDID from: $chosen"
+  exit 1
+fi
+
+echo "$udid  # $name" >"$DEVICE_FILE"
+
+echo ""
+echo "Saved to $DEVICE_FILE"
+echo "  UDID: $udid"
+echo "  Name: $name"
+echo ""
+echo "Now run:  npm run rebuild-all-ios"

--- a/dev-client/scripts/pick-ios-device
+++ b/dev-client/scripts/pick-ios-device
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Interactive: list connected physical iOS devices, prompt to pick one,
-# save the UDID to ~/.landpks-ios-device so scripts/rebuild_all can pick
-# it up on subsequent runs.
+# Interactive: list connected physical devices AND available simulators,
+# prompt to pick one, save the UDID to ~/.landpks-ios-device for
+# scripts/rebuild_all to pick up on subsequent runs.
+#
+# See list-ios-devices for the parsing/filtering rationale.
 #
 # File format is one line: `<UDID>  # <display name>` — the # comment is
 # for the human; rebuild_all reads only the first whitespace-separated
@@ -11,34 +13,64 @@ set -e
 
 DEVICE_FILE="$HOME/.landpks-ios-device"
 
-devices=$(xcrun xctrace list devices 2>&1 | awk '
+raw=$(xcrun xctrace list devices 2>&1)
+
+hardware=$(echo "$raw" | awk '
   /^== Devices ==/ { in_devices=1; next }
   /^== /           { in_devices=0 }
   in_devices && /\([0-9.]+\).*\([0-9A-Fa-f-]+\)$/ { print }
 ')
 
-if [[ -z "$devices" ]]; then
-  echo "No connected iOS devices."
-  echo "  - Plug in your iPhone via USB (or connect via network via Xcode)"
-  echo "  - Unlock the phone and tap 'Trust this computer' if prompted"
-  echo "  - Confirm the phone appears in Xcode: Window > Devices and Simulators"
+simulators=$(echo "$raw" | awk '
+  /^== Simulators ==/ { in_sims=1; next }
+  /^== /              { in_sims=0 }
+  in_sims && /\([0-9.]+\).*\([0-9A-Fa-f-]+\)$/ && !/Apple Watch/ && !/Apple TV/ { print }
+')
+
+if [[ -z "$hardware" && -z "$simulators" ]]; then
+  echo "No connected devices or simulators found."
+  echo "  - For a physical device: plug in your iPhone via USB, unlock it,"
+  echo "    and tap 'Trust this computer' if prompted"
+  echo "  - For a simulator: open Xcode > Window > Devices and Simulators"
   exit 1
 fi
 
-echo "Connected devices:"
+# Combined list for indexed lookup. Physical devices come first, then sims —
+# same order as the display below.
+if [[ -n "$hardware" && -n "$simulators" ]]; then
+  all=$(printf '%s\n%s' "$hardware" "$simulators")
+elif [[ -n "$hardware" ]]; then
+  all="$hardware"
+else
+  all="$simulators"
+fi
+
+# Print grouped display with continuous numbering.
 i=1
-while IFS= read -r line; do
-  printf "  [%d] %s\n" "$i" "$line"
-  i=$((i + 1))
-done <<<"$devices"
+if [[ -n "$hardware" ]]; then
+  echo "Physical devices:"
+  while IFS= read -r line; do
+    printf "  [%d] %s\n" "$i" "$line"
+    i=$((i + 1))
+  done <<<"$hardware"
+  echo ""
+fi
+
+if [[ -n "$simulators" ]]; then
+  echo "Simulators:"
+  while IFS= read -r line; do
+    printf "  [%d] %s\n" "$i" "$line"
+    i=$((i + 1))
+  done <<<"$simulators"
+fi
 
 count=$((i - 1))
 echo ""
 if [[ "$count" -eq 1 ]]; then
   choice=1
-  echo "Only one device — auto-selecting [1]."
+  echo "Only one entry — auto-selecting [1]."
 else
-  read -r -p "Pick device [1-$count]: " choice
+  read -r -p "Pick [1-$count]: " choice
 fi
 
 if ! [[ "$choice" =~ ^[0-9]+$ ]] || [[ "$choice" -lt 1 ]] || [[ "$choice" -gt "$count" ]]; then
@@ -46,10 +78,8 @@ if ! [[ "$choice" =~ ^[0-9]+$ ]] || [[ "$choice" -lt 1 ]] || [[ "$choice" -gt "$
   exit 1
 fi
 
-chosen=$(echo "$devices" | sed -n "${choice}p")
-# UDID is the final "(...)" group on the line — parens contents are hex + hyphens.
+chosen=$(echo "$all" | sed -n "${choice}p")
 udid=$(echo "$chosen" | grep -oE '\([0-9A-Fa-f-]+\)$' | tr -d '()')
-# Human-readable name is everything before " (<iOS version>)". Strip both paren groups.
 name=$(echo "$chosen" | sed -E 's/ \([0-9.]+\) \([0-9A-Fa-f-]+\)$//')
 
 if [[ -z "$udid" ]]; then

--- a/dev-client/scripts/rebuild_all
+++ b/dev-client/scripts/rebuild_all
@@ -157,6 +157,13 @@ else
 fi
 
 if [[ "$PLATFORM" == "ios" ]]; then
+    # Device precedence:  IOS_DEVICE_ID env var  >  ~/.landpks-ios-device file
+    # >  simulator (Expo's default when no --device flag). The file is written
+    # by scripts/pick-ios-device; its first whitespace-separated token is the
+    # UDID (anything after # is a human-readable name for the reader).
+    if [[ -z "$IOS_DEVICE_ID" ]] && [[ -f "$HOME/.landpks-ios-device" ]]; then
+        IOS_DEVICE_ID=$(awk 'NF && $1!~/^#/ {print $1; exit}' "$HOME/.landpks-ios-device")
+    fi
     if [[ -n "$IOS_DEVICE_ID" ]]; then
         $EXPO_PTY_WRAPPER npm run ios -- --device "$IOS_DEVICE_ID" | $LAUNCH_TIMER | $LOG_FILTER
     else


### PR DESCRIPTION
## Summary

Cherry-picked from the raw-camera work-in-progress. Independent build-tooling improvement that doesn't touch any runtime code.

**Stacked on #3329** (`ci/relax-pr-triggers`). Reopens after the previous PR (#3326) was auto-closed by GitHub when I rebased the branch and its old base (chore/expo-sdk-56) briefly became an ancestor of the new branch position.

## What's in it

- `scripts/list-ios-devices` — pretty-print connected physical iOS devices AND simulators, grouped under section headers. Read-only, no side effects.
- `scripts/pick-ios-device` — interactive: same list with numeric prefixes, prompt to pick, save UDID to `~/.landpks-ios-device`. Auto-selects if there's only one entry.
- `scripts/rebuild_all` — new device precedence for iOS builds: `IOS_DEVICE_ID` env var → `~/.landpks-ios-device` file → simulator.
- `npm run list-ios-devices` / `pick-ios-device` shortcuts.

## Test plan
- [ ] `npm run list-ios-devices` prints connected iPhones + sims
- [ ] `npm run pick-ios-device` writes a valid UDID to `~/.landpks-ios-device`
- [ ] `npm run rebuild-all-ios` builds to the saved device

🤖 Generated with [Claude Code](https://claude.com/claude-code)