### PR TITLE
chore: update client-shared to ESM only

### DIFF
--- a/dev-client/jest.integration.config.js
+++ b/dev-client/jest.integration.config.js
@@ -24,7 +24,7 @@ module.exports = {
     '<rootDir>/jest/integration/setup.ts',
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(.*/)?(@?react-native|react-native-.*|@react-navigation|@react-aria|uuid|immer|expo.*|@expo.*|@rnmapbox|@sentry|@gorhom|react-redux|@reduxjs|native-base))',
+    'node_modules/(?!(.*/)?(@?react-native|react-native-.*|@react-navigation|@react-aria|uuid|immer|expo.*|@expo.*|@rnmapbox|@sentry|@gorhom|react-redux|@reduxjs|native-base|terraso-client-shared))',
   ],
   moduleNameMapper: {
     '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':

--- a/dev-client/jest.unit.config.js
+++ b/dev-client/jest.unit.config.js
@@ -22,6 +22,9 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest/unit/setup.ts'],
   clearMocks: true,
+  transformIgnorePatterns: [
+    'node_modules/(?!(.*/)?(@?react-native|react-native-.*|@react-navigation|@react-aria|uuid|immer|expo.*|@expo.*|@rnmapbox|@sentry|@gorhom|react-redux|@reduxjs|native-base|terraso-client-shared))',
+  ],
   moduleNameMapper: {
     '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/__mocks__/fileMock.ts',

--- a/dev-client/package-lock.json
+++ b/dev-client/package-lock.json
@@ -83,7 +83,7 @@
         "react-redux": "^9.2.0",
         "reduce-reducers": "^1.0.4",
         "setimmediate": "^1.0.5",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-07-28.0",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#40bcfafac398d6eb230a993231fdceb4bc3ee8ae",
         "use-debounce": "^10.0.6",
         "uuid": "^11.1.0",
         "yup": "^1.7.1"
@@ -24739,7 +24739,8 @@
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#a1480c6c0d0faca1073838185d805a5ab9214ae8",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#40bcfafac398d6eb230a993231fdceb4bc3ee8ae",
+      "integrity": "sha512-nZd0RencknKPLaRBh2zWzSrePcbjFuqpxE1w1ifGduuZfqbD5iIGU9/Ouck+2n05VsQzJOdgfH9Ue5ESVuqUXg==",
       "dependencies": {
         "@reduxjs/toolkit": "^2.11.1",
         "jwt-decode": "^4.0.0",

--- a/dev-client/package.json
+++ b/dev-client/package.json
@@ -112,7 +112,7 @@
     "react-redux": "^9.2.0",
     "reduce-reducers": "^1.0.4",
     "setimmediate": "^1.0.5",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-07-28.0",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#40bcfafac398d6eb230a993231fdceb4bc3ee8ae",
     "use-debounce": "^10.0.6",
     "uuid": "^11.1.0",
     "yup": "^1.7.1"


### PR DESCRIPTION
## Description
Updates `client-shared` to ESM-only, and adds necessary entries to Jest's config. This required mirroring the list from the integration test config into the unit test config. As far as I've researched this shouldn't cause any issues or need any extra config for the actual app build/runtime, but I will kick off a beta build to confirm before merging!

### Related Issues
Needed for https://github.com/techmatters/terraso-client-shared/pull/1556

### Verification steps
Everything should work the same!