### PR TITLE
ci: run pr-gating workflows on prs targeting any branch, not just main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ on:
       - main
       - dependencies
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get iOS/Android builds too.
 
 jobs:
   ios-build-only:

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -2,9 +2,8 @@ name: Conventional Commits
 
 on:
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get commit-message linting too.
     types:
       - opened
       - edited

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,8 @@ on:
       - main
       - dependencies
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get lint too.
     types:
       - opened
       - edited

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs get i18n-check too.
     types:
       - opened
       - edited

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ on:
       - main
       - dependencies
   pull_request:
-    branches:
-      - main
-      - dependencies
+    # No `branches:` filter — fire on PRs targeting any branch so stacked
+    # PRs (PR-to-PR) get CI too. Without this, only PRs to main/dependencies
+    # would trigger, and stacked PRs sit silent.
     types:
       - opened
       - edited


### PR DESCRIPTION
## Summary
Removes the `branches: [main, dependencies]` filter from the `pull_request:` trigger on the five gating workflows (`test`, `build`, `lint`, `localization`, `check-commits`) so PRs that target a non-main base branch (stacked PRs) also get CI.

Cherry-picked from `4e6b5ae8` on the `feat/raw-camera` line — pulling it onto its own PR against `main` so we can enable stacked-PR CI ahead of the raw-camera work landing.

## What changes
- `.github/workflows/*.yml`: drop `branches:` filter under `pull_request:` on the five gating workflows.
- Leaves `push:` filters alone (still only main/dependencies).
- Leaves `types:` filters alone (still `opened / edited / synchronize`).

## Why
Before this, `pull_request: branches: [main, dependencies]` acted as a base-branch filter — the workflow only ran if the PR targeted main or dependencies. Stacked PRs (PR-to-PR) got no CI at all, which we hit on the SDK-bump stack five deep where only the bottom PR had CI results.

Cost is near-zero — CI only runs on actual PR events; opening a stacked PR is exactly when you want the checks.

## Test plan
- [ ] Open a throwaway PR whose base is a non-main branch and confirm the gating workflows fire.
- [ ] Confirm existing PRs against `main` still get CI as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)