### PR TITLE
fix: open site callout after creating site (approach 2)

### DIFF
--- a/dev-client/src/context/SitesScreenContext.tsx
+++ b/dev-client/src/context/SitesScreenContext.tsx
@@ -17,10 +17,7 @@
 
 import {createContext, memo, RefObject, useContext, useRef} from 'react';
 
-import {Site} from 'terraso-client-shared/site/siteTypes';
-
 type SitesScreenRef = {
-  showSiteOnMap: (site: Site) => void;
   collapseBottomSheet: () => void;
 };
 

--- a/dev-client/src/navigation/types.ts
+++ b/dev-client/src/navigation/types.ts
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 
+import {NavigatorScreenParams} from '@react-navigation/native';
 import {
   createNativeStackNavigator,
   NativeStackScreenProps,
@@ -32,8 +33,20 @@ export type ParamList<T extends ScreenDefinitions> = {
   [K in keyof T]: UnknownToUndefined<React.ComponentProps<T[K]>>;
 };
 
-export type BottomTabsParamList = ParamList<typeof bottomTabScreensDefinitions>;
-export type RootStackParamList = ParamList<typeof combinedScreenDefinitions>;
+/* ParamList derives each route's params from its screen component's props, which can't express two things these routes need: params that are optional, and a parent route that forwards {screen, params} into a nested navigator. Both are declared by hand here. */
+export type BottomTabsParamList = Omit<
+  ParamList<typeof bottomTabScreensDefinitions>,
+  'SITES'
+> & {
+  SITES: {calloutSiteId?: string} | undefined;
+};
+
+export type RootStackParamList = Omit<
+  ParamList<typeof combinedScreenDefinitions>,
+  'BOTTOM_TABS'
+> & {
+  BOTTOM_TABS: NavigatorScreenParams<BottomTabsParamList> | undefined;
+};
 
 export const RootStack = createNativeStackNavigator<RootStackParamList>();
 

--- a/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
+++ b/dev-client/src/screens/CreateSiteScreen/components/CreateSiteView.tsx
@@ -23,7 +23,6 @@ import {Formik} from 'formik';
 import {Site} from 'terraso-client-shared/site/siteTypes';
 import {Coords} from 'terraso-client-shared/types';
 
-import {useSitesScreenContext} from 'terraso-mobile-client/context/SitesScreenContext';
 import {useIsOffline} from 'terraso-mobile-client/hooks/connectivityHooks';
 import {SiteAddInput} from 'terraso-mobile-client/model/site/actions/localSiteActions';
 import {useNavigation} from 'terraso-mobile-client/navigation/hooks/useNavigation';
@@ -54,7 +53,6 @@ export const CreateSiteView = ({
   const defaultProject = useSelector(state =>
     defaultProjectId ? state.project.projects[defaultProjectId] : undefined,
   );
-  const sitesScreen = useSitesScreenContext();
   const isOffline = useIsOffline();
 
   const navigation = useNavigation();
@@ -73,15 +71,17 @@ export const CreateSiteView = ({
         elevation: finalElevation,
       });
       if (createdSite !== undefined) {
-        sitesScreen?.showSiteOnMap(createdSite);
-        navigation.popTo('BOTTOM_TABS');
+        /* Params ride along with the pop so the tab navigator hands them to SitesScreen, which opens the callout and then clears them. */
+        navigation.popTo('BOTTOM_TABS', {
+          screen: 'SITES',
+          params: {calloutSiteId: createdSite.id},
+        });
       }
     },
     [
       createSiteCallback,
       navigation,
       validationSchema,
-      sitesScreen,
       elevation,
       sitePin,
       isOffline,

--- a/dev-client/src/screens/SitesScreen/SitesScreen.tsx
+++ b/dev-client/src/screens/SitesScreen/SitesScreen.tsx
@@ -29,6 +29,8 @@ import {LayoutChangeEvent} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import BottomSheet from '@gorhom/bottom-sheet';
+import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
+import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import Mapbox from '@rnmapbox/maps';
 
 import {Site} from 'terraso-client-shared/site/siteTypes';
@@ -43,6 +45,7 @@ import {positionToCoords} from 'terraso-mobile-client/components/StaticMapView';
 import {useGeospatialContext} from 'terraso-mobile-client/context/GeospatialContext';
 import {SitesScreenContext} from 'terraso-mobile-client/context/SitesScreenContext';
 import {AppBar} from 'terraso-mobile-client/navigation/components/AppBar';
+import {BottomTabsParamList} from 'terraso-mobile-client/navigation/types';
 import {ScreenScaffold} from 'terraso-mobile-client/screens/ScreenScaffold';
 import {MapHeader} from 'terraso-mobile-client/screens/SitesScreen/components/MapHeader';
 import {SiteListBottomSheet} from 'terraso-mobile-client/screens/SitesScreen/components/SiteListBottomSheet';
@@ -90,11 +93,27 @@ export const SitesScreen = memo(() => {
   useImperativeHandle(
     sitesScreenContext,
     () => ({
-      showSiteOnMap,
       collapseBottomSheet,
     }),
-    [showSiteOnMap, collapseBottomSheet],
+    [collapseBottomSheet],
   );
+
+  const {calloutSiteId} =
+    useRoute<RouteProp<BottomTabsParamList, 'SITES'>>().params ?? {};
+  const tabNavigation =
+    useNavigation<BottomTabNavigationProp<BottomTabsParamList, 'SITES'>>();
+
+  /* Site creation asks for a callout by passing the new site's id in this screen's route params. React Navigation keeps params on the route, so clear them once used or the callout reopens every time this route remounts. */
+  useEffect(() => {
+    if (calloutSiteId === undefined) {
+      return;
+    }
+    const requestedSite = sites[calloutSiteId];
+    if (requestedSite) {
+      showSiteOnMap(requestedSite);
+    }
+    tabNavigation.setParams({calloutSiteId: undefined});
+  }, [calloutSiteId, sites, showSiteOnMap, tabNavigation]);
 
   const currentUserCoords = useSelector(state => state.map.userLocation.coords);
 


### PR DESCRIPTION
.. by routing the new site's id through navigation params to the SitesScreen.

This is an alternative to the context variables approach for the same bug as https://github.com/techmatters/terraso-mobile-client/pull/3341. Creating a site from the soil ID screen left the temporary-location callout on the map instead of the new site's card, because SitesScreen was reached through a ref that React detaches while the screen is frozen.

Carry the site id in the pop that returns to the map, so the tab navigator hands it to SitesScreen as a route param. Nothing crosses screens imperatively, so showSiteOnMap comes off the ref, and the pop now also selects the SITES tab for free.

The generated ParamList can't express optional params or a parent route that forwards {screen, params} into a nested navigator, so BOTTOM_TABS and SITES are declared by hand. That buys real type checking at the call site.


### Related Issues
Fixes https://github.com/techmatters/terraso-product/issues/1428
